### PR TITLE
Add column_labels to ModelView’s

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 
 # Faz um scan em toda a app buscando strings traduzíveis e o resultado fica em app/translations/messages.pot
 make_messages:
-	pybabel extract -F config/babel.cfg -k lazy_gettext -o app/translations/messages.pot .
+	pybabel extract -F config/babel.cfg -k lazy_gettext -k __ -o app/translations/messages.pot .
 
 # cria o catalogo para o idioma definido pela variável LANG, a partir das strings: app/translations/messages.pot
 # executar: $ LANG=en make create_catalog

--- a/app/admin/views.py
+++ b/app/admin/views.py
@@ -223,10 +223,10 @@ class JournalAdminView(OpacBaseAdminView):
     )
     column_labels = dict(
         jid=__(u'Id Periódico'),
-        collections=__(u'Colecções'),
+        collections=__(u'Coleções'),
         timeline=__(u'Linha do tempo'),
-        national_code=__(u'Código nacional'),
-        subject_categories=__(u'Categorias de assunto '),
+        national_code=__(u'Código IBICT - CCN'),
+        subject_categories=__(u'Categorias de assunto'),
         study_areas=__(u'Áreas de estudo'),
         social_networks=__(u'Redes sociais'),
         title=__(u'Título'),
@@ -253,14 +253,14 @@ class JournalAdminView(OpacBaseAdminView):
         publisher_country=__(u'País da editora'),
         publisher_state=__(u'Estado da editora'),
         publisher_city=__(u'Cidade da editora'),
-        publisher_address=__(u'Direção da editora'),
+        publisher_address=__(u'Endereço da editora'),
         publisher_telephone=__(u'Telefone da editora'),
         mission=__(u'Missão'),
         index_at=__(u'No índice'),
         sponsors=__(u'Patrocinadores'),
         previous_journal_ref=__(u'Ref periódico anterior'),
         current_status=__(u'Situação atual'),
-        issue_count=__(u'Número do fascículos'),
+        issue_count=__(u'Total de números'),
         is_public=__(u'Publicado?')
     )
 
@@ -307,7 +307,7 @@ class IssueAdminView(OpacBaseAdminView):
         updated=lambda v, c, m, p: m.created.strftime('%Y-%m-%d %H:%M:%S'),
     )
     column_labels = dict(
-        iid=__(u'Id Fascículo'),
+        iid=__(u'Id Número'),
         journal=__(u'Periódico'),
         sections=__(u'Seções'),
         cover_url=__(u'Url do capa'),
@@ -323,7 +323,7 @@ class IssueAdminView(OpacBaseAdminView):
         year=__(u'Ano'),
         label=__(u'Etiqueta'),
         order=__(u'Ordem'),
-        bibliographic_legend=__(u'Lenda bibliográfica'),
+        bibliographic_legend=__(u'Legenda bibliográfica'),
         is_public=__(u'Publicado?')
     )
 
@@ -372,11 +372,11 @@ class ArticleAdminView(OpacBaseAdminView):
     )
     column_labels = dict(
         aid=__(u'Id Artigo'),
-        issue=__(u'Fascículo'),
+        issue=__(u'Número'),
         journal=__(u'Periódico'),
         title=__(u'Título'),
         section=__(u'Seção'),
-        is_aop=__(u'É AOP'),
+        is_aop=__(u'É AOP?'),
         created=__(u'Criado'),
         updated=__(u'Atualizado'),
         htmls=__(u'HTML\'s'),

--- a/app/admin/views.py
+++ b/app/admin/views.py
@@ -221,6 +221,48 @@ class JournalAdminView(OpacBaseAdminView):
         updated=lambda v, c, m, p: m.created.strftime('%Y-%m-%d %H:%M:%S'),
         scielo_issn=lambda v, c, m, p: '%s\n%s' % (m.print_issn or '', m.eletronic_issn or ''),
     )
+    column_labels = dict(
+        jid=__(u'Id Periódico'),
+        collections=__(u'Colecções'),
+        timeline=__(u'Linha do tempo'),
+        national_code=__(u'Código nacional'),
+        subject_categories=__(u'Categorias de assunto '),
+        study_areas=__(u'Áreas de estudo'),
+        social_networks=__(u'Redes sociais'),
+        title=__(u'Título'),
+        title_iso=__(u'Título ISO'),
+        short_title=__(u'Título curto'),
+        created=__(u'Criado'),
+        updated=__(u'Atualizado'),
+        acronym=__(u'Acrônimo'),
+        scielo_issn=__(u'ISSN SciELO'),
+        print_issn=__(u'ISSN impresso'),
+        eletronic_issn=__(u'ISSN eletrônico'),
+        subject_descriptors=__(u'Descritores de assunto'),
+        init_year=__(u'Ano inicial'),
+        init_vol=__(u'Volume inicial'),
+        init_num=__(u'Número inicial'),
+        final_year=__(u'Ano final'),
+        final_vol=__(u'Volume final'),
+        final_num=__(u'Número final'),
+        online_submission_url=__(u'Url da submissão online'),
+        cover_url=__(u'Url do capa'),
+        logo_url=__(u'Url do logotipo'),
+        other_titles=__(u'Outros títulos'),
+        publisher_name=__(u'Nome da editora'),
+        publisher_country=__(u'País da editora'),
+        publisher_state=__(u'Estado da editora'),
+        publisher_city=__(u'Cidade da editora'),
+        publisher_address=__(u'Direção da editora'),
+        publisher_telephone=__(u'Telefone da editora'),
+        mission=__(u'Missão'),
+        index_at=__(u'No índice'),
+        sponsors=__(u'Patrocinadores'),
+        previous_journal_ref=__(u'Ref periódico anterior'),
+        current_status=__(u'Situação atual'),
+        issue_count=__(u'Número do fascículos'),
+        is_public=__(u'Publicado?')
+    )
 
     @action('publish', _(u'Publicar'), ACTION_PUBLISH_CONFIRMATION_MSG)
     def publish(self, ids):
@@ -263,6 +305,26 @@ class IssueAdminView(OpacBaseAdminView):
     column_formatters = dict(
         created=lambda v, c, m, p: m.created.strftime('%Y-%m-%d %H:%M:%S'),
         updated=lambda v, c, m, p: m.created.strftime('%Y-%m-%d %H:%M:%S'),
+    )
+    column_labels = dict(
+        iid=__(u'Id Fascículo'),
+        journal=__(u'Periódico'),
+        sections=__(u'Seções'),
+        cover_url=__(u'Url do capa'),
+        volume=__(u'Volume'),
+        number=__(u'Número'),
+        created=__(u'Criado'),
+        updated=__(u'Atualizado'),
+        type=__(u'Tipo'),
+        suppl_text=__(u'Texto do suplemento'),
+        spe_text=__(u'Texto do especial'),
+        start_month=__(u'Mês inicial'),
+        end_month=__(u'Mês final'),
+        year=__(u'Ano'),
+        label=__(u'Etiqueta'),
+        order=__(u'Ordem'),
+        bibliographic_legend=__(u'Lenda bibliográfica'),
+        is_public=__(u'Publicado?')
     )
 
     @action('publish', _(u'Publicar'), ACTION_PUBLISH_CONFIRMATION_MSG)
@@ -307,6 +369,19 @@ class ArticleAdminView(OpacBaseAdminView):
     column_formatters = dict(
         created=lambda v, c, m, p: m.created.strftime('%Y-%m-%d %H:%M:%S'),
         updated=lambda v, c, m, p: m.created.strftime('%Y-%m-%d %H:%M:%S'),
+    )
+    column_labels = dict(
+        aid=__(u'Id Artigo'),
+        issue=__(u'Fascículo'),
+        journal=__(u'Periódico'),
+        title=__(u'Título'),
+        section=__(u'Seção'),
+        is_aop=__(u'É AOP'),
+        created=__(u'Criado'),
+        updated=__(u'Atualizado'),
+        htmls=__(u'HTML\'s'),
+        domain_key=__(u'Chave de domínio'),
+        is_public=__(u'Publicado?')
     )
 
     @action('rebuild_html', _(u'Reconstruir HTML'), ACTION_REBUILD_CONFIRMATION_MSG)

--- a/app/translations/en/LC_MESSAGES/messages.po
+++ b/app/translations/en/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: OPAC 1.0\n"
 "Report-Msgid-Bugs-To: tecnologia@scielo.org\n"
-"POT-Creation-Date: 2016-01-18 12:18-0600\n"
+"POT-Creation-Date: 2016-01-19 10:01-0600\n"
 "PO-Revision-Date: 2016-01-07 14:56-0200\n"
 "Last-Translator: scielo <tecnologia@scielo.org>\n"
 "Language: en\n"
@@ -18,11 +18,12 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.2.0\n"
 
-#: app/__init__.py:89 app/templates/journal/includes/alternative_header.html:47
+#: app/__init__.py:89 app/admin/views.py:311 app/admin/views.py:376
+#: app/templates/journal/includes/alternative_header.html:47
 msgid "Periódico"
 msgstr "Journal"
 
-#: app/__init__.py:90
+#: app/__init__.py:90 app/admin/views.py:375
 msgid "Fascículo"
 msgstr "Issue"
 
@@ -117,67 +118,307 @@ msgstr "%(count)s users were successfully notified!"
 msgid "Ocorreu um erro no envio do emails de confirmação. Erro: %(ex)s"
 msgstr "An error occurred while sending the confirmation emails. Error: %(ex)s"
 
-#: app/admin/views.py:225 app/admin/views.py:268 app/admin/views.py:328
+#: app/admin/views.py:225
+msgid "Id Periódico"
+msgstr "Journal Id"
+
+#: app/admin/views.py:226
+msgid "Colecções"
+msgstr ""
+
+#: app/admin/views.py:227
+msgid "Linha do tempo"
+msgstr ""
+
+#: app/admin/views.py:228
+msgid "Código nacional"
+msgstr ""
+
+#: app/admin/views.py:229
+msgid "Categorias de assunto "
+msgstr ""
+
+#: app/admin/views.py:230
+msgid "Áreas de estudo"
+msgstr ""
+
+#: app/admin/views.py:231
+#, fuzzy
+msgid "Redes sociais"
+msgstr "Other social networks"
+
+#: app/admin/views.py:232 app/admin/views.py:377
+#: app/templates/collection/list_alpha.html:46
+#: app/templates/collection/list_theme.html:54
+#: app/templates/collection/list_theme.html:111
+msgid "Título"
+msgstr ""
+
+#: app/admin/views.py:233
+msgid "Título ISO"
+msgstr ""
+
+#: app/admin/views.py:234
+msgid "Título curto"
+msgstr ""
+
+#: app/admin/views.py:235 app/admin/views.py:316 app/admin/views.py:380
+msgid "Criado"
+msgstr ""
+
+#: app/admin/views.py:236 app/admin/views.py:317 app/admin/views.py:381
+#, fuzzy
+msgid "Atualizado"
+msgstr "Total"
+
+#: app/admin/views.py:237
+msgid "Acrônimo"
+msgstr ""
+
+#: app/admin/views.py:238
+msgid "ISSN SciELO"
+msgstr ""
+
+#: app/admin/views.py:239
+msgid "ISSN impresso"
+msgstr ""
+
+#: app/admin/views.py:240
+msgid "ISSN eletrônico"
+msgstr ""
+
+#: app/admin/views.py:241
+msgid "Descritores de assunto"
+msgstr ""
+
+#: app/admin/views.py:242
+msgid "Ano inicial"
+msgstr ""
+
+#: app/admin/views.py:243
+msgid "Volume inicial"
+msgstr ""
+
+#: app/admin/views.py:244
+msgid "Número inicial"
+msgstr ""
+
+#: app/admin/views.py:245
+msgid "Ano final"
+msgstr ""
+
+#: app/admin/views.py:246
+msgid "Volume final"
+msgstr ""
+
+#: app/admin/views.py:247
+msgid "Número final"
+msgstr ""
+
+#: app/admin/views.py:248
+msgid "Url da submissão online"
+msgstr ""
+
+#: app/admin/views.py:249 app/admin/views.py:313
+msgid "Url do capa"
+msgstr ""
+
+#: app/admin/views.py:250
+msgid "Url do logotipo"
+msgstr ""
+
+#: app/admin/views.py:251
+msgid "Outros títulos"
+msgstr ""
+
+#: app/admin/views.py:252
+msgid "Nome da editora"
+msgstr ""
+
+#: app/admin/views.py:253
+msgid "País da editora"
+msgstr ""
+
+#: app/admin/views.py:254
+msgid "Estado da editora"
+msgstr ""
+
+#: app/admin/views.py:255
+msgid "Cidade da editora"
+msgstr ""
+
+#: app/admin/views.py:256
+msgid "Direção da editora"
+msgstr ""
+
+#: app/admin/views.py:257
+msgid "Telefone da editora"
+msgstr ""
+
+#: app/admin/views.py:258
+msgid "Missão"
+msgstr ""
+
+#: app/admin/views.py:259
+msgid "No índice"
+msgstr ""
+
+#: app/admin/views.py:260
+msgid "Patrocinadores"
+msgstr ""
+
+#: app/admin/views.py:261
+#, fuzzy
+msgid "Ref periódico anterior"
+msgstr "Journal"
+
+#: app/admin/views.py:262
+msgid "Situação atual"
+msgstr ""
+
+#: app/admin/views.py:263
+msgid "Número do fascículos"
+msgstr ""
+
+#: app/admin/views.py:264 app/admin/views.py:327 app/admin/views.py:384
+msgid "Publicado?"
+msgstr "Published?"
+
+#: app/admin/views.py:267 app/admin/views.py:330 app/admin/views.py:403
 msgid "Publicar"
 msgstr "Publish"
 
-#: app/admin/views.py:230
+#: app/admin/views.py:272
 msgid "Periódico(s) publicado(s) com sucesso!!"
 msgstr "Journal(s) successfully published!!"
 
-#: app/admin/views.py:232
+#: app/admin/views.py:274
 msgid "Ocorreu um erro tentando publicar o(s) periódico(s)!!"
 msgstr "An error occurred trying to publish the journal(s)!!"
 
-#: app/admin/views.py:236 app/admin/views.py:281
+#: app/admin/views.py:278 app/admin/views.py:343
 msgid "Despublicar"
 msgstr "Unpublish"
 
-#: app/admin/views.py:241
+#: app/admin/views.py:283
 msgid "Periódico(s) despublicado com sucesso!!"
 msgstr "Journal(s) successfully unpublished!!"
 
-#: app/admin/views.py:244
+#: app/admin/views.py:286
 #, python-format
 msgid "Ocorreu um erro tentando publicar o(s) periódico(s)!!. Erro: %(ex)s"
 msgstr "An error occurred trying to publish the journal(s)!! Error %(ex)s"
 
-#: app/admin/views.py:273
+#: app/admin/views.py:310
+msgid "Id Fascículo"
+msgstr "Issue Id"
+
+#: app/admin/views.py:312
+msgid "Seções"
+msgstr ""
+
+#: app/admin/views.py:314 app/templates/includes/format_journal_row.html:14
+#: app/templates/issue/grid.html:36
+msgid "Volume"
+msgstr ""
+
+#: app/admin/views.py:315 app/templates/issue/grid.html:37
+msgid "Número"
+msgstr ""
+
+#: app/admin/views.py:318
+#, fuzzy
+msgid "Tipo"
+msgstr "Article"
+
+#: app/admin/views.py:319
+msgid "Texto do suplemento"
+msgstr ""
+
+#: app/admin/views.py:320
+msgid "Texto do especial"
+msgstr ""
+
+#: app/admin/views.py:321
+msgid "Mês inicial"
+msgstr ""
+
+#: app/admin/views.py:322
+msgid "Mês final"
+msgstr ""
+
+#: app/admin/views.py:323 app/templates/issue/grid.html:35
+msgid "Ano"
+msgstr ""
+
+#: app/admin/views.py:324
+msgid "Etiqueta"
+msgstr ""
+
+#: app/admin/views.py:325
+msgid "Ordem"
+msgstr ""
+
+#: app/admin/views.py:326
+msgid "Lenda bibliográfica"
+msgstr ""
+
+#: app/admin/views.py:335
 msgid "Fascículo(s) publicado(s) com sucesso!!"
 msgstr "Issue(s) successfully published!!"
 
-#: app/admin/views.py:276 app/admin/views.py:337
+#: app/admin/views.py:338 app/admin/views.py:412
 #, python-format
 msgid "Ocorreu um erro tentando publicar o(s) fascículo(s)!!. Erro: %(ex)s"
 msgstr "An error occurred trying to publish the issue(s)!! Error %(ex)s"
 
-#: app/admin/views.py:286
+#: app/admin/views.py:348
 msgid "Fascículo(s) despublicado(s) com sucesso!!"
 msgstr "Issue(s) successfully unpublished!!"
 
-#: app/admin/views.py:289 app/admin/views.py:350
+#: app/admin/views.py:351 app/admin/views.py:425
 #, python-format
 msgid "Ocorreu um erro tentando despublicar o(s) fascículo(s)!!. Erro: %(ex)s"
 msgstr "An error occurred trying to unpublish the issue(s)!! Error %(ex)s"
 
-#: app/admin/views.py:312
+#: app/admin/views.py:374
+msgid "Id Artigo"
+msgstr "Article Id"
+
+#: app/admin/views.py:378
+msgid "Seção"
+msgstr ""
+
+#: app/admin/views.py:379
+msgid "É AOP"
+msgstr ""
+
+#: app/admin/views.py:382
+msgid "HTML's"
+msgstr ""
+
+#: app/admin/views.py:383
+msgid "Chave de domínio"
+msgstr ""
+
+#: app/admin/views.py:387
 msgid "Reconstruir HTML"
 msgstr "Rebuild HTML"
 
-#: app/admin/views.py:320
+#: app/admin/views.py:395
 msgid "Artigo(s) reconstruido com sucesso!!"
 msgstr "Article(s) successfully rebuilt!!"
 
-#: app/admin/views.py:323
+#: app/admin/views.py:398
 #, python-format
 msgid "Ocorreu um erro tentando reconstruir o(s) artigo(s)!!. Erro: %(ex)s"
 msgstr "An error occurred trying to rebuild the article(s)!! Error %(ex)s"
 
-#: app/admin/views.py:333
+#: app/admin/views.py:408
 msgid "Artigo(s) publicado com sucesso!!"
 msgstr "Article(s) successfully published!!"
 
-#: app/admin/views.py:347
+#: app/admin/views.py:422
 msgid "Artigo(s) despublicado com sucesso!!"
 msgstr "Article(s) successfully unpublished!!"
 
@@ -414,12 +655,6 @@ msgstr "News"
 msgid "Lista alfabética de periódicos"
 msgstr ""
 
-#: app/templates/collection/list_alpha.html:46
-#: app/templates/collection/list_theme.html:54
-#: app/templates/collection/list_theme.html:111
-msgid "Título"
-msgstr ""
-
 #: app/templates/collection/list_alpha.html:49
 #: app/templates/collection/list_institution.html:45
 #: app/templates/collection/list_theme.html:57
@@ -621,25 +856,12 @@ msgstr ""
 msgid "Último"
 msgstr ""
 
-#: app/templates/includes/format_journal_row.html:14
-#: app/templates/issue/grid.html:36
-msgid "Volume"
-msgstr ""
-
 #: app/templates/includes/format_journal_row.html:15
 msgid "Nº"
 msgstr ""
 
 #: app/templates/issue/grid.html:29
 msgid "Todos os números"
-msgstr ""
-
-#: app/templates/issue/grid.html:35
-msgid "Ano"
-msgstr ""
-
-#: app/templates/issue/grid.html:37
-msgid "Número"
 msgstr ""
 
 #: app/templates/issue/grid.html:66
@@ -844,4 +1066,7 @@ msgstr ""
 
 #~ msgid "%(name)s"
 #~ msgstr "%(name)s"
+
+#~ msgid "É Pública"
+#~ msgstr "Unpublish"
 

--- a/app/translations/en/LC_MESSAGES/messages.po
+++ b/app/translations/en/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: OPAC 1.0\n"
 "Report-Msgid-Bugs-To: tecnologia@scielo.org\n"
-"POT-Creation-Date: 2016-01-19 10:01-0600\n"
+"POT-Creation-Date: 2016-01-19 12:15-0600\n"
 "PO-Revision-Date: 2016-01-07 14:56-0200\n"
 "Last-Translator: scielo <tecnologia@scielo.org>\n"
 "Language: en\n"
@@ -23,7 +23,7 @@ msgstr ""
 msgid "Periódico"
 msgstr "Journal"
 
-#: app/__init__.py:90 app/admin/views.py:375
+#: app/__init__.py:90
 msgid "Fascículo"
 msgstr "Issue"
 
@@ -123,7 +123,7 @@ msgid "Id Periódico"
 msgstr "Journal Id"
 
 #: app/admin/views.py:226
-msgid "Colecções"
+msgid "Coleções"
 msgstr ""
 
 #: app/admin/views.py:227
@@ -131,11 +131,11 @@ msgid "Linha do tempo"
 msgstr ""
 
 #: app/admin/views.py:228
-msgid "Código nacional"
+msgid "Código IBICT - CCN"
 msgstr ""
 
 #: app/admin/views.py:229
-msgid "Categorias de assunto "
+msgid "Categorias de assunto"
 msgstr ""
 
 #: app/admin/views.py:230
@@ -248,7 +248,7 @@ msgid "Cidade da editora"
 msgstr ""
 
 #: app/admin/views.py:256
-msgid "Direção da editora"
+msgid "Endereço da editora"
 msgstr ""
 
 #: app/admin/views.py:257
@@ -277,7 +277,7 @@ msgid "Situação atual"
 msgstr ""
 
 #: app/admin/views.py:263
-msgid "Número do fascículos"
+msgid "Total de números"
 msgstr ""
 
 #: app/admin/views.py:264 app/admin/views.py:327 app/admin/views.py:384
@@ -310,7 +310,7 @@ msgid "Ocorreu um erro tentando publicar o(s) periódico(s)!!. Erro: %(ex)s"
 msgstr "An error occurred trying to publish the journal(s)!! Error %(ex)s"
 
 #: app/admin/views.py:310
-msgid "Id Fascículo"
+msgid "Id Número"
 msgstr "Issue Id"
 
 #: app/admin/views.py:312
@@ -322,7 +322,8 @@ msgstr ""
 msgid "Volume"
 msgstr ""
 
-#: app/admin/views.py:315 app/templates/issue/grid.html:37
+#: app/admin/views.py:315 app/admin/views.py:375
+#: app/templates/issue/grid.html:37
 msgid "Número"
 msgstr ""
 
@@ -360,7 +361,7 @@ msgid "Ordem"
 msgstr ""
 
 #: app/admin/views.py:326
-msgid "Lenda bibliográfica"
+msgid "Legenda bibliográfica"
 msgstr ""
 
 #: app/admin/views.py:335
@@ -390,7 +391,7 @@ msgid "Seção"
 msgstr ""
 
 #: app/admin/views.py:379
-msgid "É AOP"
+msgid "É AOP?"
 msgstr ""
 
 #: app/admin/views.py:382
@@ -1069,4 +1070,25 @@ msgstr ""
 
 #~ msgid "É Pública"
 #~ msgstr "Unpublish"
+
+#~ msgid "Colecções"
+#~ msgstr ""
+
+#~ msgid "Código nacional"
+#~ msgstr ""
+
+#~ msgid "Categorias de assunto "
+#~ msgstr ""
+
+#~ msgid "Direção da editora"
+#~ msgstr ""
+
+#~ msgid "Número do fascículos"
+#~ msgstr ""
+
+#~ msgid "Lenda bibliográfica"
+#~ msgstr ""
+
+#~ msgid "É AOP"
+#~ msgstr ""
 

--- a/app/translations/es/LC_MESSAGES/messages.po
+++ b/app/translations/es/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: OPAC 1.0\n"
 "Report-Msgid-Bugs-To: tecnologia@scielo.org\n"
-"POT-Creation-Date: 2016-01-18 12:18-0600\n"
+"POT-Creation-Date: 2016-01-19 10:01-0600\n"
 "PO-Revision-Date: 2016-01-07 14:56-0200\n"
 "Last-Translator: scielo <tecnologia@scielo.org>\n"
 "Language: es\n"
@@ -18,11 +18,12 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.2.0\n"
 
-#: app/__init__.py:89 app/templates/journal/includes/alternative_header.html:47
+#: app/__init__.py:89 app/admin/views.py:311 app/admin/views.py:376
+#: app/templates/journal/includes/alternative_header.html:47
 msgid "Periódico"
 msgstr "Periódico"
 
-#: app/__init__.py:90
+#: app/__init__.py:90 app/admin/views.py:375
 msgid "Fascículo"
 msgstr "Fascícluo"
 
@@ -121,69 +122,309 @@ msgstr "%(count)s usuarios fueron notificados con éxito!"
 msgid "Ocorreu um erro no envio do emails de confirmação. Erro: %(ex)s"
 msgstr "Ocurrió un error en el envío de emails de confirmación. Error: %(ex)s"
 
-#: app/admin/views.py:225 app/admin/views.py:268 app/admin/views.py:328
+#: app/admin/views.py:225
+msgid "Id Periódico"
+msgstr "Id Revista"
+
+#: app/admin/views.py:226
+msgid "Colecções"
+msgstr ""
+
+#: app/admin/views.py:227
+msgid "Linha do tempo"
+msgstr ""
+
+#: app/admin/views.py:228
+msgid "Código nacional"
+msgstr ""
+
+#: app/admin/views.py:229
+msgid "Categorias de assunto "
+msgstr ""
+
+#: app/admin/views.py:230
+msgid "Áreas de estudo"
+msgstr ""
+
+#: app/admin/views.py:231
+#, fuzzy
+msgid "Redes sociais"
+msgstr "Otras redes sociales"
+
+#: app/admin/views.py:232 app/admin/views.py:377
+#: app/templates/collection/list_alpha.html:46
+#: app/templates/collection/list_theme.html:54
+#: app/templates/collection/list_theme.html:111
+msgid "Título"
+msgstr ""
+
+#: app/admin/views.py:233
+msgid "Título ISO"
+msgstr ""
+
+#: app/admin/views.py:234
+msgid "Título curto"
+msgstr ""
+
+#: app/admin/views.py:235 app/admin/views.py:316 app/admin/views.py:380
+msgid "Criado"
+msgstr ""
+
+#: app/admin/views.py:236 app/admin/views.py:317 app/admin/views.py:381
+#, fuzzy
+msgid "Atualizado"
+msgstr "Total"
+
+#: app/admin/views.py:237
+msgid "Acrônimo"
+msgstr ""
+
+#: app/admin/views.py:238
+msgid "ISSN SciELO"
+msgstr ""
+
+#: app/admin/views.py:239
+msgid "ISSN impresso"
+msgstr ""
+
+#: app/admin/views.py:240
+msgid "ISSN eletrônico"
+msgstr ""
+
+#: app/admin/views.py:241
+msgid "Descritores de assunto"
+msgstr ""
+
+#: app/admin/views.py:242
+msgid "Ano inicial"
+msgstr ""
+
+#: app/admin/views.py:243
+msgid "Volume inicial"
+msgstr ""
+
+#: app/admin/views.py:244
+msgid "Número inicial"
+msgstr ""
+
+#: app/admin/views.py:245
+msgid "Ano final"
+msgstr ""
+
+#: app/admin/views.py:246
+msgid "Volume final"
+msgstr ""
+
+#: app/admin/views.py:247
+msgid "Número final"
+msgstr ""
+
+#: app/admin/views.py:248
+msgid "Url da submissão online"
+msgstr ""
+
+#: app/admin/views.py:249 app/admin/views.py:313
+msgid "Url do capa"
+msgstr ""
+
+#: app/admin/views.py:250
+msgid "Url do logotipo"
+msgstr ""
+
+#: app/admin/views.py:251
+msgid "Outros títulos"
+msgstr ""
+
+#: app/admin/views.py:252
+msgid "Nome da editora"
+msgstr ""
+
+#: app/admin/views.py:253
+msgid "País da editora"
+msgstr ""
+
+#: app/admin/views.py:254
+msgid "Estado da editora"
+msgstr ""
+
+#: app/admin/views.py:255
+msgid "Cidade da editora"
+msgstr ""
+
+#: app/admin/views.py:256
+msgid "Direção da editora"
+msgstr ""
+
+#: app/admin/views.py:257
+msgid "Telefone da editora"
+msgstr ""
+
+#: app/admin/views.py:258
+msgid "Missão"
+msgstr ""
+
+#: app/admin/views.py:259
+msgid "No índice"
+msgstr ""
+
+#: app/admin/views.py:260
+msgid "Patrocinadores"
+msgstr ""
+
+#: app/admin/views.py:261
+#, fuzzy
+msgid "Ref periódico anterior"
+msgstr "Periódico"
+
+#: app/admin/views.py:262
+msgid "Situação atual"
+msgstr ""
+
+#: app/admin/views.py:263
+msgid "Número do fascículos"
+msgstr ""
+
+#: app/admin/views.py:264 app/admin/views.py:327 app/admin/views.py:384
+msgid "Publicado?"
+msgstr "Publicado?"
+
+#: app/admin/views.py:267 app/admin/views.py:330 app/admin/views.py:403
 msgid "Publicar"
 msgstr "Publicar"
 
-#: app/admin/views.py:230
+#: app/admin/views.py:272
 msgid "Periódico(s) publicado(s) com sucesso!!"
 msgstr "Periódico(s) publicado(s) con éxito!!"
 
-#: app/admin/views.py:232
+#: app/admin/views.py:274
 msgid "Ocorreu um erro tentando publicar o(s) periódico(s)!!"
 msgstr "Ocurrió un error intentando publicar el/los periódico(s)!!"
 
-#: app/admin/views.py:236 app/admin/views.py:281
+#: app/admin/views.py:278 app/admin/views.py:343
 msgid "Despublicar"
 msgstr "Despublicar"
 
-#: app/admin/views.py:241
+#: app/admin/views.py:283
 msgid "Periódico(s) despublicado com sucesso!!"
 msgstr "Periódico(s) despublicado(s) com éxito!!"
 
-#: app/admin/views.py:244
+#: app/admin/views.py:286
 #, python-format
 msgid "Ocorreu um erro tentando publicar o(s) periódico(s)!!. Erro: %(ex)s"
 msgstr "Ocurrió un error intentando publicar el/los periódico(s)!! Erro: %(ex)s"
 
-#: app/admin/views.py:273
+#: app/admin/views.py:310
+msgid "Id Fascículo"
+msgstr "Id Fascícluo"
+
+#: app/admin/views.py:312
+msgid "Seções"
+msgstr ""
+
+#: app/admin/views.py:314 app/templates/includes/format_journal_row.html:14
+#: app/templates/issue/grid.html:36
+msgid "Volume"
+msgstr ""
+
+#: app/admin/views.py:315 app/templates/issue/grid.html:37
+msgid "Número"
+msgstr ""
+
+#: app/admin/views.py:318
+#, fuzzy
+msgid "Tipo"
+msgstr "Artículo"
+
+#: app/admin/views.py:319
+msgid "Texto do suplemento"
+msgstr ""
+
+#: app/admin/views.py:320
+msgid "Texto do especial"
+msgstr ""
+
+#: app/admin/views.py:321
+msgid "Mês inicial"
+msgstr ""
+
+#: app/admin/views.py:322
+msgid "Mês final"
+msgstr ""
+
+#: app/admin/views.py:323 app/templates/issue/grid.html:35
+msgid "Ano"
+msgstr ""
+
+#: app/admin/views.py:324
+msgid "Etiqueta"
+msgstr ""
+
+#: app/admin/views.py:325
+msgid "Ordem"
+msgstr ""
+
+#: app/admin/views.py:326
+msgid "Lenda bibliográfica"
+msgstr ""
+
+#: app/admin/views.py:335
 msgid "Fascículo(s) publicado(s) com sucesso!!"
 msgstr "Fascículo(s) publicado(s) com éxito!!"
 
-#: app/admin/views.py:276 app/admin/views.py:337
+#: app/admin/views.py:338 app/admin/views.py:412
 #, python-format
 msgid "Ocorreu um erro tentando publicar o(s) fascículo(s)!!. Erro: %(ex)s"
 msgstr "Ocurrió un error intentando publicar el/los fascículo(s)!! Error: %(ex)s"
 
-#: app/admin/views.py:286
+#: app/admin/views.py:348
 msgid "Fascículo(s) despublicado(s) com sucesso!!"
 msgstr "Fascículo(s) despublicado(s) com éxito!!"
 
-#: app/admin/views.py:289 app/admin/views.py:350
+#: app/admin/views.py:351 app/admin/views.py:425
 #, python-format
 msgid "Ocorreu um erro tentando despublicar o(s) fascículo(s)!!. Erro: %(ex)s"
 msgstr ""
 "Ocurrió un error intentando despublicar el/los fascículo(s)!! Error: "
 "%(ex)s"
 
-#: app/admin/views.py:312
+#: app/admin/views.py:374
+msgid "Id Artigo"
+msgstr "Id Artículo"
+
+#: app/admin/views.py:378
+msgid "Seção"
+msgstr ""
+
+#: app/admin/views.py:379
+msgid "É AOP"
+msgstr ""
+
+#: app/admin/views.py:382
+msgid "HTML's"
+msgstr ""
+
+#: app/admin/views.py:383
+msgid "Chave de domínio"
+msgstr ""
+
+#: app/admin/views.py:387
 msgid "Reconstruir HTML"
 msgstr "Reconstruir HTML"
 
-#: app/admin/views.py:320
+#: app/admin/views.py:395
 msgid "Artigo(s) reconstruido com sucesso!!"
 msgstr "Artículo recontruido con éxito!!"
 
-#: app/admin/views.py:323
+#: app/admin/views.py:398
 #, python-format
 msgid "Ocorreu um erro tentando reconstruir o(s) artigo(s)!!. Erro: %(ex)s"
 msgstr "Ocurrió un error intentando reconstruir el/los artículo(s). Error: %(ex)s"
 
-#: app/admin/views.py:333
+#: app/admin/views.py:408
 msgid "Artigo(s) publicado com sucesso!!"
 msgstr "Artículo(s) publicado con éxito!!"
 
-#: app/admin/views.py:347
+#: app/admin/views.py:422
 msgid "Artigo(s) despublicado com sucesso!!"
 msgstr "Artículo(s) despublicado con éxito!!"
 
@@ -420,12 +661,6 @@ msgstr "Noticias"
 msgid "Lista alfabética de periódicos"
 msgstr ""
 
-#: app/templates/collection/list_alpha.html:46
-#: app/templates/collection/list_theme.html:54
-#: app/templates/collection/list_theme.html:111
-msgid "Título"
-msgstr ""
-
 #: app/templates/collection/list_alpha.html:49
 #: app/templates/collection/list_institution.html:45
 #: app/templates/collection/list_theme.html:57
@@ -627,25 +862,12 @@ msgstr ""
 msgid "Último"
 msgstr ""
 
-#: app/templates/includes/format_journal_row.html:14
-#: app/templates/issue/grid.html:36
-msgid "Volume"
-msgstr ""
-
 #: app/templates/includes/format_journal_row.html:15
 msgid "Nº"
 msgstr ""
 
 #: app/templates/issue/grid.html:29
 msgid "Todos os números"
-msgstr ""
-
-#: app/templates/issue/grid.html:35
-msgid "Ano"
-msgstr ""
-
-#: app/templates/issue/grid.html:37
-msgid "Número"
 msgstr ""
 
 #: app/templates/issue/grid.html:66
@@ -850,4 +1072,7 @@ msgstr ""
 
 #~ msgid "%(name)s"
 #~ msgstr "%(name)s"
+
+#~ msgid "É Pública"
+#~ msgstr "Despublicar"
 

--- a/app/translations/es/LC_MESSAGES/messages.po
+++ b/app/translations/es/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: OPAC 1.0\n"
 "Report-Msgid-Bugs-To: tecnologia@scielo.org\n"
-"POT-Creation-Date: 2016-01-19 10:01-0600\n"
+"POT-Creation-Date: 2016-01-19 12:15-0600\n"
 "PO-Revision-Date: 2016-01-07 14:56-0200\n"
 "Last-Translator: scielo <tecnologia@scielo.org>\n"
 "Language: es\n"
@@ -23,7 +23,7 @@ msgstr ""
 msgid "Periódico"
 msgstr "Periódico"
 
-#: app/__init__.py:90 app/admin/views.py:375
+#: app/__init__.py:90
 msgid "Fascículo"
 msgstr "Fascícluo"
 
@@ -127,7 +127,7 @@ msgid "Id Periódico"
 msgstr "Id Revista"
 
 #: app/admin/views.py:226
-msgid "Colecções"
+msgid "Coleções"
 msgstr ""
 
 #: app/admin/views.py:227
@@ -135,11 +135,11 @@ msgid "Linha do tempo"
 msgstr ""
 
 #: app/admin/views.py:228
-msgid "Código nacional"
+msgid "Código IBICT - CCN"
 msgstr ""
 
 #: app/admin/views.py:229
-msgid "Categorias de assunto "
+msgid "Categorias de assunto"
 msgstr ""
 
 #: app/admin/views.py:230
@@ -252,7 +252,7 @@ msgid "Cidade da editora"
 msgstr ""
 
 #: app/admin/views.py:256
-msgid "Direção da editora"
+msgid "Endereço da editora"
 msgstr ""
 
 #: app/admin/views.py:257
@@ -281,7 +281,7 @@ msgid "Situação atual"
 msgstr ""
 
 #: app/admin/views.py:263
-msgid "Número do fascículos"
+msgid "Total de números"
 msgstr ""
 
 #: app/admin/views.py:264 app/admin/views.py:327 app/admin/views.py:384
@@ -314,8 +314,8 @@ msgid "Ocorreu um erro tentando publicar o(s) periódico(s)!!. Erro: %(ex)s"
 msgstr "Ocurrió un error intentando publicar el/los periódico(s)!! Erro: %(ex)s"
 
 #: app/admin/views.py:310
-msgid "Id Fascículo"
-msgstr "Id Fascícluo"
+msgid "Id Número"
+msgstr "Id Fascículo"
 
 #: app/admin/views.py:312
 msgid "Seções"
@@ -326,7 +326,8 @@ msgstr ""
 msgid "Volume"
 msgstr ""
 
-#: app/admin/views.py:315 app/templates/issue/grid.html:37
+#: app/admin/views.py:315 app/admin/views.py:375
+#: app/templates/issue/grid.html:37
 msgid "Número"
 msgstr ""
 
@@ -364,7 +365,7 @@ msgid "Ordem"
 msgstr ""
 
 #: app/admin/views.py:326
-msgid "Lenda bibliográfica"
+msgid "Legenda bibliográfica"
 msgstr ""
 
 #: app/admin/views.py:335
@@ -396,7 +397,7 @@ msgid "Seção"
 msgstr ""
 
 #: app/admin/views.py:379
-msgid "É AOP"
+msgid "É AOP?"
 msgstr ""
 
 #: app/admin/views.py:382
@@ -1075,4 +1076,25 @@ msgstr ""
 
 #~ msgid "É Pública"
 #~ msgstr "Despublicar"
+
+#~ msgid "Colecções"
+#~ msgstr ""
+
+#~ msgid "Código nacional"
+#~ msgstr ""
+
+#~ msgid "Categorias de assunto "
+#~ msgstr ""
+
+#~ msgid "Direção da editora"
+#~ msgstr ""
+
+#~ msgid "Número do fascículos"
+#~ msgstr ""
+
+#~ msgid "Lenda bibliográfica"
+#~ msgstr ""
+
+#~ msgid "É AOP"
+#~ msgstr ""
 

--- a/app/translations/messages.pot
+++ b/app/translations/messages.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-01-18 12:18-0600\n"
+"POT-Creation-Date: 2016-01-19 10:01-0600\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,11 +17,12 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.2.0\n"
 
-#: app/__init__.py:89 app/templates/journal/includes/alternative_header.html:47
+#: app/__init__.py:89 app/admin/views.py:311 app/admin/views.py:376
+#: app/templates/journal/includes/alternative_header.html:47
 msgid "Periódico"
 msgstr ""
 
-#: app/__init__.py:90
+#: app/__init__.py:90 app/admin/views.py:375
 msgid "Fascículo"
 msgstr ""
 
@@ -116,67 +117,303 @@ msgstr ""
 msgid "Ocorreu um erro no envio do emails de confirmação. Erro: %(ex)s"
 msgstr ""
 
-#: app/admin/views.py:225 app/admin/views.py:268 app/admin/views.py:328
-msgid "Publicar"
+#: app/admin/views.py:225
+msgid "Id Periódico"
+msgstr ""
+
+#: app/admin/views.py:226
+msgid "Colecções"
+msgstr ""
+
+#: app/admin/views.py:227
+msgid "Linha do tempo"
+msgstr ""
+
+#: app/admin/views.py:228
+msgid "Código nacional"
+msgstr ""
+
+#: app/admin/views.py:229
+msgid "Categorias de assunto "
 msgstr ""
 
 #: app/admin/views.py:230
-msgid "Periódico(s) publicado(s) com sucesso!!"
+msgid "Áreas de estudo"
 msgstr ""
 
-#: app/admin/views.py:232
-msgid "Ocorreu um erro tentando publicar o(s) periódico(s)!!"
+#: app/admin/views.py:231
+msgid "Redes sociais"
 msgstr ""
 
-#: app/admin/views.py:236 app/admin/views.py:281
-msgid "Despublicar"
+#: app/admin/views.py:232 app/admin/views.py:377
+#: app/templates/collection/list_alpha.html:46
+#: app/templates/collection/list_theme.html:54
+#: app/templates/collection/list_theme.html:111
+msgid "Título"
+msgstr ""
+
+#: app/admin/views.py:233
+msgid "Título ISO"
+msgstr ""
+
+#: app/admin/views.py:234
+msgid "Título curto"
+msgstr ""
+
+#: app/admin/views.py:235 app/admin/views.py:316 app/admin/views.py:380
+msgid "Criado"
+msgstr ""
+
+#: app/admin/views.py:236 app/admin/views.py:317 app/admin/views.py:381
+msgid "Atualizado"
+msgstr ""
+
+#: app/admin/views.py:237
+msgid "Acrônimo"
+msgstr ""
+
+#: app/admin/views.py:238
+msgid "ISSN SciELO"
+msgstr ""
+
+#: app/admin/views.py:239
+msgid "ISSN impresso"
+msgstr ""
+
+#: app/admin/views.py:240
+msgid "ISSN eletrônico"
 msgstr ""
 
 #: app/admin/views.py:241
-msgid "Periódico(s) despublicado com sucesso!!"
+msgid "Descritores de assunto"
+msgstr ""
+
+#: app/admin/views.py:242
+msgid "Ano inicial"
+msgstr ""
+
+#: app/admin/views.py:243
+msgid "Volume inicial"
 msgstr ""
 
 #: app/admin/views.py:244
+msgid "Número inicial"
+msgstr ""
+
+#: app/admin/views.py:245
+msgid "Ano final"
+msgstr ""
+
+#: app/admin/views.py:246
+msgid "Volume final"
+msgstr ""
+
+#: app/admin/views.py:247
+msgid "Número final"
+msgstr ""
+
+#: app/admin/views.py:248
+msgid "Url da submissão online"
+msgstr ""
+
+#: app/admin/views.py:249 app/admin/views.py:313
+msgid "Url do capa"
+msgstr ""
+
+#: app/admin/views.py:250
+msgid "Url do logotipo"
+msgstr ""
+
+#: app/admin/views.py:251
+msgid "Outros títulos"
+msgstr ""
+
+#: app/admin/views.py:252
+msgid "Nome da editora"
+msgstr ""
+
+#: app/admin/views.py:253
+msgid "País da editora"
+msgstr ""
+
+#: app/admin/views.py:254
+msgid "Estado da editora"
+msgstr ""
+
+#: app/admin/views.py:255
+msgid "Cidade da editora"
+msgstr ""
+
+#: app/admin/views.py:256
+msgid "Direção da editora"
+msgstr ""
+
+#: app/admin/views.py:257
+msgid "Telefone da editora"
+msgstr ""
+
+#: app/admin/views.py:258
+msgid "Missão"
+msgstr ""
+
+#: app/admin/views.py:259
+msgid "No índice"
+msgstr ""
+
+#: app/admin/views.py:260
+msgid "Patrocinadores"
+msgstr ""
+
+#: app/admin/views.py:261
+msgid "Ref periódico anterior"
+msgstr ""
+
+#: app/admin/views.py:262
+msgid "Situação atual"
+msgstr ""
+
+#: app/admin/views.py:263
+msgid "Número do fascículos"
+msgstr ""
+
+#: app/admin/views.py:264 app/admin/views.py:327 app/admin/views.py:384
+msgid "Publicado?"
+msgstr ""
+
+#: app/admin/views.py:267 app/admin/views.py:330 app/admin/views.py:403
+msgid "Publicar"
+msgstr ""
+
+#: app/admin/views.py:272
+msgid "Periódico(s) publicado(s) com sucesso!!"
+msgstr ""
+
+#: app/admin/views.py:274
+msgid "Ocorreu um erro tentando publicar o(s) periódico(s)!!"
+msgstr ""
+
+#: app/admin/views.py:278 app/admin/views.py:343
+msgid "Despublicar"
+msgstr ""
+
+#: app/admin/views.py:283
+msgid "Periódico(s) despublicado com sucesso!!"
+msgstr ""
+
+#: app/admin/views.py:286
 #, python-format
 msgid "Ocorreu um erro tentando publicar o(s) periódico(s)!!. Erro: %(ex)s"
 msgstr ""
 
-#: app/admin/views.py:273
+#: app/admin/views.py:310
+msgid "Id Fascículo"
+msgstr ""
+
+#: app/admin/views.py:312
+msgid "Seções"
+msgstr ""
+
+#: app/admin/views.py:314 app/templates/includes/format_journal_row.html:14
+#: app/templates/issue/grid.html:36
+msgid "Volume"
+msgstr ""
+
+#: app/admin/views.py:315 app/templates/issue/grid.html:37
+msgid "Número"
+msgstr ""
+
+#: app/admin/views.py:318
+msgid "Tipo"
+msgstr ""
+
+#: app/admin/views.py:319
+msgid "Texto do suplemento"
+msgstr ""
+
+#: app/admin/views.py:320
+msgid "Texto do especial"
+msgstr ""
+
+#: app/admin/views.py:321
+msgid "Mês inicial"
+msgstr ""
+
+#: app/admin/views.py:322
+msgid "Mês final"
+msgstr ""
+
+#: app/admin/views.py:323 app/templates/issue/grid.html:35
+msgid "Ano"
+msgstr ""
+
+#: app/admin/views.py:324
+msgid "Etiqueta"
+msgstr ""
+
+#: app/admin/views.py:325
+msgid "Ordem"
+msgstr ""
+
+#: app/admin/views.py:326
+msgid "Lenda bibliográfica"
+msgstr ""
+
+#: app/admin/views.py:335
 msgid "Fascículo(s) publicado(s) com sucesso!!"
 msgstr ""
 
-#: app/admin/views.py:276 app/admin/views.py:337
+#: app/admin/views.py:338 app/admin/views.py:412
 #, python-format
 msgid "Ocorreu um erro tentando publicar o(s) fascículo(s)!!. Erro: %(ex)s"
 msgstr ""
 
-#: app/admin/views.py:286
+#: app/admin/views.py:348
 msgid "Fascículo(s) despublicado(s) com sucesso!!"
 msgstr ""
 
-#: app/admin/views.py:289 app/admin/views.py:350
+#: app/admin/views.py:351 app/admin/views.py:425
 #, python-format
 msgid "Ocorreu um erro tentando despublicar o(s) fascículo(s)!!. Erro: %(ex)s"
 msgstr ""
 
-#: app/admin/views.py:312
+#: app/admin/views.py:374
+msgid "Id Artigo"
+msgstr ""
+
+#: app/admin/views.py:378
+msgid "Seção"
+msgstr ""
+
+#: app/admin/views.py:379
+msgid "É AOP"
+msgstr ""
+
+#: app/admin/views.py:382
+msgid "HTML's"
+msgstr ""
+
+#: app/admin/views.py:383
+msgid "Chave de domínio"
+msgstr ""
+
+#: app/admin/views.py:387
 msgid "Reconstruir HTML"
 msgstr ""
 
-#: app/admin/views.py:320
+#: app/admin/views.py:395
 msgid "Artigo(s) reconstruido com sucesso!!"
 msgstr ""
 
-#: app/admin/views.py:323
+#: app/admin/views.py:398
 #, python-format
 msgid "Ocorreu um erro tentando reconstruir o(s) artigo(s)!!. Erro: %(ex)s"
 msgstr ""
 
-#: app/admin/views.py:333
+#: app/admin/views.py:408
 msgid "Artigo(s) publicado com sucesso!!"
 msgstr ""
 
-#: app/admin/views.py:347
+#: app/admin/views.py:422
 msgid "Artigo(s) despublicado com sucesso!!"
 msgstr ""
 
@@ -408,12 +645,6 @@ msgstr ""
 msgid "Lista alfabética de periódicos"
 msgstr ""
 
-#: app/templates/collection/list_alpha.html:46
-#: app/templates/collection/list_theme.html:54
-#: app/templates/collection/list_theme.html:111
-msgid "Título"
-msgstr ""
-
 #: app/templates/collection/list_alpha.html:49
 #: app/templates/collection/list_institution.html:45
 #: app/templates/collection/list_theme.html:57
@@ -614,25 +845,12 @@ msgstr ""
 msgid "Último"
 msgstr ""
 
-#: app/templates/includes/format_journal_row.html:14
-#: app/templates/issue/grid.html:36
-msgid "Volume"
-msgstr ""
-
 #: app/templates/includes/format_journal_row.html:15
 msgid "Nº"
 msgstr ""
 
 #: app/templates/issue/grid.html:29
 msgid "Todos os números"
-msgstr ""
-
-#: app/templates/issue/grid.html:35
-msgid "Ano"
-msgstr ""
-
-#: app/templates/issue/grid.html:37
-msgid "Número"
 msgstr ""
 
 #: app/templates/issue/grid.html:66

--- a/app/translations/messages.pot
+++ b/app/translations/messages.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-01-19 10:01-0600\n"
+"POT-Creation-Date: 2016-01-19 12:15-0600\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -22,7 +22,7 @@ msgstr ""
 msgid "Periódico"
 msgstr ""
 
-#: app/__init__.py:90 app/admin/views.py:375
+#: app/__init__.py:90
 msgid "Fascículo"
 msgstr ""
 
@@ -122,7 +122,7 @@ msgid "Id Periódico"
 msgstr ""
 
 #: app/admin/views.py:226
-msgid "Colecções"
+msgid "Coleções"
 msgstr ""
 
 #: app/admin/views.py:227
@@ -130,11 +130,11 @@ msgid "Linha do tempo"
 msgstr ""
 
 #: app/admin/views.py:228
-msgid "Código nacional"
+msgid "Código IBICT - CCN"
 msgstr ""
 
 #: app/admin/views.py:229
-msgid "Categorias de assunto "
+msgid "Categorias de assunto"
 msgstr ""
 
 #: app/admin/views.py:230
@@ -245,7 +245,7 @@ msgid "Cidade da editora"
 msgstr ""
 
 #: app/admin/views.py:256
-msgid "Direção da editora"
+msgid "Endereço da editora"
 msgstr ""
 
 #: app/admin/views.py:257
@@ -273,7 +273,7 @@ msgid "Situação atual"
 msgstr ""
 
 #: app/admin/views.py:263
-msgid "Número do fascículos"
+msgid "Total de números"
 msgstr ""
 
 #: app/admin/views.py:264 app/admin/views.py:327 app/admin/views.py:384
@@ -306,7 +306,7 @@ msgid "Ocorreu um erro tentando publicar o(s) periódico(s)!!. Erro: %(ex)s"
 msgstr ""
 
 #: app/admin/views.py:310
-msgid "Id Fascículo"
+msgid "Id Número"
 msgstr ""
 
 #: app/admin/views.py:312
@@ -318,7 +318,8 @@ msgstr ""
 msgid "Volume"
 msgstr ""
 
-#: app/admin/views.py:315 app/templates/issue/grid.html:37
+#: app/admin/views.py:315 app/admin/views.py:375
+#: app/templates/issue/grid.html:37
 msgid "Número"
 msgstr ""
 
@@ -355,7 +356,7 @@ msgid "Ordem"
 msgstr ""
 
 #: app/admin/views.py:326
-msgid "Lenda bibliográfica"
+msgid "Legenda bibliográfica"
 msgstr ""
 
 #: app/admin/views.py:335
@@ -385,7 +386,7 @@ msgid "Seção"
 msgstr ""
 
 #: app/admin/views.py:379
-msgid "É AOP"
+msgid "É AOP?"
 msgstr ""
 
 #: app/admin/views.py:382


### PR DESCRIPTION
Fix #40 

Se requiere actualizar la versión de Flask-Admin a la version 1.4.0 ya que la actual tiene un problema al utilizar column_filters y column_label con traducciones (los elementos dentro de column_filters mandan mensaje de error)