### PR TITLE
#14 - Definições para implementação dos testes unitários

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: python
+python:
+  - "2.7"
+script:
+  - make test

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,8 @@
 
+#########
+## i18n #
+#########
+
 # Faz um scan em toda a app buscando strings traduzíveis e o resultado fica em app/translations/messages.pot
 make_messages:
 	pybabel extract -F config/babel.cfg -k lazy_gettext -o app/translations/messages.pot .
@@ -15,3 +19,10 @@ update_catalog:
 # compila as traduções dos .po em arquivos .mo prontos para serm utilizados.
 compile_messages:
 	pybabel compile -d app/translations
+
+#########
+## test #
+#########
+
+test:
+	OPAC_CONFIG="config.testing" && python manager.py test

--- a/config/testing.py
+++ b/config/testing.py
@@ -1,0 +1,31 @@
+# coding: utf-8
+
+"""
+    Configuração para o ambiente de testing
+"""
+
+TESTING = True
+DEBUG = True
+ASSETS_DEBUG = DEBUG
+
+# SQL Alchemy
+DATABASE_FILE = 'TESTING_opac_admin.sqlite'
+DATABASE_DIR = '/tmp'  # Absoulte path
+DATABASE_PATH = '%s/%s' % (DATABASE_DIR, DATABASE_FILE)
+SQLALCHEMY_DATABASE_URI = 'sqlite:////%s' % DATABASE_PATH
+SQLALCHEMY_ECHO = False
+SQLALCHEMY_TRACK_MODIFICATIONS = False
+
+
+# envio de emails
+MAIL_SERVER = 'localhost'
+MAIL_PORT = 1025
+MAIL_USE_TLS = False
+MAIL_USE_SSL = False
+MAIL_DEBUG = DEBUG
+MAIL_USERNAME = None
+MAIL_PASSWORD = None
+MAIL_DEFAULT_SENDER = 'webmaster.test@opac.scielo.org'
+MAIL_MAX_EMAILS = None
+# MAIL_SUPPRESS_SEND = default app.testing
+MAIL_ASCII_ATTACHMENTS = False

--- a/manager.py
+++ b/manager.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # coding: utf-8
 import os
+import unittest
 from app import create_app, dbsql, dbmongo, mail
 from opac_schema.v1.models import Journal, Issue, Article
 from app import utils, controllers
@@ -84,6 +85,17 @@ def create_superuser():
     # cria usuario
     utils.create_user(user_email, user_password, email_confirmed)
     print u'Novo usuário criado com sucesso!'
+
+
+@manager.command
+@manager.option('-v', '--verbosity', dest='verbosity', default=2)
+def test(verbosity=2):
+    """ Executa tests unitarios.
+    Lembre de definir a variável: OPAC_CONFIG="config.testing" antes de executar este comando:
+    > OPAC_CONFIG="config.testing" && python manager.py test
+    """
+    tests = unittest.TestLoader().discover('tests')
+    unittest.TextTestRunner(verbosity=verbosity).run(tests)
 
 if __name__ == '__main__':
     manager.run()

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ Flask-Script==2.0.5
 Flask-Mail==0.9.1
 lxml==3.5.0
 Flask-BabelEx==0.9.2
+Flask-Testing==0.4.2

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,0 +1,23 @@
+from flask.ext.testing import TestCase
+from flask import current_app
+from app import dbsql
+
+
+class BasicsTestCase(TestCase):
+    def setUp(self):
+        # criamos o banco de dados relacional
+        dbsql.create_all()
+
+    def create_app(self):
+        return current_app
+
+    def tearDown(self):
+        # apagamos o banco de dados relacional
+        dbsql.session.remove()
+        dbsql.drop_all()
+
+    def test_app_exists(self):
+        self.assertFalse(current_app is None)
+
+    def test_app_is_testing(self):
+        self.assertTrue(current_app.config['TESTING'])

--- a/tests/test_main_views.py
+++ b/tests/test_main_views.py
@@ -1,0 +1,21 @@
+from flask.ext.testing import TestCase
+from flask import current_app, url_for
+from app import create_app, dbsql
+
+
+class FlaskClientTestCase(TestCase):
+    def setUp(self):
+        dbsql.create_all()
+
+    def create_app(self):
+        return current_app
+
+    def tearDown(self):
+        dbsql.session.remove()
+        dbsql.drop_all()
+
+    def test_home_page(self):
+        response = self.client.get(url_for('main.index'))
+        self.assertEqual(200, response.status_code)
+        self.assertEqual('text/html; charset=utf-8', response.content_type)
+        self.assert_template_used("collection/index.html")


### PR DESCRIPTION
#### Objetivo do PR:

Setup e instalação para poder trabalhar com tests unitários.

#### Por onde deve começar a revisão manual:
- makefile tem um comando para executar os tests: ``make  test``
- tests simples foram criados na pasta ``/opac/tests/``

#### Extra:
Também foi adicionado um arquivo: ``.travis.yml`` para integração com travis-ci