### PR TITLE
#17 - R6. O sistema deve permitir associar a lista de sponsor por coleção

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -13,7 +13,7 @@ from flask_babelex import Babel
 from flask_babelex import lazy_gettext
 
 import errors
-from opac_schema.v1.models import Journal, Issue, Article
+from opac_schema.v1.models import Collection, Sponsor, Journal, Issue, Article
 
 assets = Environment()
 toolbar = DebugToolbarExtension()
@@ -86,6 +86,8 @@ def create_app(config_name=None):
         template_mode='bootstrap3',
         base_template="admin/opac_base.html")
 
+    admin.add_view(views.CollectionAdminView(Collection, name=lazy_gettext(u'Coleção')))
+    admin.add_view(views.SponsorAdminView(Sponsor, name=lazy_gettext(u'Financiador')))
     admin.add_view(views.JournalAdminView(Journal, name=lazy_gettext(u'Periódico')))
     admin.add_view(views.IssueAdminView(Issue, name=lazy_gettext(u'Fascículo')))
     admin.add_view(views.ArticleAdminView(Article, name=lazy_gettext(u'Artigo')))

--- a/app/admin/views.py
+++ b/app/admin/views.py
@@ -1,9 +1,11 @@
 # coding: utf-8
 import logging
+from uuid import uuid4
 from flask_babelex import gettext as _
 from flask_babelex import lazy_gettext as __
 import flask_admin as admin
 from flask_admin.actions import action
+from flask_admin.model.form import InlineFormAdmin
 import flask_login as login
 from flask import url_for, redirect, render_template, request, flash, abort
 from flask.ext.admin.contrib import sqla, mongoengine
@@ -14,6 +16,7 @@ import forms
 from app import models
 from app import controllers
 from ..utils import get_timed_serializer, rebuild_article_xml
+from opac_schema.v1.models import Sponsor
 
 
 ACTION_PUBLISH_CONFIRMATION_MSG = _(u'Tem certeza que quer publicar os itens selecionados?')
@@ -195,6 +198,30 @@ class OpacBaseAdminView(mongoengine.ModelView):
 
     def is_accessible(self):
         return login.current_user.is_authenticated
+
+
+class SponsorAdminView(OpacBaseAdminView):
+    can_create = True
+    can_edit = True
+    can_delete = True
+    create_modal = True
+    edit_modal = True
+    can_view_details = True
+    column_exclude_list = ('_id', )
+    column_searchable_list = ('name',)
+
+    def on_model_change(self, form, model, is_created):
+        # é necessario definir um valor para o campo ``_id`` na criação.
+        if is_created:
+            model._id = str(uuid4().hex)
+
+
+class CollectionAdminView(OpacBaseAdminView):
+    can_edit = True
+    edit_modal = True
+    form_excluded_columns = ('acronym', )
+    column_exclude_list = ('_id', )
+    inline_models = (InlineFormAdmin(Sponsor),)
 
 
 class JournalAdminView(OpacBaseAdminView):

--- a/app/controllers.py
+++ b/app/controllers.py
@@ -29,8 +29,7 @@ def get_journals(collection=None, is_public=True, order_by="title"):
     if not collection:
         collection = current_app.config.get('OPAC_COLLECTION')
 
-    return Journal.objects(collections__acronym=collection,
-                           is_public=is_public).order_by(order_by)
+    return Journal.objects(is_public=is_public).order_by(order_by)
 
 
 def get_journals_by_study_area():

--- a/app/translations/en/LC_MESSAGES/messages.po
+++ b/app/translations/en/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: OPAC 1.0\n"
 "Report-Msgid-Bugs-To: tecnologia@scielo.org\n"
-"POT-Creation-Date: 2016-01-19 12:15-0600\n"
+"POT-Creation-Date: 2016-01-26 16:36-0200\n"
 "PO-Revision-Date: 2016-01-07 14:56-0200\n"
 "Last-Translator: scielo <tecnologia@scielo.org>\n"
 "Language: en\n"
@@ -18,20 +18,29 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.2.0\n"
 
-#: app/__init__.py:89 app/admin/views.py:311 app/admin/views.py:376
+#: app/__init__.py:89
+#, fuzzy
+msgid "Coleção"
+msgstr "of collection"
+
+#: app/__init__.py:90
+msgid "Financiador"
+msgstr ""
+
+#: app/__init__.py:91 app/admin/views.py:338 app/admin/views.py:403
 #: app/templates/journal/includes/alternative_header.html:47
 msgid "Periódico"
 msgstr "Journal"
 
-#: app/__init__.py:90
+#: app/__init__.py:92
 msgid "Fascículo"
 msgstr "Issue"
 
-#: app/__init__.py:91
+#: app/__init__.py:93
 msgid "Artigo"
 msgstr "Article"
 
-#: app/__init__.py:92
+#: app/__init__.py:94
 msgid "Usuário"
 msgstr "User"
 
@@ -51,375 +60,375 @@ msgstr "Invalid user"
 msgid "Senha inválida"
 msgstr "Invalid password"
 
-#: app/admin/views.py:19
+#: app/admin/views.py:22
 msgid "Tem certeza que quer publicar os itens selecionados?"
 msgstr "Are you sure you want to publish the selected items?"
 
-#: app/admin/views.py:20
+#: app/admin/views.py:23
 msgid "Tem certeza que quer despublicar os itens selecionados?"
 msgstr "Are you sure you want to unpublish the selected items?"
 
-#: app/admin/views.py:21
+#: app/admin/views.py:24
 msgid "Tem certeza que quer reconstruir os artigos selecionados?"
 msgstr "Are you sure you want to rebuild the selected articles?"
 
-#: app/admin/views.py:22
+#: app/admin/views.py:25
 msgid ""
 "Tem certeza que quer enviar email de confirmação aos usuários "
 "selecionados?"
 msgstr "Are you sure you want to send confirmation email to the selected users?"
 
-#: app/admin/views.py:79 app/admin/views.py:92
+#: app/admin/views.py:82 app/admin/views.py:95
 msgid "Usuário não encontrado"
 msgstr "User not found"
 
-#: app/admin/views.py:82
+#: app/admin/views.py:85
 #, python-format
 msgid "Email: %(email)s confirmado com sucesso!"
 msgstr "Email: %(email)s successfully confirmed!"
 
-#: app/admin/views.py:98
+#: app/admin/views.py:101
 #, python-format
 msgid "Enviamos as instruções para recuperar a senha para: %(email)s"
 msgstr "Sent the instructions to recover the password to: %(email)s"
 
-#: app/admin/views.py:101
+#: app/admin/views.py:104
 #, python-format
 msgid ""
 "Ocorreu um erro no envio das instruções por email para: %(email)s. Erro: "
 "%(error)s"
 msgstr "Error sending the instructions via email to: %(email)s. Error: %(error)s"
 
-#: app/admin/views.py:127
+#: app/admin/views.py:130
 msgid "Nova senha salva com sucesso!!"
 msgstr "New password saved successfully!!"
 
-#: app/admin/views.py:152 app/admin/views.py:171
+#: app/admin/views.py:155 app/admin/views.py:174
 #, python-format
 msgid "Enviamos o email de confirmação para: %(email)s"
 msgstr "We sent a confirmation email to: %(email)s"
 
-#: app/admin/views.py:155 app/admin/views.py:174
+#: app/admin/views.py:158 app/admin/views.py:177
 #, python-format
 msgid "Ocorreu um erro no envio do email de confirmação para: %(email)s"
 msgstr "An error occurred while sending the confirmation email to: %(email)s"
 
-#: app/admin/views.py:162
+#: app/admin/views.py:165
 msgid "Enviar email de confirmação"
 msgstr "Send confirmation email"
 
-#: app/admin/views.py:178
+#: app/admin/views.py:181
 #, python-format
 msgid "%(count)s usuários foram notificados com sucesso!"
 msgstr "%(count)s users were successfully notified!"
 
-#: app/admin/views.py:181
+#: app/admin/views.py:184
 #, python-format
 msgid "Ocorreu um erro no envio do emails de confirmação. Erro: %(ex)s"
 msgstr "An error occurred while sending the confirmation emails. Error: %(ex)s"
 
-#: app/admin/views.py:225
+#: app/admin/views.py:252
 msgid "Id Periódico"
 msgstr "Journal Id"
 
-#: app/admin/views.py:226
+#: app/admin/views.py:253
 msgid "Coleções"
 msgstr ""
 
-#: app/admin/views.py:227
+#: app/admin/views.py:254
 msgid "Linha do tempo"
 msgstr ""
 
-#: app/admin/views.py:228
+#: app/admin/views.py:255
 msgid "Código IBICT - CCN"
 msgstr ""
 
-#: app/admin/views.py:229
+#: app/admin/views.py:256
 msgid "Categorias de assunto"
 msgstr ""
 
-#: app/admin/views.py:230
+#: app/admin/views.py:257
 msgid "Áreas de estudo"
 msgstr ""
 
-#: app/admin/views.py:231
+#: app/admin/views.py:258
 #, fuzzy
 msgid "Redes sociais"
 msgstr "Other social networks"
 
-#: app/admin/views.py:232 app/admin/views.py:377
+#: app/admin/views.py:259 app/admin/views.py:404
 #: app/templates/collection/list_alpha.html:46
 #: app/templates/collection/list_theme.html:54
 #: app/templates/collection/list_theme.html:111
 msgid "Título"
 msgstr ""
 
-#: app/admin/views.py:233
+#: app/admin/views.py:260
 msgid "Título ISO"
 msgstr ""
 
-#: app/admin/views.py:234
+#: app/admin/views.py:261
 msgid "Título curto"
 msgstr ""
 
-#: app/admin/views.py:235 app/admin/views.py:316 app/admin/views.py:380
+#: app/admin/views.py:262 app/admin/views.py:343 app/admin/views.py:407
 msgid "Criado"
 msgstr ""
 
-#: app/admin/views.py:236 app/admin/views.py:317 app/admin/views.py:381
+#: app/admin/views.py:263 app/admin/views.py:344 app/admin/views.py:408
 #, fuzzy
 msgid "Atualizado"
 msgstr "Total"
 
-#: app/admin/views.py:237
+#: app/admin/views.py:264
 msgid "Acrônimo"
 msgstr ""
 
-#: app/admin/views.py:238
+#: app/admin/views.py:265
 msgid "ISSN SciELO"
 msgstr ""
 
-#: app/admin/views.py:239
+#: app/admin/views.py:266
 msgid "ISSN impresso"
 msgstr ""
 
-#: app/admin/views.py:240
+#: app/admin/views.py:267
 msgid "ISSN eletrônico"
 msgstr ""
 
-#: app/admin/views.py:241
+#: app/admin/views.py:268
 msgid "Descritores de assunto"
 msgstr ""
 
-#: app/admin/views.py:242
+#: app/admin/views.py:269
 msgid "Ano inicial"
 msgstr ""
 
-#: app/admin/views.py:243
+#: app/admin/views.py:270
 msgid "Volume inicial"
 msgstr ""
 
-#: app/admin/views.py:244
+#: app/admin/views.py:271
 msgid "Número inicial"
 msgstr ""
 
-#: app/admin/views.py:245
+#: app/admin/views.py:272
 msgid "Ano final"
 msgstr ""
 
-#: app/admin/views.py:246
+#: app/admin/views.py:273
 msgid "Volume final"
 msgstr ""
 
-#: app/admin/views.py:247
+#: app/admin/views.py:274
 msgid "Número final"
 msgstr ""
 
-#: app/admin/views.py:248
+#: app/admin/views.py:275
 msgid "Url da submissão online"
 msgstr ""
 
-#: app/admin/views.py:249 app/admin/views.py:313
+#: app/admin/views.py:276 app/admin/views.py:340
 msgid "Url do capa"
 msgstr ""
 
-#: app/admin/views.py:250
+#: app/admin/views.py:277
 msgid "Url do logotipo"
 msgstr ""
 
-#: app/admin/views.py:251
+#: app/admin/views.py:278
 msgid "Outros títulos"
 msgstr ""
 
-#: app/admin/views.py:252
+#: app/admin/views.py:279
 msgid "Nome da editora"
 msgstr ""
 
-#: app/admin/views.py:253
+#: app/admin/views.py:280
 msgid "País da editora"
 msgstr ""
 
-#: app/admin/views.py:254
+#: app/admin/views.py:281
 msgid "Estado da editora"
 msgstr ""
 
-#: app/admin/views.py:255
+#: app/admin/views.py:282
 msgid "Cidade da editora"
 msgstr ""
 
-#: app/admin/views.py:256
+#: app/admin/views.py:283
 msgid "Endereço da editora"
 msgstr ""
 
-#: app/admin/views.py:257
+#: app/admin/views.py:284
 msgid "Telefone da editora"
 msgstr ""
 
-#: app/admin/views.py:258
+#: app/admin/views.py:285
 msgid "Missão"
 msgstr ""
 
-#: app/admin/views.py:259
+#: app/admin/views.py:286
 msgid "No índice"
 msgstr ""
 
-#: app/admin/views.py:260
+#: app/admin/views.py:287
 msgid "Patrocinadores"
 msgstr ""
 
-#: app/admin/views.py:261
+#: app/admin/views.py:288
 #, fuzzy
 msgid "Ref periódico anterior"
 msgstr "Journal"
 
-#: app/admin/views.py:262
+#: app/admin/views.py:289
 msgid "Situação atual"
 msgstr ""
 
-#: app/admin/views.py:263
+#: app/admin/views.py:290
 msgid "Total de números"
 msgstr ""
 
-#: app/admin/views.py:264 app/admin/views.py:327 app/admin/views.py:384
+#: app/admin/views.py:291 app/admin/views.py:354 app/admin/views.py:411
 msgid "Publicado?"
 msgstr "Published?"
 
-#: app/admin/views.py:267 app/admin/views.py:330 app/admin/views.py:403
+#: app/admin/views.py:294 app/admin/views.py:357 app/admin/views.py:430
 msgid "Publicar"
 msgstr "Publish"
 
-#: app/admin/views.py:272
+#: app/admin/views.py:299
 msgid "Periódico(s) publicado(s) com sucesso!!"
 msgstr "Journal(s) successfully published!!"
 
-#: app/admin/views.py:274
+#: app/admin/views.py:301
 msgid "Ocorreu um erro tentando publicar o(s) periódico(s)!!"
 msgstr "An error occurred trying to publish the journal(s)!!"
 
-#: app/admin/views.py:278 app/admin/views.py:343
+#: app/admin/views.py:305 app/admin/views.py:370
 msgid "Despublicar"
 msgstr "Unpublish"
 
-#: app/admin/views.py:283
+#: app/admin/views.py:310
 msgid "Periódico(s) despublicado com sucesso!!"
 msgstr "Journal(s) successfully unpublished!!"
 
-#: app/admin/views.py:286
+#: app/admin/views.py:313
 #, python-format
 msgid "Ocorreu um erro tentando publicar o(s) periódico(s)!!. Erro: %(ex)s"
 msgstr "An error occurred trying to publish the journal(s)!! Error %(ex)s"
 
-#: app/admin/views.py:310
+#: app/admin/views.py:337
 msgid "Id Número"
 msgstr "Issue Id"
 
-#: app/admin/views.py:312
+#: app/admin/views.py:339
 msgid "Seções"
 msgstr ""
 
-#: app/admin/views.py:314 app/templates/includes/format_journal_row.html:14
+#: app/admin/views.py:341 app/templates/includes/format_journal_row.html:14
 #: app/templates/issue/grid.html:36
 msgid "Volume"
 msgstr ""
 
-#: app/admin/views.py:315 app/admin/views.py:375
+#: app/admin/views.py:342 app/admin/views.py:402
 #: app/templates/issue/grid.html:37
 msgid "Número"
 msgstr ""
 
-#: app/admin/views.py:318
+#: app/admin/views.py:345
 #, fuzzy
 msgid "Tipo"
 msgstr "Article"
 
-#: app/admin/views.py:319
+#: app/admin/views.py:346
 msgid "Texto do suplemento"
 msgstr ""
 
-#: app/admin/views.py:320
+#: app/admin/views.py:347
 msgid "Texto do especial"
 msgstr ""
 
-#: app/admin/views.py:321
+#: app/admin/views.py:348
 msgid "Mês inicial"
 msgstr ""
 
-#: app/admin/views.py:322
+#: app/admin/views.py:349
 msgid "Mês final"
 msgstr ""
 
-#: app/admin/views.py:323 app/templates/issue/grid.html:35
+#: app/admin/views.py:350 app/templates/issue/grid.html:35
 msgid "Ano"
 msgstr ""
 
-#: app/admin/views.py:324
+#: app/admin/views.py:351
 msgid "Etiqueta"
 msgstr ""
 
-#: app/admin/views.py:325
+#: app/admin/views.py:352
 msgid "Ordem"
 msgstr ""
 
-#: app/admin/views.py:326
+#: app/admin/views.py:353
 msgid "Legenda bibliográfica"
 msgstr ""
 
-#: app/admin/views.py:335
+#: app/admin/views.py:362
 msgid "Fascículo(s) publicado(s) com sucesso!!"
 msgstr "Issue(s) successfully published!!"
 
-#: app/admin/views.py:338 app/admin/views.py:412
+#: app/admin/views.py:365 app/admin/views.py:439
 #, python-format
 msgid "Ocorreu um erro tentando publicar o(s) fascículo(s)!!. Erro: %(ex)s"
 msgstr "An error occurred trying to publish the issue(s)!! Error %(ex)s"
 
-#: app/admin/views.py:348
+#: app/admin/views.py:375
 msgid "Fascículo(s) despublicado(s) com sucesso!!"
 msgstr "Issue(s) successfully unpublished!!"
 
-#: app/admin/views.py:351 app/admin/views.py:425
+#: app/admin/views.py:378 app/admin/views.py:452
 #, python-format
 msgid "Ocorreu um erro tentando despublicar o(s) fascículo(s)!!. Erro: %(ex)s"
 msgstr "An error occurred trying to unpublish the issue(s)!! Error %(ex)s"
 
-#: app/admin/views.py:374
+#: app/admin/views.py:401
 msgid "Id Artigo"
 msgstr "Article Id"
 
-#: app/admin/views.py:378
+#: app/admin/views.py:405
 msgid "Seção"
 msgstr ""
 
-#: app/admin/views.py:379
+#: app/admin/views.py:406
 msgid "É AOP?"
 msgstr ""
 
-#: app/admin/views.py:382
+#: app/admin/views.py:409
 msgid "HTML's"
 msgstr ""
 
-#: app/admin/views.py:383
+#: app/admin/views.py:410
 msgid "Chave de domínio"
 msgstr ""
 
-#: app/admin/views.py:387
+#: app/admin/views.py:414
 msgid "Reconstruir HTML"
 msgstr "Rebuild HTML"
 
-#: app/admin/views.py:395
+#: app/admin/views.py:422
 msgid "Artigo(s) reconstruido com sucesso!!"
 msgstr "Article(s) successfully rebuilt!!"
 
-#: app/admin/views.py:398
+#: app/admin/views.py:425
 #, python-format
 msgid "Ocorreu um erro tentando reconstruir o(s) artigo(s)!!. Erro: %(ex)s"
 msgstr "An error occurred trying to rebuild the article(s)!! Error %(ex)s"
 
-#: app/admin/views.py:408
+#: app/admin/views.py:435
 msgid "Artigo(s) publicado com sucesso!!"
 msgstr "Article(s) successfully published!!"
 
-#: app/admin/views.py:422
+#: app/admin/views.py:449
 msgid "Artigo(s) despublicado com sucesso!!"
 msgstr "Article(s) successfully unpublished!!"
 

--- a/app/translations/es/LC_MESSAGES/messages.po
+++ b/app/translations/es/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: OPAC 1.0\n"
 "Report-Msgid-Bugs-To: tecnologia@scielo.org\n"
-"POT-Creation-Date: 2016-01-19 12:15-0600\n"
+"POT-Creation-Date: 2016-01-26 16:36-0200\n"
 "PO-Revision-Date: 2016-01-07 14:56-0200\n"
 "Last-Translator: scielo <tecnologia@scielo.org>\n"
 "Language: es\n"
@@ -18,20 +18,29 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.2.0\n"
 
-#: app/__init__.py:89 app/admin/views.py:311 app/admin/views.py:376
+#: app/__init__.py:89
+#, fuzzy
+msgid "Coleção"
+msgstr "de la colección"
+
+#: app/__init__.py:90
+msgid "Financiador"
+msgstr ""
+
+#: app/__init__.py:91 app/admin/views.py:338 app/admin/views.py:403
 #: app/templates/journal/includes/alternative_header.html:47
 msgid "Periódico"
 msgstr "Periódico"
 
-#: app/__init__.py:90
+#: app/__init__.py:92
 msgid "Fascículo"
 msgstr "Fascícluo"
 
-#: app/__init__.py:91
+#: app/__init__.py:93
 msgid "Artigo"
 msgstr "Artículo"
 
-#: app/__init__.py:92
+#: app/__init__.py:94
 msgid "Usuário"
 msgstr "Usuario"
 
@@ -51,19 +60,19 @@ msgstr "Usuario inválido"
 msgid "Senha inválida"
 msgstr "Contraseña inválida"
 
-#: app/admin/views.py:19
+#: app/admin/views.py:22
 msgid "Tem certeza que quer publicar os itens selecionados?"
 msgstr "¿Está seguro que desea publicar los ítems seleccionados?"
 
-#: app/admin/views.py:20
+#: app/admin/views.py:23
 msgid "Tem certeza que quer despublicar os itens selecionados?"
 msgstr "¿Está seguro que desea despublicar los ítems seleccionados?"
 
-#: app/admin/views.py:21
+#: app/admin/views.py:24
 msgid "Tem certeza que quer reconstruir os artigos selecionados?"
 msgstr "¿Está seguro que desea reconstruir los artículos seleccionados?"
 
-#: app/admin/views.py:22
+#: app/admin/views.py:25
 msgid ""
 "Tem certeza que quer enviar email de confirmação aos usuários "
 "selecionados?"
@@ -71,21 +80,21 @@ msgstr ""
 "¿Está seguro que desea enviar email de confirmación a los usuarios "
 "seleccionados?"
 
-#: app/admin/views.py:79 app/admin/views.py:92
+#: app/admin/views.py:82 app/admin/views.py:95
 msgid "Usuário não encontrado"
 msgstr "Usuario no encontrado"
 
-#: app/admin/views.py:82
+#: app/admin/views.py:85
 #, python-format
 msgid "Email: %(email)s confirmado com sucesso!"
 msgstr "Email: %(email)s confirmado com éxito!"
 
-#: app/admin/views.py:98
+#: app/admin/views.py:101
 #, python-format
 msgid "Enviamos as instruções para recuperar a senha para: %(email)s"
 msgstr "Enviamos las instrucciones para recuperar la contraseña para: %(email)s"
 
-#: app/admin/views.py:101
+#: app/admin/views.py:104
 #, python-format
 msgid ""
 "Ocorreu um erro no envio das instruções por email para: %(email)s. Erro: "
@@ -94,338 +103,338 @@ msgstr ""
 "Ocurrió un error en el envío de las instrucciones por email para "
 "%(email)s. Error: %(error)s"
 
-#: app/admin/views.py:127
+#: app/admin/views.py:130
 msgid "Nova senha salva com sucesso!!"
 msgstr "Nueva contraseña guardada con éxito!!"
 
-#: app/admin/views.py:152 app/admin/views.py:171
+#: app/admin/views.py:155 app/admin/views.py:174
 #, python-format
 msgid "Enviamos o email de confirmação para: %(email)s"
 msgstr "Enviamos el email de confirmación para %(email)s"
 
-#: app/admin/views.py:155 app/admin/views.py:174
+#: app/admin/views.py:158 app/admin/views.py:177
 #, python-format
 msgid "Ocorreu um erro no envio do email de confirmação para: %(email)s"
 msgstr "Ocurrió un error en el envío de email de confirmación para %(email)s"
 
-#: app/admin/views.py:162
+#: app/admin/views.py:165
 msgid "Enviar email de confirmação"
 msgstr "Enviar email de confirmación"
 
-#: app/admin/views.py:178
+#: app/admin/views.py:181
 #, python-format
 msgid "%(count)s usuários foram notificados com sucesso!"
 msgstr "%(count)s usuarios fueron notificados con éxito!"
 
-#: app/admin/views.py:181
+#: app/admin/views.py:184
 #, python-format
 msgid "Ocorreu um erro no envio do emails de confirmação. Erro: %(ex)s"
 msgstr "Ocurrió un error en el envío de emails de confirmación. Error: %(ex)s"
 
-#: app/admin/views.py:225
+#: app/admin/views.py:252
 msgid "Id Periódico"
 msgstr "Id Revista"
 
-#: app/admin/views.py:226
+#: app/admin/views.py:253
 msgid "Coleções"
 msgstr ""
 
-#: app/admin/views.py:227
+#: app/admin/views.py:254
 msgid "Linha do tempo"
 msgstr ""
 
-#: app/admin/views.py:228
+#: app/admin/views.py:255
 msgid "Código IBICT - CCN"
 msgstr ""
 
-#: app/admin/views.py:229
+#: app/admin/views.py:256
 msgid "Categorias de assunto"
 msgstr ""
 
-#: app/admin/views.py:230
+#: app/admin/views.py:257
 msgid "Áreas de estudo"
 msgstr ""
 
-#: app/admin/views.py:231
+#: app/admin/views.py:258
 #, fuzzy
 msgid "Redes sociais"
 msgstr "Otras redes sociales"
 
-#: app/admin/views.py:232 app/admin/views.py:377
+#: app/admin/views.py:259 app/admin/views.py:404
 #: app/templates/collection/list_alpha.html:46
 #: app/templates/collection/list_theme.html:54
 #: app/templates/collection/list_theme.html:111
 msgid "Título"
 msgstr ""
 
-#: app/admin/views.py:233
+#: app/admin/views.py:260
 msgid "Título ISO"
 msgstr ""
 
-#: app/admin/views.py:234
+#: app/admin/views.py:261
 msgid "Título curto"
 msgstr ""
 
-#: app/admin/views.py:235 app/admin/views.py:316 app/admin/views.py:380
+#: app/admin/views.py:262 app/admin/views.py:343 app/admin/views.py:407
 msgid "Criado"
 msgstr ""
 
-#: app/admin/views.py:236 app/admin/views.py:317 app/admin/views.py:381
+#: app/admin/views.py:263 app/admin/views.py:344 app/admin/views.py:408
 #, fuzzy
 msgid "Atualizado"
 msgstr "Total"
 
-#: app/admin/views.py:237
+#: app/admin/views.py:264
 msgid "Acrônimo"
 msgstr ""
 
-#: app/admin/views.py:238
+#: app/admin/views.py:265
 msgid "ISSN SciELO"
 msgstr ""
 
-#: app/admin/views.py:239
+#: app/admin/views.py:266
 msgid "ISSN impresso"
 msgstr ""
 
-#: app/admin/views.py:240
+#: app/admin/views.py:267
 msgid "ISSN eletrônico"
 msgstr ""
 
-#: app/admin/views.py:241
+#: app/admin/views.py:268
 msgid "Descritores de assunto"
 msgstr ""
 
-#: app/admin/views.py:242
+#: app/admin/views.py:269
 msgid "Ano inicial"
 msgstr ""
 
-#: app/admin/views.py:243
+#: app/admin/views.py:270
 msgid "Volume inicial"
 msgstr ""
 
-#: app/admin/views.py:244
+#: app/admin/views.py:271
 msgid "Número inicial"
 msgstr ""
 
-#: app/admin/views.py:245
+#: app/admin/views.py:272
 msgid "Ano final"
 msgstr ""
 
-#: app/admin/views.py:246
+#: app/admin/views.py:273
 msgid "Volume final"
 msgstr ""
 
-#: app/admin/views.py:247
+#: app/admin/views.py:274
 msgid "Número final"
 msgstr ""
 
-#: app/admin/views.py:248
+#: app/admin/views.py:275
 msgid "Url da submissão online"
 msgstr ""
 
-#: app/admin/views.py:249 app/admin/views.py:313
+#: app/admin/views.py:276 app/admin/views.py:340
 msgid "Url do capa"
 msgstr ""
 
-#: app/admin/views.py:250
+#: app/admin/views.py:277
 msgid "Url do logotipo"
 msgstr ""
 
-#: app/admin/views.py:251
+#: app/admin/views.py:278
 msgid "Outros títulos"
 msgstr ""
 
-#: app/admin/views.py:252
+#: app/admin/views.py:279
 msgid "Nome da editora"
 msgstr ""
 
-#: app/admin/views.py:253
+#: app/admin/views.py:280
 msgid "País da editora"
 msgstr ""
 
-#: app/admin/views.py:254
+#: app/admin/views.py:281
 msgid "Estado da editora"
 msgstr ""
 
-#: app/admin/views.py:255
+#: app/admin/views.py:282
 msgid "Cidade da editora"
 msgstr ""
 
-#: app/admin/views.py:256
+#: app/admin/views.py:283
 msgid "Endereço da editora"
 msgstr ""
 
-#: app/admin/views.py:257
+#: app/admin/views.py:284
 msgid "Telefone da editora"
 msgstr ""
 
-#: app/admin/views.py:258
+#: app/admin/views.py:285
 msgid "Missão"
 msgstr ""
 
-#: app/admin/views.py:259
+#: app/admin/views.py:286
 msgid "No índice"
 msgstr ""
 
-#: app/admin/views.py:260
+#: app/admin/views.py:287
 msgid "Patrocinadores"
 msgstr ""
 
-#: app/admin/views.py:261
+#: app/admin/views.py:288
 #, fuzzy
 msgid "Ref periódico anterior"
 msgstr "Periódico"
 
-#: app/admin/views.py:262
+#: app/admin/views.py:289
 msgid "Situação atual"
 msgstr ""
 
-#: app/admin/views.py:263
+#: app/admin/views.py:290
 msgid "Total de números"
 msgstr ""
 
-#: app/admin/views.py:264 app/admin/views.py:327 app/admin/views.py:384
+#: app/admin/views.py:291 app/admin/views.py:354 app/admin/views.py:411
 msgid "Publicado?"
 msgstr "Publicado?"
 
-#: app/admin/views.py:267 app/admin/views.py:330 app/admin/views.py:403
+#: app/admin/views.py:294 app/admin/views.py:357 app/admin/views.py:430
 msgid "Publicar"
 msgstr "Publicar"
 
-#: app/admin/views.py:272
+#: app/admin/views.py:299
 msgid "Periódico(s) publicado(s) com sucesso!!"
 msgstr "Periódico(s) publicado(s) con éxito!!"
 
-#: app/admin/views.py:274
+#: app/admin/views.py:301
 msgid "Ocorreu um erro tentando publicar o(s) periódico(s)!!"
 msgstr "Ocurrió un error intentando publicar el/los periódico(s)!!"
 
-#: app/admin/views.py:278 app/admin/views.py:343
+#: app/admin/views.py:305 app/admin/views.py:370
 msgid "Despublicar"
 msgstr "Despublicar"
 
-#: app/admin/views.py:283
+#: app/admin/views.py:310
 msgid "Periódico(s) despublicado com sucesso!!"
 msgstr "Periódico(s) despublicado(s) com éxito!!"
 
-#: app/admin/views.py:286
+#: app/admin/views.py:313
 #, python-format
 msgid "Ocorreu um erro tentando publicar o(s) periódico(s)!!. Erro: %(ex)s"
 msgstr "Ocurrió un error intentando publicar el/los periódico(s)!! Erro: %(ex)s"
 
-#: app/admin/views.py:310
+#: app/admin/views.py:337
 msgid "Id Número"
 msgstr "Id Fascículo"
 
-#: app/admin/views.py:312
+#: app/admin/views.py:339
 msgid "Seções"
 msgstr ""
 
-#: app/admin/views.py:314 app/templates/includes/format_journal_row.html:14
+#: app/admin/views.py:341 app/templates/includes/format_journal_row.html:14
 #: app/templates/issue/grid.html:36
 msgid "Volume"
 msgstr ""
 
-#: app/admin/views.py:315 app/admin/views.py:375
+#: app/admin/views.py:342 app/admin/views.py:402
 #: app/templates/issue/grid.html:37
 msgid "Número"
 msgstr ""
 
-#: app/admin/views.py:318
+#: app/admin/views.py:345
 #, fuzzy
 msgid "Tipo"
 msgstr "Artículo"
 
-#: app/admin/views.py:319
+#: app/admin/views.py:346
 msgid "Texto do suplemento"
 msgstr ""
 
-#: app/admin/views.py:320
+#: app/admin/views.py:347
 msgid "Texto do especial"
 msgstr ""
 
-#: app/admin/views.py:321
+#: app/admin/views.py:348
 msgid "Mês inicial"
 msgstr ""
 
-#: app/admin/views.py:322
+#: app/admin/views.py:349
 msgid "Mês final"
 msgstr ""
 
-#: app/admin/views.py:323 app/templates/issue/grid.html:35
+#: app/admin/views.py:350 app/templates/issue/grid.html:35
 msgid "Ano"
 msgstr ""
 
-#: app/admin/views.py:324
+#: app/admin/views.py:351
 msgid "Etiqueta"
 msgstr ""
 
-#: app/admin/views.py:325
+#: app/admin/views.py:352
 msgid "Ordem"
 msgstr ""
 
-#: app/admin/views.py:326
+#: app/admin/views.py:353
 msgid "Legenda bibliográfica"
 msgstr ""
 
-#: app/admin/views.py:335
+#: app/admin/views.py:362
 msgid "Fascículo(s) publicado(s) com sucesso!!"
 msgstr "Fascículo(s) publicado(s) com éxito!!"
 
-#: app/admin/views.py:338 app/admin/views.py:412
+#: app/admin/views.py:365 app/admin/views.py:439
 #, python-format
 msgid "Ocorreu um erro tentando publicar o(s) fascículo(s)!!. Erro: %(ex)s"
 msgstr "Ocurrió un error intentando publicar el/los fascículo(s)!! Error: %(ex)s"
 
-#: app/admin/views.py:348
+#: app/admin/views.py:375
 msgid "Fascículo(s) despublicado(s) com sucesso!!"
 msgstr "Fascículo(s) despublicado(s) com éxito!!"
 
-#: app/admin/views.py:351 app/admin/views.py:425
+#: app/admin/views.py:378 app/admin/views.py:452
 #, python-format
 msgid "Ocorreu um erro tentando despublicar o(s) fascículo(s)!!. Erro: %(ex)s"
 msgstr ""
 "Ocurrió un error intentando despublicar el/los fascículo(s)!! Error: "
 "%(ex)s"
 
-#: app/admin/views.py:374
+#: app/admin/views.py:401
 msgid "Id Artigo"
 msgstr "Id Artículo"
 
-#: app/admin/views.py:378
+#: app/admin/views.py:405
 msgid "Seção"
 msgstr ""
 
-#: app/admin/views.py:379
+#: app/admin/views.py:406
 msgid "É AOP?"
 msgstr ""
 
-#: app/admin/views.py:382
+#: app/admin/views.py:409
 msgid "HTML's"
 msgstr ""
 
-#: app/admin/views.py:383
+#: app/admin/views.py:410
 msgid "Chave de domínio"
 msgstr ""
 
-#: app/admin/views.py:387
+#: app/admin/views.py:414
 msgid "Reconstruir HTML"
 msgstr "Reconstruir HTML"
 
-#: app/admin/views.py:395
+#: app/admin/views.py:422
 msgid "Artigo(s) reconstruido com sucesso!!"
 msgstr "Artículo recontruido con éxito!!"
 
-#: app/admin/views.py:398
+#: app/admin/views.py:425
 #, python-format
 msgid "Ocorreu um erro tentando reconstruir o(s) artigo(s)!!. Erro: %(ex)s"
 msgstr "Ocurrió un error intentando reconstruir el/los artículo(s). Error: %(ex)s"
 
-#: app/admin/views.py:408
+#: app/admin/views.py:435
 msgid "Artigo(s) publicado com sucesso!!"
 msgstr "Artículo(s) publicado con éxito!!"
 
-#: app/admin/views.py:422
+#: app/admin/views.py:449
 msgid "Artigo(s) despublicado com sucesso!!"
 msgstr "Artículo(s) despublicado con éxito!!"
 

--- a/app/translations/messages.pot
+++ b/app/translations/messages.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-01-19 12:15-0600\n"
+"POT-Creation-Date: 2016-01-26 16:36-0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,20 +17,28 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.2.0\n"
 
-#: app/__init__.py:89 app/admin/views.py:311 app/admin/views.py:376
+#: app/__init__.py:89
+msgid "Coleção"
+msgstr ""
+
+#: app/__init__.py:90
+msgid "Financiador"
+msgstr ""
+
+#: app/__init__.py:91 app/admin/views.py:338 app/admin/views.py:403
 #: app/templates/journal/includes/alternative_header.html:47
 msgid "Periódico"
 msgstr ""
 
-#: app/__init__.py:90
+#: app/__init__.py:92
 msgid "Fascículo"
 msgstr ""
 
-#: app/__init__.py:91
+#: app/__init__.py:93
 msgid "Artigo"
 msgstr ""
 
-#: app/__init__.py:92
+#: app/__init__.py:94
 msgid "Usuário"
 msgstr ""
 
@@ -50,371 +58,371 @@ msgstr ""
 msgid "Senha inválida"
 msgstr ""
 
-#: app/admin/views.py:19
+#: app/admin/views.py:22
 msgid "Tem certeza que quer publicar os itens selecionados?"
 msgstr ""
 
-#: app/admin/views.py:20
+#: app/admin/views.py:23
 msgid "Tem certeza que quer despublicar os itens selecionados?"
 msgstr ""
 
-#: app/admin/views.py:21
+#: app/admin/views.py:24
 msgid "Tem certeza que quer reconstruir os artigos selecionados?"
 msgstr ""
 
-#: app/admin/views.py:22
+#: app/admin/views.py:25
 msgid ""
 "Tem certeza que quer enviar email de confirmação aos usuários "
 "selecionados?"
 msgstr ""
 
-#: app/admin/views.py:79 app/admin/views.py:92
+#: app/admin/views.py:82 app/admin/views.py:95
 msgid "Usuário não encontrado"
 msgstr ""
 
-#: app/admin/views.py:82
+#: app/admin/views.py:85
 #, python-format
 msgid "Email: %(email)s confirmado com sucesso!"
 msgstr ""
 
-#: app/admin/views.py:98
+#: app/admin/views.py:101
 #, python-format
 msgid "Enviamos as instruções para recuperar a senha para: %(email)s"
 msgstr ""
 
-#: app/admin/views.py:101
+#: app/admin/views.py:104
 #, python-format
 msgid ""
 "Ocorreu um erro no envio das instruções por email para: %(email)s. Erro: "
 "%(error)s"
 msgstr ""
 
-#: app/admin/views.py:127
+#: app/admin/views.py:130
 msgid "Nova senha salva com sucesso!!"
-msgstr ""
-
-#: app/admin/views.py:152 app/admin/views.py:171
-#, python-format
-msgid "Enviamos o email de confirmação para: %(email)s"
 msgstr ""
 
 #: app/admin/views.py:155 app/admin/views.py:174
 #, python-format
+msgid "Enviamos o email de confirmação para: %(email)s"
+msgstr ""
+
+#: app/admin/views.py:158 app/admin/views.py:177
+#, python-format
 msgid "Ocorreu um erro no envio do email de confirmação para: %(email)s"
 msgstr ""
 
-#: app/admin/views.py:162
+#: app/admin/views.py:165
 msgid "Enviar email de confirmação"
-msgstr ""
-
-#: app/admin/views.py:178
-#, python-format
-msgid "%(count)s usuários foram notificados com sucesso!"
 msgstr ""
 
 #: app/admin/views.py:181
 #, python-format
+msgid "%(count)s usuários foram notificados com sucesso!"
+msgstr ""
+
+#: app/admin/views.py:184
+#, python-format
 msgid "Ocorreu um erro no envio do emails de confirmação. Erro: %(ex)s"
 msgstr ""
 
-#: app/admin/views.py:225
+#: app/admin/views.py:252
 msgid "Id Periódico"
 msgstr ""
 
-#: app/admin/views.py:226
+#: app/admin/views.py:253
 msgid "Coleções"
 msgstr ""
 
-#: app/admin/views.py:227
+#: app/admin/views.py:254
 msgid "Linha do tempo"
 msgstr ""
 
-#: app/admin/views.py:228
+#: app/admin/views.py:255
 msgid "Código IBICT - CCN"
 msgstr ""
 
-#: app/admin/views.py:229
+#: app/admin/views.py:256
 msgid "Categorias de assunto"
 msgstr ""
 
-#: app/admin/views.py:230
+#: app/admin/views.py:257
 msgid "Áreas de estudo"
 msgstr ""
 
-#: app/admin/views.py:231
+#: app/admin/views.py:258
 msgid "Redes sociais"
 msgstr ""
 
-#: app/admin/views.py:232 app/admin/views.py:377
+#: app/admin/views.py:259 app/admin/views.py:404
 #: app/templates/collection/list_alpha.html:46
 #: app/templates/collection/list_theme.html:54
 #: app/templates/collection/list_theme.html:111
 msgid "Título"
 msgstr ""
 
-#: app/admin/views.py:233
+#: app/admin/views.py:260
 msgid "Título ISO"
 msgstr ""
 
-#: app/admin/views.py:234
+#: app/admin/views.py:261
 msgid "Título curto"
 msgstr ""
 
-#: app/admin/views.py:235 app/admin/views.py:316 app/admin/views.py:380
+#: app/admin/views.py:262 app/admin/views.py:343 app/admin/views.py:407
 msgid "Criado"
 msgstr ""
 
-#: app/admin/views.py:236 app/admin/views.py:317 app/admin/views.py:381
+#: app/admin/views.py:263 app/admin/views.py:344 app/admin/views.py:408
 msgid "Atualizado"
 msgstr ""
 
-#: app/admin/views.py:237
+#: app/admin/views.py:264
 msgid "Acrônimo"
 msgstr ""
 
-#: app/admin/views.py:238
+#: app/admin/views.py:265
 msgid "ISSN SciELO"
 msgstr ""
 
-#: app/admin/views.py:239
+#: app/admin/views.py:266
 msgid "ISSN impresso"
 msgstr ""
 
-#: app/admin/views.py:240
+#: app/admin/views.py:267
 msgid "ISSN eletrônico"
 msgstr ""
 
-#: app/admin/views.py:241
+#: app/admin/views.py:268
 msgid "Descritores de assunto"
 msgstr ""
 
-#: app/admin/views.py:242
+#: app/admin/views.py:269
 msgid "Ano inicial"
 msgstr ""
 
-#: app/admin/views.py:243
+#: app/admin/views.py:270
 msgid "Volume inicial"
 msgstr ""
 
-#: app/admin/views.py:244
+#: app/admin/views.py:271
 msgid "Número inicial"
 msgstr ""
 
-#: app/admin/views.py:245
+#: app/admin/views.py:272
 msgid "Ano final"
 msgstr ""
 
-#: app/admin/views.py:246
+#: app/admin/views.py:273
 msgid "Volume final"
 msgstr ""
 
-#: app/admin/views.py:247
+#: app/admin/views.py:274
 msgid "Número final"
 msgstr ""
 
-#: app/admin/views.py:248
+#: app/admin/views.py:275
 msgid "Url da submissão online"
 msgstr ""
 
-#: app/admin/views.py:249 app/admin/views.py:313
+#: app/admin/views.py:276 app/admin/views.py:340
 msgid "Url do capa"
 msgstr ""
 
-#: app/admin/views.py:250
+#: app/admin/views.py:277
 msgid "Url do logotipo"
 msgstr ""
 
-#: app/admin/views.py:251
+#: app/admin/views.py:278
 msgid "Outros títulos"
 msgstr ""
 
-#: app/admin/views.py:252
+#: app/admin/views.py:279
 msgid "Nome da editora"
 msgstr ""
 
-#: app/admin/views.py:253
+#: app/admin/views.py:280
 msgid "País da editora"
 msgstr ""
 
-#: app/admin/views.py:254
+#: app/admin/views.py:281
 msgid "Estado da editora"
 msgstr ""
 
-#: app/admin/views.py:255
+#: app/admin/views.py:282
 msgid "Cidade da editora"
 msgstr ""
 
-#: app/admin/views.py:256
+#: app/admin/views.py:283
 msgid "Endereço da editora"
 msgstr ""
 
-#: app/admin/views.py:257
+#: app/admin/views.py:284
 msgid "Telefone da editora"
 msgstr ""
 
-#: app/admin/views.py:258
+#: app/admin/views.py:285
 msgid "Missão"
 msgstr ""
 
-#: app/admin/views.py:259
+#: app/admin/views.py:286
 msgid "No índice"
 msgstr ""
 
-#: app/admin/views.py:260
+#: app/admin/views.py:287
 msgid "Patrocinadores"
 msgstr ""
 
-#: app/admin/views.py:261
+#: app/admin/views.py:288
 msgid "Ref periódico anterior"
 msgstr ""
 
-#: app/admin/views.py:262
+#: app/admin/views.py:289
 msgid "Situação atual"
 msgstr ""
 
-#: app/admin/views.py:263
+#: app/admin/views.py:290
 msgid "Total de números"
 msgstr ""
 
-#: app/admin/views.py:264 app/admin/views.py:327 app/admin/views.py:384
+#: app/admin/views.py:291 app/admin/views.py:354 app/admin/views.py:411
 msgid "Publicado?"
 msgstr ""
 
-#: app/admin/views.py:267 app/admin/views.py:330 app/admin/views.py:403
+#: app/admin/views.py:294 app/admin/views.py:357 app/admin/views.py:430
 msgid "Publicar"
 msgstr ""
 
-#: app/admin/views.py:272
+#: app/admin/views.py:299
 msgid "Periódico(s) publicado(s) com sucesso!!"
 msgstr ""
 
-#: app/admin/views.py:274
+#: app/admin/views.py:301
 msgid "Ocorreu um erro tentando publicar o(s) periódico(s)!!"
 msgstr ""
 
-#: app/admin/views.py:278 app/admin/views.py:343
+#: app/admin/views.py:305 app/admin/views.py:370
 msgid "Despublicar"
 msgstr ""
 
-#: app/admin/views.py:283
+#: app/admin/views.py:310
 msgid "Periódico(s) despublicado com sucesso!!"
 msgstr ""
 
-#: app/admin/views.py:286
+#: app/admin/views.py:313
 #, python-format
 msgid "Ocorreu um erro tentando publicar o(s) periódico(s)!!. Erro: %(ex)s"
 msgstr ""
 
-#: app/admin/views.py:310
+#: app/admin/views.py:337
 msgid "Id Número"
 msgstr ""
 
-#: app/admin/views.py:312
+#: app/admin/views.py:339
 msgid "Seções"
 msgstr ""
 
-#: app/admin/views.py:314 app/templates/includes/format_journal_row.html:14
+#: app/admin/views.py:341 app/templates/includes/format_journal_row.html:14
 #: app/templates/issue/grid.html:36
 msgid "Volume"
 msgstr ""
 
-#: app/admin/views.py:315 app/admin/views.py:375
+#: app/admin/views.py:342 app/admin/views.py:402
 #: app/templates/issue/grid.html:37
 msgid "Número"
 msgstr ""
 
-#: app/admin/views.py:318
+#: app/admin/views.py:345
 msgid "Tipo"
 msgstr ""
 
-#: app/admin/views.py:319
+#: app/admin/views.py:346
 msgid "Texto do suplemento"
 msgstr ""
 
-#: app/admin/views.py:320
+#: app/admin/views.py:347
 msgid "Texto do especial"
 msgstr ""
 
-#: app/admin/views.py:321
+#: app/admin/views.py:348
 msgid "Mês inicial"
 msgstr ""
 
-#: app/admin/views.py:322
+#: app/admin/views.py:349
 msgid "Mês final"
 msgstr ""
 
-#: app/admin/views.py:323 app/templates/issue/grid.html:35
+#: app/admin/views.py:350 app/templates/issue/grid.html:35
 msgid "Ano"
 msgstr ""
 
-#: app/admin/views.py:324
+#: app/admin/views.py:351
 msgid "Etiqueta"
 msgstr ""
 
-#: app/admin/views.py:325
+#: app/admin/views.py:352
 msgid "Ordem"
 msgstr ""
 
-#: app/admin/views.py:326
+#: app/admin/views.py:353
 msgid "Legenda bibliográfica"
 msgstr ""
 
-#: app/admin/views.py:335
+#: app/admin/views.py:362
 msgid "Fascículo(s) publicado(s) com sucesso!!"
 msgstr ""
 
-#: app/admin/views.py:338 app/admin/views.py:412
+#: app/admin/views.py:365 app/admin/views.py:439
 #, python-format
 msgid "Ocorreu um erro tentando publicar o(s) fascículo(s)!!. Erro: %(ex)s"
 msgstr ""
 
-#: app/admin/views.py:348
+#: app/admin/views.py:375
 msgid "Fascículo(s) despublicado(s) com sucesso!!"
 msgstr ""
 
-#: app/admin/views.py:351 app/admin/views.py:425
+#: app/admin/views.py:378 app/admin/views.py:452
 #, python-format
 msgid "Ocorreu um erro tentando despublicar o(s) fascículo(s)!!. Erro: %(ex)s"
 msgstr ""
 
-#: app/admin/views.py:374
+#: app/admin/views.py:401
 msgid "Id Artigo"
 msgstr ""
 
-#: app/admin/views.py:378
+#: app/admin/views.py:405
 msgid "Seção"
 msgstr ""
 
-#: app/admin/views.py:379
+#: app/admin/views.py:406
 msgid "É AOP?"
 msgstr ""
 
-#: app/admin/views.py:382
+#: app/admin/views.py:409
 msgid "HTML's"
 msgstr ""
 
-#: app/admin/views.py:383
+#: app/admin/views.py:410
 msgid "Chave de domínio"
 msgstr ""
 
-#: app/admin/views.py:387
+#: app/admin/views.py:414
 msgid "Reconstruir HTML"
 msgstr ""
 
-#: app/admin/views.py:395
+#: app/admin/views.py:422
 msgid "Artigo(s) reconstruido com sucesso!!"
 msgstr ""
 
-#: app/admin/views.py:398
+#: app/admin/views.py:425
 #, python-format
 msgid "Ocorreu um erro tentando reconstruir o(s) artigo(s)!!. Erro: %(ex)s"
 msgstr ""
 
-#: app/admin/views.py:408
+#: app/admin/views.py:435
 msgid "Artigo(s) publicado com sucesso!!"
 msgstr ""
 
-#: app/admin/views.py:422
+#: app/admin/views.py:449
 msgid "Artigo(s) despublicado com sucesso!!"
 msgstr ""
 

--- a/config/testing.py
+++ b/config/testing.py
@@ -16,6 +16,11 @@ SQLALCHEMY_DATABASE_URI = 'sqlite:////%s' % DATABASE_PATH
 SQLALCHEMY_ECHO = False
 SQLALCHEMY_TRACK_MODIFICATIONS = False
 
+MONGODB_SETTINGS = {
+    'db': 'TESTING_opac_mongo',
+    # 'host': '127.0.0.1',
+    # 'port': 27017
+}
 
 # envio de emails
 MAIL_SERVER = 'localhost'
@@ -29,3 +34,5 @@ MAIL_DEFAULT_SENDER = 'webmaster.test@opac.scielo.org'
 MAIL_MAX_EMAILS = None
 # MAIL_SUPPRESS_SEND = default app.testing
 MAIL_ASCII_ATTACHMENTS = False
+
+DEBUG_TB_INTERCEPT_REDIRECTS = False

--- a/manager.py
+++ b/manager.py
@@ -4,7 +4,7 @@ import sys
 import os
 import unittest
 from app import create_app, dbsql, dbmongo, mail
-from opac_schema.v1.models import Journal, Issue, Article
+from opac_schema.v1.models import Collection, Sponsor, Journal, Issue, Article
 from app import utils, controllers
 from flask.ext.script import Manager, Shell
 from flask.ext.migrate import Migrate, MigrateCommand
@@ -18,7 +18,14 @@ manager.add_command('dbsql', MigrateCommand)
 
 
 def make_shell_context():
-    return dict(app=app, dbsql=dbsql, dbmongo=dbmongo, mail=mail, Journal=Journal, Issue=Issue, Article=Article)
+    app_models = {
+        'Collection': Collection,
+        'Sponsor': Sponsor,
+        'Journal': Journal,
+        'Issue': Issue,
+        'Article': Article,
+    }
+    return dict(app=app, dbsql=dbsql, dbmongo=dbmongo, mail=mail, **app_models)
 manager.add_command("shell", Shell(make_context=make_shell_context))
 
 


### PR DESCRIPTION
## Objetivos do PR:

1. Importar o novo modelo (OPAC schema) que armazena metadados da Coleção (ver: [0]);
2. Importar o novo *Documento* (OPAC schema) que armazena metadados de Sponsor (ver: [0]);
3. Implementar a capacidade de associar um ou mais sponsors a uma coleção (via ``/admin/``).

## Por onde deve começar a revisão?:

- `` app/admin/views.py`` aonde são definidas as novas views de Admin, para coleção e financiador;
- ``app/__init__.py`` aonde estão associadas as novas views com o app.

## Como pode ser testado manualmente?

**IMPORANTE:** veja abaixo os pré-requisitos.

1. acessar no admin com usuário válido;
2. pelo menu acessar em *Sponsors*/*Financiadores*;
3. criar alguns financiadores;
4. pelo menu acessar a: *Collections*/*Coleções*;
5. deve existir uma coleção criada, acesse para editar essa coleção;
6. associar um ou mais financiadores na coleção.

## Pré-requisitos:
- é necessário ter a versão mais recente do pacote: ``opac_schema``, pode instalar a última versão executando: ``pip install -e git+git@github.com:scieloorg/opac_schema.git#egg=opac_schema``;
- é necessário ter instalado o dump mais recente do banco de dados mongo.
 
## Issues relacionados:
- FIXES: #17 ;
- https://github.com/scieloorg/opac_schema/issues/4.
