### PR TITLE
#12 - Adicionar a capacidade de i18n.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,17 @@
+
+# Faz um scan em toda a app buscando strings traduzíveis e o resultado fica em app/translations/messages.pot
+make_messages:
+	pybabel extract -F config/babel.cfg -k lazy_gettext -o app/translations/messages.pot .
+
+# cria o catalogo para o idioma definido pela variável LANG, a partir das strings: app/translations/messages.pot
+# executar: $ LANG=en make create_catalog
+create_catalog:
+	pybabel init -i app/translations/messages.pot -d app/translations -l $(LANG)
+
+# atualiza os catalogos, a partir das strings: app/translations/messages.pot
+update_catalog:
+	pybabel update -i app/translations/messages.pot -d app/translations
+
+# compila as traduções dos .po em arquivos .mo prontos para serm utilizados.
+compile_messages:
+	pybabel compile -d app/translations

--- a/app/admin/forms.py
+++ b/app/admin/forms.py
@@ -1,25 +1,25 @@
 # coding: utf-8
 
+from flask_babelex import gettext as _
 from wtforms import form, fields, validators
-
 from app.controllers import get_user_by_email
 
 
 class LoginForm(form.Form):
-    email = fields.TextField('Email', validators=[validators.required(), validators.email()])
-    password = fields.PasswordField(validators=[validators.required()])
+    email = fields.TextField(_(u'Email'), validators=[validators.required(), validators.email()])
+    password = fields.PasswordField(_(u'Senha'), validators=[validators.required()])
 
     def validate_password(self, field):
         user = get_user_by_email(self.email.data)
         if user is None:
-            raise validators.ValidationError('Invalid user')
+            raise validators.ValidationError(_(u'Usuário inválido'))
         if not user.is_correct_password(self.password.data):
-            raise validators.ValidationError('Invalid password')
+            raise validators.ValidationError(_(u'Senha inválida'))
 
 
 class EmailForm(form.Form):
-    email = fields.TextField('Email', validators=[validators.required(), validators.email()])
+    email = fields.TextField(_(u'Email'), validators=[validators.required(), validators.email()])
 
 
 class PasswordForm(form.Form):
-    password = fields.PasswordField('Password', validators=[validators.required()])
+    password = fields.PasswordField(_(u'Senha'), validators=[validators.required()])

--- a/app/main/views.py
+++ b/app/main/views.py
@@ -1,10 +1,33 @@
 # coding: utf-8
 
 from collections import OrderedDict
+from flask_babelex import gettext as _
+from flask import render_template, abort, current_app, request, session, redirect
 
-from flask import render_template, abort
 from . import main
+from flask import current_app
+from app import babel
 from app import controllers
+
+
+@babel.localeselector
+def get_locale():
+    langs = current_app.config.get('LANGUAGES')
+    lang_from_headers = request.accept_languages.best_match(langs.keys())
+    if 'lang' not in session.keys():
+        session['lang'] = lang_from_headers
+    return session['lang']
+
+
+@main.route('/set_locale/<string:lang_code>')
+def set_locale(lang_code):
+    langs = current_app.config.get('LANGUAGES')
+    if lang_code not in langs.keys():
+        abort(400, _('Código de idioma inválido'))
+
+    # salvar o lang code na sessão
+    session['lang'] = lang_code
+    return redirect(request.referrer)
 
 
 @main.route('/')
@@ -46,7 +69,7 @@ def journal_detail(journal_id):
     journal = controllers.get_journal_by_jid(journal_id)
 
     if not journal:
-        abort(404, 'Journal not found')
+        abort(404, _(u'Periódico não encontrado'))
 
     context = {'journal': journal}
 
@@ -58,7 +81,7 @@ def issue_grid(journal_id):
     journal = controllers.get_journal_by_jid(journal_id)
 
     if not journal:
-        abort(404, 'Journal not found')
+        abort(404, _(u'Periódico não encontrado'))
 
     issues = controllers.get_issues_by_jid(journal_id)
 
@@ -81,7 +104,7 @@ def issue_toc(issue_id):
     issue = controllers.get_issue_by_iid(issue_id)
 
     if not issue:
-        abort(404, 'Issue not found')
+        abort(404, _(u'Fascículo não encontrado'))
 
     journal = issue.journal
     articles = controllers.get_articles_by_iid(issue.iid)
@@ -98,7 +121,7 @@ def article_detail(article_id):
     article = controllers.get_article_by_aid(article_id)
 
     if not article:
-        abort(404, 'Article not found')
+        abort(404, _(u'Artigo não encontrado'))
 
     context = {
         'article': article,
@@ -113,7 +136,7 @@ def article_html_by_aid(article_id):
     article = controllers.get_article_by_aid(article_id)
 
     if not article:
-        abort(404, 'Article not found')
+        abort(404, _(u'Artigo não encontrado'))
 
     article_html = article.htmls[0].source
 
@@ -125,7 +148,7 @@ def abstract_detail(article_id):
     article = controllers.get_article_by_aid(article_id)
 
     if not article:
-        abort(404, 'Article not found')
+        abort(404, _(u'Artigo não encontrado'))
 
     context = {
         'article': article,

--- a/app/templates/admin/auth/login.html
+++ b/app/templates/admin/auth/login.html
@@ -8,24 +8,24 @@
       {% if current_user.is_authenticated %}
 
         <div class="panel panel-default">
-          <div class="panel-heading">Iniciar sessão</div>
+          <div class="panel-heading">{% trans %}Iniciar sessão{% endtrans %}</div>
           <div class="panel-body">
-            Você já iniciou sessão!
+            {% trans %}Você já iniciou sessão!{% endtrans %}
           </div>
         </div>
 
       {% else %}
 
         <div class="panel panel-default">
-          <div class="panel-heading">Iniciar sessão</div>
+          <div class="panel-heading">{% trans %}Iniciar sessão{% endtrans %}</div>
           <div class="panel-body">
             <form method="POST" action="" class="form-horizontal">
               {% include "admin/includes/forms.html" %}
-              <button class="btn btn-primary pull-right" type="submit">Enviar</button>
+              <button class="btn btn-primary pull-right" type="submit">{% trans %}Enviar{% endtrans %}</button>
             </form>
           </div>
           <div class="panel-footer">
-            <a href="{{ url_for('.reset') }}">Esqueci a senha?</a>
+            <a href="{{ url_for('.reset') }}">{% trans %}Esqueci a senha?{% endtrans %}</a>
           </div>
         </div>
 

--- a/app/templates/admin/auth/reset.html
+++ b/app/templates/admin/auth/reset.html
@@ -6,11 +6,11 @@
     <div class="col-md-5 col-md-offset-4">
 
         <div class="panel panel-default">
-          <div class="panel-heading">Recuperar a senha</div>
+          <div class="panel-heading">{% trans %}Recuperar a senha{% endtrans %}</div>
           <div class="panel-body">
             <form method="POST" action="" class="form-horizontal">
               {% include "admin/includes/forms.html" %}
-              <button class="btn btn-primary pull-right" type="submit">Enviar</button>
+              <button class="btn btn-primary pull-right" type="submit">{% trans %}Enviar{% endtrans %}</button>
             </form>
           </div>
         </div>

--- a/app/templates/admin/auth/reset_with_token.html
+++ b/app/templates/admin/auth/reset_with_token.html
@@ -6,11 +6,11 @@
     <div class="col-md-5 col-md-offset-4">
 
         <div class="panel panel-default">
-          <div class="panel-heading">Recuperar a senha</div>
+          <div class="panel-heading">{% trans %}Recuperar a senha{% endtrans %}</div>
           <div class="panel-body">
             <form method="POST" action="{{ url_for('.reset_with_token', token=token) }}" class="form-horizontal">
               {% include "admin/includes/forms.html" %}
-              <button class="btn btn-primary pull-right" type="submit">Enviar</button>
+              <button class="btn btn-primary pull-right" type="submit">{% trans %}Enviar{% endtrans %}</button>
             </form>
           </div>
         </div>

--- a/app/templates/admin/auth/unconfirm_email.html
+++ b/app/templates/admin/auth/unconfirm_email.html
@@ -4,10 +4,10 @@
   <div class="row-fluid">
     <div class="col-md-5 col-md-offset-4">
         <div class="panel panel-danger">
-          <div class="panel-heading">Email não confirmado!</div>
+          <div class="panel-heading">{% trans %}Email não confirmado!</div>
           <div class="panel-body">
-            Você <strong>deve</strong> confirmar seu email.<br>
-            <strong>Por favor entre em contato com o administrador.</strong>
+            {% trans %}Você <strong>deve</strong> confirmar seu email.<br>
+            <strong>Por favor entre em contato com o administrador.</strong>{% endtrans %}
           </div>
         </div>
     </div>

--- a/app/templates/admin/index.html
+++ b/app/templates/admin/index.html
@@ -4,22 +4,22 @@
   <div class="container">
     <div class="row">
       <div class="page-header">
-        <h1>OPAC Admin <small>da coleção: {{config.OPAC_COLLECTION|upper}}</small></h1>
+        <h1>OPAC Admin <small>{% trans %}da coleção{% endtrans %}: {{config.OPAC_COLLECTION|upper}}</small></h1>
       </div>
       <div class="col-md-4">
         <div class="panel panel-default">
           <div class="panel-heading">
-            <h3 class="panel-title">Periódicos:</h3>
+            <h3 class="panel-title">{% trans %}Periódicos{% endtrans %}:</h3>
           </div>
           <div class="panel-body">
-            <h1>{{counts.journals_public_count}} <small>Publicados</small></h1>
-            <h2>{{counts.journals_total_count}} <small>Total</small></h2>
+            <h1>{{counts.journals_public_count}} <small>{% trans %}Publicados{% endtrans %}</small></h1>
+            <h2>{{counts.journals_total_count}} <small>{% trans %}Total{% endtrans %}</small></h2>
           </div>
           {% if counts.journals_total_count > 0 %}
             <div class="panel-footer">
               <div class="progress">
                 <div class="progress-bar" role="progressbar" aria-valuenow="{{counts.journals_public_count}}" aria-valuemin="0" aria-valuemax="100" style="width: {{ 100 * (counts.journals_public_count / counts.journals_total_count)|round(2, 'floor') }}%;">
-                  {{ 100 * (counts.journals_public_count / counts.journals_total_count)|round(2, 'floor') }}% Publicados
+                  {{ 100 * (counts.journals_public_count / counts.journals_total_count)|round(2, 'floor') }}% {% trans %}Publicados{% endtrans %}
                 </div>
               </div>
             </div>
@@ -29,17 +29,17 @@
       <div class="col-md-4">
         <div class="panel panel-info">
           <div class="panel-heading">
-            <h3 class="panel-title">Fascícluos:</h3>
+            <h3 class="panel-title">{% trans %}Fascícluos{% endtrans %}:</h3>
           </div>
           <div class="panel-body">
-            <h1>{{counts.issues_public_count}} <small>Publicados</small></h1>
-            <h2>{{counts.issues_total_count}} <small>Total</small></h2>
+            <h1>{{counts.issues_public_count}} <small>{% trans %}Publicados{% endtrans %}</small></h1>
+            <h2>{{counts.issues_total_count}} <small>{% trans %}Total{% endtrans %}</small></h2>
           </div>
           {% if counts.issues_total_count > 0 %}
             <div class="panel-footer">
               <div class="progress">
                 <div class="progress-bar progress-bar-info" role="progressbar" aria-valuenow="{{counts.issues_public_count}}" aria-valuemin="0" aria-valuemax="100" style="width: {{ 100 * (counts.issues_public_count / counts.issues_total_count)|round(2, 'floor') }}%;">
-                  {{ 100 * (counts.issues_public_count / counts.issues_total_count)|round(2, 'floor') }}% Publicados
+                  {{ 100 * (counts.issues_public_count / counts.issues_total_count)|round(2, 'floor') }}% {% trans %}Publicados{% endtrans %}
                 </div>
               </div>
             </div>
@@ -49,17 +49,17 @@
       <div class="col-md-4">
         <div class="panel panel-success">
           <div class="panel-heading">
-            <h3 class="panel-title">Artigos:</h3>
+            <h3 class="panel-title">{% trans %}Artigos{% endtrans %}:</h3>
           </div>
           <div class="panel-body">
-            <h1>{{counts.articles_public_count}} <small>Publicados</small></h1>
-            <h2>{{counts.articles_total_count}} <small>Total</small></h2>
+            <h1>{{counts.articles_public_count}} <small>{% trans %}Publicados{% endtrans %}</small></h1>
+            <h2>{{counts.articles_total_count}} <small>{% trans %}Total{% endtrans %}</small></h2>
           </div>
           {% if counts.articles_total_count > 0 %}
             <div class="panel-footer">
               <div class="progress">
                 <div class="progress-bar progress-bar-success" role="progressbar" aria-valuenow="{{counts.articles_public_count}}" aria-valuemin="0" aria-valuemax="100" style="width: {{ 100 * (counts.articles_public_count / counts.articles_total_count)|round(2, 'floor') }}%;">
-                  {{ 100 * (counts.articles_public_count / counts.articles_total_count)|round(2, 'floor') }}% Publicados
+                  {{ 100 * (counts.articles_public_count / counts.articles_total_count)|round(2, 'floor') }}% {% trans %}Publicados{% endtrans %}
                 </div>
               </div>
             </div>

--- a/app/templates/admin/opac_base.html
+++ b/app/templates/admin/opac_base.html
@@ -19,12 +19,37 @@
           {{ current_user.email }} <span class="caret"></span>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="{{ url_for('admin.reset') }}">Recuperar a senha</a></li>
-          <li><a href="{{ url_for('admin.logout_view') }}">Terminar sessão</a></li>
+          <li><a href="{{ url_for('admin.reset') }}">{% trans %}Recuperar a senha{% endtrans %}</a></li>
+          <li><a href="{{ url_for('admin.logout_view') }}">{% trans %}Terminar sessão{% endtrans %}</a></li>
         </ul>
       </li>
     {% else %}
-      <li><a href="{{ url_for('admin.login_view') }}">Iniciar sessão</a></li>
+      <li><a href="{{ url_for('admin.login_view') }}">{% trans %}Iniciar sessão{% endtrans %}</a></li>
     {% endif %}
   </ul>
+{% endblock %}
+
+{% block tail %}
+  <div class="container">
+    <div class="row">
+      <div class="col-md-12">
+        <hr>
+        <p class="text-center text-capitalize">
+          <small>
+            {% for k,v in config.LANGUAGES.iteritems() %}
+              <a href="{{ url_for('main.set_locale', lang_code=k) }}">
+                {% if k == session['lang'] %}
+                  <strong>{{ v }}</strong>
+                {% else %}
+                  {{ v }}
+                {% endif %}
+              </a>
+              {% if not loop.last %}|{% endif %}
+            {% endfor %}
+          </small>
+        </p>
+        <hr>
+      </div>
+    </div>
+  </div>
 {% endblock %}

--- a/app/templates/collection/index.html
+++ b/app/templates/collection/index.html
@@ -5,18 +5,18 @@
   <section class="collection collectionNews">
     <div class="container">
       <div class="row sectionTitle">
-        <h1 class="col-md-8 col-sm-7">Notícias</h1>
+        <h1 class="col-md-8 col-sm-7">{% trans %}Notícias{% endtrans%}</h1>
         <div class="col-md-4 col-sm-5 share">
           <a href="javascript:window.print();" class="sharePrint showTooltip" data-placement="top" title="Imprimir"><span class="glyphBtn print"></span></a>
           <a href="#" class="showTooltip" data-placement="top" title="RSS" target="blank"><span class="glyphBtn rssMini"></span></a>
           <span class="divisor"></span>
-          Compartilhe
+          {% trans %}Compartilhe{% endtrans %}
           <a href="" class="sendViaMail showTooltip" data-placement="top" title="Enviar link por e-mail"><span class="glyphBtn sendMail"></span></a>
           <a href="" class="shareFacebook showTooltip" data-placement="top" title="Compartilhar no Facebook"><span class="glyphBtn facebook"></span></a>
           <a href="" class="shareTwitter showTooltip" data-placement="top" title="Compartilhar no Twitter"><span class="glyphBtn twitter"></span></a>
           <a href="" class="showTooltip dropdown-toggle" data-toggle="dropdown" data-placement="top" title="Outras redes sociais"><span class="glyphBtn otherNetworks"></span></a>
           <ul class="dropdown-menu">
-              <li class="dropdown-header">Outras redes sociais</li>
+              <li class="dropdown-header">{% trans %}Outras redes sociais{% endtrans %}</li>
               <li><a href="" class="shareGooglePlus"><span class="glyphBtn googlePlus"></span> Google+</a></li>
               <li><a href="" class="shareLinkedIn"><span class="glyphBtn linkedIn"></span> LinkedIn</a></li>
               <li><a href="" class="shareReddit"><span class="glyphBtn reddit"></span> Reddit</a></li>

--- a/app/translations/en/LC_MESSAGES/messages.po
+++ b/app/translations/en/LC_MESSAGES/messages.po
@@ -1,0 +1,317 @@
+# English translations for OPAC.
+# Copyright (C) 2016 ORGANIZATION
+# This file is distributed under the same license as the OPAC project.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2016.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: OPAC 1.0\n"
+"Report-Msgid-Bugs-To: tecnologia@scielo.org\n"
+"POT-Creation-Date: 2016-01-07 14:31-0200\n"
+"PO-Revision-Date: 2016-01-07 14:56-0200\n"
+"Last-Translator: scielo <tecnologia@scielo.org>\n"
+"Language: en\n"
+"Language-Team: en <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.2.0\n"
+"X-Generator: Poedit 1.8.6\n"
+
+#: app/__init__.py:80
+msgid "Periódico"
+msgstr "Journal"
+
+#: app/__init__.py:81
+msgid "Fascículo"
+msgstr "Issue"
+
+#: app/__init__.py:82
+msgid "Artigo"
+msgstr "Article"
+
+#: app/__init__.py:83
+msgid "Usuário"
+msgstr "User"
+
+#: app/admin/forms.py:9 app/admin/forms.py:21
+msgid "Email"
+msgstr "Email"
+
+#: app/admin/forms.py:10 app/admin/forms.py:25
+msgid "Senha"
+msgstr "Password"
+
+#: app/admin/forms.py:15
+msgid "Usuário inválido"
+msgstr "Invalid user"
+
+#: app/admin/forms.py:17
+msgid "Senha inválida"
+msgstr "Invalid password"
+
+#: app/admin/views.py:18
+msgid "Tem certeza que quer publicar os itens selecionados?"
+msgstr "Are you sure you want to publish the selected items?"
+
+#: app/admin/views.py:19
+msgid "Tem certeza que quer despublicar os itens selecionados?"
+msgstr "Are you sure you want to unpublish the selected items?"
+
+#: app/admin/views.py:20
+msgid "Tem certeza que quer reconstruir os artigos selecionados?"
+msgstr "Are you sure you want to rebuild the selected articles?"
+
+#: app/admin/views.py:21
+msgid ""
+"Tem certeza que quer enviar email de confirmação aos usuários selecionados?"
+msgstr "Are you sure you want to send confirmation email to the selected users?"
+
+#: app/admin/views.py:76 app/admin/views.py:89
+msgid "Usuário não encontrado"
+msgstr "User not found"
+
+#: app/admin/views.py:79
+#, python-format
+msgid "Email: %(email)s confirmado com sucesso!"
+msgstr "Email: %(email)s successfully confirmed!"
+
+#: app/admin/views.py:95
+#, python-format
+msgid "Enviamos as instruções para recuperar a senha para: %(email)s"
+msgstr "Sent the instructions to recover the password to: %(email)s"
+
+#: app/admin/views.py:98
+#, python-format
+msgid ""
+"Ocorreu um erro no envio das instruções por email para: %(email)s. Erro: "
+"%(error)s"
+msgstr "Error sending the instructions via email to: %(email)s. Error: %(error)s"
+
+#: app/admin/views.py:124
+msgid "Nova senha salva com sucesso!!"
+msgstr "New password saved successfully!!"
+
+#: app/admin/views.py:150 app/admin/views.py:169
+#, python-format
+msgid "Enviamos o email de confirmação para: %(email)s"
+msgstr "We sent a confirmation email to: %(email)s"
+
+#: app/admin/views.py:153 app/admin/views.py:172
+#, python-format
+msgid "Ocorreu um erro no envio do email de confirmação para: %(email)s"
+msgstr "An error occurred while sending the confirmation email to: %(email)s"
+
+#: app/admin/views.py:160
+msgid "Enviar email de confirmação"
+msgstr "Send confirmation email"
+
+#: app/admin/views.py:176
+#, python-format
+msgid "%(count)s usuários foram notificados com sucesso!"
+msgstr "%(count)s users were successfully notified!"
+
+#: app/admin/views.py:179
+#, python-format
+msgid "Ocorreu um erro no envio do emails de confirmação. Erro: %(ex)s"
+msgstr "An error occurred while sending the confirmation emails. Error: %(ex)s"
+
+#: app/admin/views.py:225 app/admin/views.py:268 app/admin/views.py:328
+msgid "Publicar"
+msgstr "Publish"
+
+#: app/admin/views.py:230
+msgid "Periódico(s) publicado(s) com sucesso!!"
+msgstr "Journal(s) successfully published!!"
+
+#: app/admin/views.py:232
+msgid "Ocorreu um erro tentando publicar o(s) periódico(s)!!"
+msgstr "An error occurred trying to publish the journal(s)!!"
+
+#: app/admin/views.py:236 app/admin/views.py:281
+msgid "Despublicar"
+msgstr "Unpublish"
+
+#: app/admin/views.py:241
+msgid "Periódico(s) despublicado com sucesso!!"
+msgstr "Journal(s) successfully unpublished!!"
+
+#: app/admin/views.py:244
+#, python-format
+msgid "Ocorreu um erro tentando publicar o(s) periódico(s)!!. Erro: %(ex)s"
+msgstr "An error occurred trying to publish the journal(s)!! Error %(ex)s"
+
+#: app/admin/views.py:273
+msgid "Fascículo(s) publicado(s) com sucesso!!"
+msgstr "Issue(s) successfully published!!"
+
+#: app/admin/views.py:276 app/admin/views.py:337
+#, python-format
+msgid "Ocorreu um erro tentando publicar o(s) fascículo(s)!!. Erro: %(ex)s"
+msgstr "An error occurred trying to publish the issue(s)!! Error %(ex)s"
+
+#: app/admin/views.py:286
+msgid "Fascículo(s) despublicado(s) com sucesso!!"
+msgstr "Issue(s) successfully unpublished!!"
+
+#: app/admin/views.py:289 app/admin/views.py:350
+#, python-format
+msgid "Ocorreu um erro tentando despublicar o(s) fascículo(s)!!. Erro: %(ex)s"
+msgstr "An error occurred trying to unpublish the issue(s)!! Error %(ex)s"
+
+#: app/admin/views.py:312
+msgid "Reconstruir HTML"
+msgstr "Rebuild HTML"
+
+#: app/admin/views.py:320
+msgid "Artigo(s) reconstruido com sucesso!!"
+msgstr "Article(s) successfully rebuilt!!"
+
+#: app/admin/views.py:323
+#, python-format
+msgid "Ocorreu um erro tentando reconstruir o(s) artigo(s)!!. Erro: %(ex)s"
+msgstr "An error occurred trying to rebuild the article(s)!! Error %(ex)s"
+
+#: app/admin/views.py:333
+msgid "Artigo(s) publicado com sucesso!!"
+msgstr "Article(s) successfully published!!"
+
+#: app/admin/views.py:347
+msgid "Artigo(s) despublicado com sucesso!!"
+msgstr "Article(s) successfully unpublished!!"
+
+#: app/main/views.py:26
+msgid "Código de idioma inválido"
+msgstr "Invalid language code"
+
+#: app/main/views.py:72 app/main/views.py:84
+msgid "Periódico não encontrado"
+msgstr "Journal not found"
+
+#: app/main/views.py:107
+msgid "Fascículo não encontrado"
+msgstr "Issue not found"
+
+#: app/main/views.py:124 app/main/views.py:139 app/main/views.py:151
+msgid "Artigo não encontrado"
+msgstr "Article not found"
+
+#: app/templates/admin/index.html:7
+msgid "da coleção"
+msgstr "of collection"
+
+#: app/templates/admin/index.html:12
+msgid "Periódicos"
+msgstr "Journals"
+
+#: app/templates/admin/index.html:15 app/templates/admin/index.html:22
+#: app/templates/admin/index.html:35 app/templates/admin/index.html:42
+#: app/templates/admin/index.html:55 app/templates/admin/index.html:62
+msgid "Publicados"
+msgstr "Published"
+
+#: app/templates/admin/index.html:16 app/templates/admin/index.html:36
+#: app/templates/admin/index.html:56
+msgid "Total"
+msgstr "Total"
+
+#: app/templates/admin/index.html:32
+msgid "Fascícluos"
+msgstr "Issues"
+
+#: app/templates/admin/index.html:52
+msgid "Artigos"
+msgstr "Articles"
+
+#: app/templates/admin/opac_base.html:22 app/templates/admin/auth/reset.html:9
+#: app/templates/admin/auth/reset_with_token.html:9
+msgid "Recuperar a senha"
+msgstr "Reset password"
+
+#: app/templates/admin/opac_base.html:23
+msgid "Terminar sessão"
+msgstr "Logout"
+
+#: app/templates/admin/opac_base.html:27 app/templates/admin/auth/login.html:11
+#: app/templates/admin/auth/login.html:20
+msgid "Iniciar sessão"
+msgstr "Login"
+
+#: app/templates/admin/auth/login.html:13
+msgid "Você já iniciou sessão!"
+msgstr "You’re already logged in!"
+
+#: app/templates/admin/auth/login.html:24 app/templates/admin/auth/reset.html:13
+#: app/templates/admin/auth/reset_with_token.html:13
+msgid "Enviar"
+msgstr "Send"
+
+#: app/templates/admin/auth/login.html:28
+msgid "Esqueci a senha?"
+msgstr "Forgot the password?"
+
+#: app/templates/admin/model/custom_list.html:17
+#, python-format
+msgid "%(name)s"
+msgstr "%(name)s"
+
+#: app/templates/collection/index.html:8
+msgid "Notícias"
+msgstr "News"
+
+#: app/templates/collection/index.html:13
+msgid "Compartilhe"
+msgstr "Share"
+
+#: app/templates/collection/index.html:19
+msgid "Outras redes sociais"
+msgstr "Other social networks"
+
+#~ msgid "JID"
+#~ msgstr "JID"
+
+#~ msgid "Coleções"
+#~ msgstr "Collections"
+
+#~ msgid "Título"
+#~ msgstr "Title"
+
+#~ msgid "Criado"
+#~ msgstr "Created"
+
+#~ msgid "Atualizado"
+#~ msgstr "Updated"
+
+#~ msgid "Acrônimo"
+#~ msgstr "Acronym"
+
+#~ msgid "Issn"
+#~ msgstr "Issn"
+
+#~ msgid "Periódico anterior"
+#~ msgstr "Previous journal"
+
+#~ msgid "Estado atual"
+#~ msgstr "Current state"
+
+#~ msgid "Publicado?"
+#~ msgstr "Published?"
+
+#~ msgid "IID"
+#~ msgstr "IID"
+
+#~ msgid "Volume"
+#~ msgstr "Volume"
+
+#~ msgid "Número"
+#~ msgstr "Number"
+
+#~ msgid "Tipo"
+#~ msgstr "Type"
+
+#~ msgid "Ano"
+#~ msgstr "Year"
+
+#~ msgid "AID"
+#~ msgstr "AID"

--- a/app/translations/es/LC_MESSAGES/messages.po
+++ b/app/translations/es/LC_MESSAGES/messages.po
@@ -1,0 +1,322 @@
+# Spanish translations for OPAC.
+# Copyright (C) 2016 ORGANIZATION
+# This file is distributed under the same license as the OPAC project.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2016.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: OPAC 1.0\n"
+"Report-Msgid-Bugs-To: tecnologia@scielo.org\n"
+"POT-Creation-Date: 2016-01-07 14:31-0200\n"
+"PO-Revision-Date: 2016-01-07 14:56-0200\n"
+"Last-Translator: scielo <tecnologia@scielo.org>\n"
+"Language: es\n"
+"Language-Team: es <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.2.0\n"
+"X-Generator: Poedit 1.8.6\n"
+
+#: app/__init__.py:80
+msgid "Periódico"
+msgstr "Periódico"
+
+#: app/__init__.py:81
+msgid "Fascículo"
+msgstr "Fascícluo"
+
+#: app/__init__.py:82
+msgid "Artigo"
+msgstr "Artículo"
+
+#: app/__init__.py:83
+msgid "Usuário"
+msgstr "Usuario"
+
+#: app/admin/forms.py:9 app/admin/forms.py:21
+msgid "Email"
+msgstr "Email"
+
+#: app/admin/forms.py:10 app/admin/forms.py:25
+msgid "Senha"
+msgstr "Contraseña"
+
+#: app/admin/forms.py:15
+msgid "Usuário inválido"
+msgstr "Usuario inválido"
+
+#: app/admin/forms.py:17
+msgid "Senha inválida"
+msgstr "Contraseña inválida"
+
+#: app/admin/views.py:18
+msgid "Tem certeza que quer publicar os itens selecionados?"
+msgstr "¿Está seguro que desea publicar los ítems seleccionados?"
+
+#: app/admin/views.py:19
+msgid "Tem certeza que quer despublicar os itens selecionados?"
+msgstr "¿Está seguro que desea despublicar los ítems seleccionados?"
+
+#: app/admin/views.py:20
+msgid "Tem certeza que quer reconstruir os artigos selecionados?"
+msgstr "¿Está seguro que desea reconstruir los artículos seleccionados?"
+
+#: app/admin/views.py:21
+msgid ""
+"Tem certeza que quer enviar email de confirmação aos usuários selecionados?"
+msgstr ""
+"¿Está seguro que desea enviar email de confirmación a los usuarios "
+"seleccionados?"
+
+#: app/admin/views.py:76 app/admin/views.py:89
+msgid "Usuário não encontrado"
+msgstr "Usuario no encontrado"
+
+#: app/admin/views.py:79
+#, python-format
+msgid "Email: %(email)s confirmado com sucesso!"
+msgstr "Email: %(email)s confirmado com éxito!"
+
+#: app/admin/views.py:95
+#, python-format
+msgid "Enviamos as instruções para recuperar a senha para: %(email)s"
+msgstr "Enviamos las instrucciones para recuperar la contraseña para: %(email)s"
+
+#: app/admin/views.py:98
+#, python-format
+msgid ""
+"Ocorreu um erro no envio das instruções por email para: %(email)s. Erro: "
+"%(error)s"
+msgstr ""
+"Ocurrió un error en el envío de las instrucciones por email para %(email)s. "
+"Error: %(error)s"
+
+#: app/admin/views.py:124
+msgid "Nova senha salva com sucesso!!"
+msgstr "Nueva contraseña guardada con éxito!!"
+
+#: app/admin/views.py:150 app/admin/views.py:169
+#, python-format
+msgid "Enviamos o email de confirmação para: %(email)s"
+msgstr "Enviamos el email de confirmación para %(email)s"
+
+#: app/admin/views.py:153 app/admin/views.py:172
+#, python-format
+msgid "Ocorreu um erro no envio do email de confirmação para: %(email)s"
+msgstr "Ocurrió un error en el envío de email de confirmación para %(email)s"
+
+#: app/admin/views.py:160
+msgid "Enviar email de confirmação"
+msgstr "Enviar email de confirmación"
+
+#: app/admin/views.py:176
+#, python-format
+msgid "%(count)s usuários foram notificados com sucesso!"
+msgstr "%(count)s usuarios fueron notificados con éxito!"
+
+#: app/admin/views.py:179
+#, python-format
+msgid "Ocorreu um erro no envio do emails de confirmação. Erro: %(ex)s"
+msgstr "Ocurrió un error en el envío de emails de confirmación. Error: %(ex)s"
+
+#: app/admin/views.py:225 app/admin/views.py:268 app/admin/views.py:328
+msgid "Publicar"
+msgstr "Publicar"
+
+#: app/admin/views.py:230
+msgid "Periódico(s) publicado(s) com sucesso!!"
+msgstr "Periódico(s) publicado(s) con éxito!!"
+
+#: app/admin/views.py:232
+msgid "Ocorreu um erro tentando publicar o(s) periódico(s)!!"
+msgstr "Ocurrió un error intentando publicar el/los periódico(s)!!"
+
+#: app/admin/views.py:236 app/admin/views.py:281
+msgid "Despublicar"
+msgstr "Despublicar"
+
+#: app/admin/views.py:241
+msgid "Periódico(s) despublicado com sucesso!!"
+msgstr "Periódico(s) despublicado(s) com éxito!!"
+
+#: app/admin/views.py:244
+#, python-format
+msgid "Ocorreu um erro tentando publicar o(s) periódico(s)!!. Erro: %(ex)s"
+msgstr "Ocurrió un error intentando publicar el/los periódico(s)!! Erro: %(ex)s"
+
+#: app/admin/views.py:273
+msgid "Fascículo(s) publicado(s) com sucesso!!"
+msgstr "Fascículo(s) publicado(s) com éxito!!"
+
+#: app/admin/views.py:276 app/admin/views.py:337
+#, python-format
+msgid "Ocorreu um erro tentando publicar o(s) fascículo(s)!!. Erro: %(ex)s"
+msgstr "Ocurrió un error intentando publicar el/los fascículo(s)!! Error: %(ex)s"
+
+#: app/admin/views.py:286
+msgid "Fascículo(s) despublicado(s) com sucesso!!"
+msgstr "Fascículo(s) despublicado(s) com éxito!!"
+
+#: app/admin/views.py:289 app/admin/views.py:350
+#, python-format
+msgid "Ocorreu um erro tentando despublicar o(s) fascículo(s)!!. Erro: %(ex)s"
+msgstr ""
+"Ocurrió un error intentando despublicar el/los fascículo(s)!! Error: %(ex)s"
+
+#: app/admin/views.py:312
+msgid "Reconstruir HTML"
+msgstr "Reconstruir HTML"
+
+#: app/admin/views.py:320
+msgid "Artigo(s) reconstruido com sucesso!!"
+msgstr "Artículo recontruido con éxito!!"
+
+#: app/admin/views.py:323
+#, python-format
+msgid "Ocorreu um erro tentando reconstruir o(s) artigo(s)!!. Erro: %(ex)s"
+msgstr "Ocurrió un error intentando reconstruir el/los artículo(s). Error: %(ex)s"
+
+#: app/admin/views.py:333
+msgid "Artigo(s) publicado com sucesso!!"
+msgstr "Artículo(s) publicado con éxito!!"
+
+#: app/admin/views.py:347
+msgid "Artigo(s) despublicado com sucesso!!"
+msgstr "Artículo(s) despublicado con éxito!!"
+
+#: app/main/views.py:26
+msgid "Código de idioma inválido"
+msgstr "Código de idioma inválido"
+
+#: app/main/views.py:72 app/main/views.py:84
+msgid "Periódico não encontrado"
+msgstr "Periódico no encontrado"
+
+#: app/main/views.py:107
+msgid "Fascículo não encontrado"
+msgstr "Fascículo no encontrado"
+
+#: app/main/views.py:124 app/main/views.py:139 app/main/views.py:151
+msgid "Artigo não encontrado"
+msgstr "Artículo no encontrado"
+
+#: app/templates/admin/index.html:7
+msgid "da coleção"
+msgstr "de la colección"
+
+#: app/templates/admin/index.html:12
+msgid "Periódicos"
+msgstr "Periódicos"
+
+#: app/templates/admin/index.html:15 app/templates/admin/index.html:22
+#: app/templates/admin/index.html:35 app/templates/admin/index.html:42
+#: app/templates/admin/index.html:55 app/templates/admin/index.html:62
+msgid "Publicados"
+msgstr "Publicados"
+
+#: app/templates/admin/index.html:16 app/templates/admin/index.html:36
+#: app/templates/admin/index.html:56
+msgid "Total"
+msgstr "Total"
+
+#: app/templates/admin/index.html:32
+msgid "Fascícluos"
+msgstr "Fascícluos"
+
+#: app/templates/admin/index.html:52
+msgid "Artigos"
+msgstr "Artículos"
+
+#: app/templates/admin/opac_base.html:22 app/templates/admin/auth/reset.html:9
+#: app/templates/admin/auth/reset_with_token.html:9
+msgid "Recuperar a senha"
+msgstr "Recuperar contraseña"
+
+#: app/templates/admin/opac_base.html:23
+msgid "Terminar sessão"
+msgstr "Cerrar sesión"
+
+#: app/templates/admin/opac_base.html:27 app/templates/admin/auth/login.html:11
+#: app/templates/admin/auth/login.html:20
+msgid "Iniciar sessão"
+msgstr "Inicial sesión"
+
+#: app/templates/admin/auth/login.html:13
+msgid "Você já iniciou sessão!"
+msgstr "Usted ya inició sesión!"
+
+#: app/templates/admin/auth/login.html:24 app/templates/admin/auth/reset.html:13
+#: app/templates/admin/auth/reset_with_token.html:13
+msgid "Enviar"
+msgstr "Enviar"
+
+#: app/templates/admin/auth/login.html:28
+msgid "Esqueci a senha?"
+msgstr "Olvidé mi contraseña"
+
+#: app/templates/admin/model/custom_list.html:17
+#, python-format
+msgid "%(name)s"
+msgstr "%(name)s"
+
+#: app/templates/collection/index.html:8
+msgid "Notícias"
+msgstr "Noticias"
+
+#: app/templates/collection/index.html:13
+msgid "Compartilhe"
+msgstr "Compartir"
+
+#: app/templates/collection/index.html:19
+msgid "Outras redes sociais"
+msgstr "Otras redes sociales"
+
+#~ msgid "JID"
+#~ msgstr "JID"
+
+#~ msgid "Coleções"
+#~ msgstr "Colecciones"
+
+#~ msgid "Título"
+#~ msgstr "Título"
+
+#~ msgid "Criado"
+#~ msgstr "Creado"
+
+#~ msgid "Atualizado"
+#~ msgstr "Actualizado"
+
+#~ msgid "Acrônimo"
+#~ msgstr "Acrónimo"
+
+#~ msgid "Issn"
+#~ msgstr "Issn"
+
+#~ msgid "Periódico anterior"
+#~ msgstr "Periódico anterior"
+
+#~ msgid "Estado atual"
+#~ msgstr "Estado actual"
+
+#~ msgid "Publicado?"
+#~ msgstr "Publicado?"
+
+#~ msgid "IID"
+#~ msgstr "IID"
+
+#~ msgid "Volume"
+#~ msgstr "Volúmen"
+
+#~ msgid "Número"
+#~ msgstr "Número"
+
+#~ msgid "Tipo"
+#~ msgstr "Tipo"
+
+#~ msgid "Ano"
+#~ msgstr "Año"
+
+#~ msgid "AID"
+#~ msgstr "AID"

--- a/app/utils.py
+++ b/app/utils.py
@@ -1,4 +1,5 @@
 # coding: utf-8
+
 from lxml import etree
 import packtools
 from itsdangerous import URLSafeTimedSerializer
@@ -6,7 +7,7 @@ from flask_mail import Message
 from flask import current_app
 from . import dbsql, controllers, mail, models
 
-CSS = "/static/css/style_article_html.css"
+CSS = "/static/css/style_article_html.css"  # caminho para o CSS a ser incluído no HTML do artigo
 
 
 def get_timed_serializer():

--- a/config/babel.cfg
+++ b/config/babel.cfg
@@ -1,0 +1,3 @@
+[python: **.py]
+[jinja2: **/templates/**.html]
+extensions=jinja2.ext.autoescape,jinja2.ext.with_

--- a/config/default.py
+++ b/config/default.py
@@ -29,3 +29,10 @@ OPAC_COLLECTION = ''
 
 # Tempo de expiração para os tokens
 TOKEN_MAX_AGE = 86400  # valor en segundos: 86400 = 60*60*24 = 1 dia
+
+LANGUAGES = {
+    'pt_BR': u'Português',
+    'en': u'English',
+    'es': u'Español',
+}
+BABEL_DEFAULT_LOCALE = 'pt_BR'

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ Flask-Login==0.3.2
 Flask-Script==2.0.5
 Flask-Mail==0.9.1
 lxml==3.5.0
+Flask-BabelEx==0.9.2


### PR DESCRIPTION
#### Objetivos do PR?

* Definir quais são os idiomas suportados
  * Definido: pt_BR, ES, EN
* Definir estratégia de decisão do idioma para o usuário (Quando abrir um recurso da app qual será o idioma?)
  * No primeiro acesso ao site, vai ser segundo o sugerido pelo cabeçalho: [``Accept-Language``](http://www.w3.org/International/questions/qa-lang-priorities.en.php),
  * O usuário pode trocar o idioma visitando os links (view function: ``set_locale``), a escolha do idioma fica salvo na sessão.
* instalar as dependências e configurações necessárias para ter a funcionalidade de i18n.
   * Para isso foi utilzado ``Flask-Babelex``, um fork do ``Flask-Babel`` sugerido pela documentação oficial do  [``Flask-Admin``](https://flask-admin.readthedocs.org/en/latest/advanced/#localization-with-flask-babelex)

#### Por onde deve começar a revisão?

Os textos traduzíveis são:
1 - o admin, com exceção  do cabeçalho das listagens, e a página com o detalhe de cada registro (ver comentários) .
2 - alguns textos do página inicial (template: ``templates/collection/index.html``)
3 - as traduções ficam salvas em: ``/app/translations/es/LC_MESSAGES`` (espanhol) e ``/app/translations/en/LC_MESSAGES`` (inglês)

#### Como deveria ser testado manualmente?

1. compilar os arquivos ``.po`` para gerar os ``.mo`` com o comando: ``make compile_messages`` no terminal. 
2. definir um idioma padrão no navegador que será enviado na primeira requisição ao site no cabeçalho ``Accept-Language``
3. trocar de idioma com os link no rodapé do admin. o admin e o site público deve atualizar os texto para o idioma selecionado.

#### Tickets relacionados?

FIXES: #12 

#### Comentários:
- Alguns textos forma ajustados, sobre todo nos ``flash`` das view functions, e ``actions`` do admin.
- Falta colocar os tags para tradução nos templates do site (público).
- No admin ainda não ficou traduzível: 1) os cabeçalhos nas listagens do admin, e 2) as páginas que mostram cada objeto (detail), possivelmente seja necessário criar templates personalizados para as listagens e detalhes, acrescentando a tag de tradução, ou definir o atributo [``column_labels``](https://flask-admin.readthedocs.org/en/latest/api/mod_model/#flask_admin.model.BaseModelView.column_labels) com valores retornados pela função ``gettext('string')``.
- Foi adicionado um make file para facilitar as tarefas de coleta, atualização e compilação de textos traduzíveis. 
  - ``make make_messages`` faz scan para extrair os textos traduzíveis e atualiza o arquivo: ``/app/translations/messages.pot``
  - ``LANG=en make create_catalog`` quando for adicionado um novo idioma a ser traduzido, indicar o código do idioma com a variável LANG, e logo ``make create_catalog`` vai criar os diretórios com os arquivos .po necessários. O novo idioma também deve ser adicionado na variável ``LANGUAGES``definida em ``config/default.py``
   - quando os textos a serem traduzido mudarem (ou apareçam novos) no lugar de criar todos os catálogos para cada idioma, podemos executar: ``make update_catalog`` no terminal.
   - editar os arquivos ``.po`` contidos em ``/app/translations/XX/LC_MESSAGES`` (aonde XX representa o código do idioma, por exemplo: 'pt_BR', ou 'es' ou 'en'). Para editar os arquivos pode ser utilizado transifex ou o app [PoEdit](http://poedit.net/download).
  - finalmente temos que compilas as mensagens para que fique disponível para o site, para isso executamos: ``make compile_messages``

- no futuro podemos atualizar o make file com novas funções, por exemplo para o setup, ver por exemplo [xen/flask-project-template](https://github.com/xen/flask-project-template/blob/master/Makefile)
