### PR TITLE
Agregados tests para main.errors

### DIFF
--- a/tests/test_main_errors.py
+++ b/tests/test_main_errors.py
@@ -1,0 +1,50 @@
+# coding: utf-8
+
+from flask.ext.testing import TestCase
+from flask import current_app, abort
+from app import dbsql
+
+
+class ErrorsTestCase(TestCase):
+
+    def setUp(self):
+        dbsql.create_all()
+
+    def create_app(self):
+        return current_app
+
+    def tearDown(self):
+        dbsql.session.remove()
+        dbsql.drop_all()
+
+    @current_app.route('/forbidden')
+    def forbidden_page():
+        abort(403)
+
+    @current_app.route('/page_not_found')
+    def page_not_found():
+        abort(404)
+
+    @current_app.route('/internal_server_error')
+    def internal_server_error():
+        1 // 0
+
+    def test_forbidden(self):
+        response = self.client.get('/forbidden')
+        self.assert_403(response)
+        self.assertEqual('text/html; charset=utf-8', response.content_type)
+        self.assert_template_used("errors/403.html")
+
+    def test_page_not_found(self):
+        response = self.client.get('/page_not_found')
+        self.assert_404(response)
+        self.assertEqual('text/html; charset=utf-8', response.content_type)
+        self.assert_template_used("errors/404.html")
+
+    def test_internal_server_error(self):
+        current_app.config['DEBUG'] = False
+        current_app.config['PROPAGATE_EXCEPTIONS'] = False
+        response = self.client.get('/internal_server_error')
+        self.assert_500(response)
+        self.assertEqual('text/html; charset=utf-8', response.content_type)
+        self.assert_template_used("errors/500.html")

--- a/tests/test_main_errors.py
+++ b/tests/test_main_errors.py
@@ -35,11 +35,25 @@ class ErrorsTestCase(TestCase):
         self.assertEqual('text/html; charset=utf-8', response.content_type)
         self.assert_template_used("errors/403.html")
 
+    def test_forbidden_json(self):
+        response = self.client.get('/forbidden',
+                                   headers={'Accept': 'application/json'})
+        self.assert_403(response)
+        self.assertEqual('application/json', response.content_type)
+        self.assertEquals(response.json, {'error': 'forbidden'})
+
     def test_page_not_found(self):
         response = self.client.get('/page_not_found')
         self.assert_404(response)
         self.assertEqual('text/html; charset=utf-8', response.content_type)
         self.assert_template_used("errors/404.html")
+
+    def test_page_not_found_json(self):
+        response = self.client.get('/page_not_found',
+                                   headers={'Accept': 'application/json'})
+        self.assert_404(response)
+        self.assertEqual('application/json', response.content_type)
+        self.assertEquals(response.json, {'error': 'not found'})
 
     def test_internal_server_error(self):
         current_app.config['DEBUG'] = False
@@ -48,3 +62,12 @@ class ErrorsTestCase(TestCase):
         self.assert_500(response)
         self.assertEqual('text/html; charset=utf-8', response.content_type)
         self.assert_template_used("errors/500.html")
+
+    def test_internal_server_error_json(self):
+        current_app.config['DEBUG'] = False
+        current_app.config['PROPAGATE_EXCEPTIONS'] = False
+        response = self.client.get('/internal_server_error',
+                                   headers={'Accept': 'application/json'})
+        self.assert_500(response)
+        self.assertEqual('application/json', response.content_type)
+        self.assertEquals(response.json, {'error': 'internal server error'})


### PR DESCRIPTION
Para que el test del error 500 funcione como debe ser (un verdadero internal server error) fue necesario cambiar la configuración:

```current_app.config['DEBUG'] = False``` Esto porque con un valor de ```True``` flask nos muestra el log del error en lugar del error personalizado

```current_app.config['TESTING'] = False``` Esto porque con un valor de ```True```:
```What it does is disabling the error catching during request handling so that you get better error reports when performing test requests against the application```(http://flask.pocoo.org/docs/0.10/testing/)
Lo que provoca que el error no sea mostrado durante el request que es el momento en el cual ocurre el error 500 y se puede hacer el manejo del error personalizado.

También se puede forzar el error con un ```abort(500)``` y en este caso no hay que cambiar la configuración, pero en realidad no ha ocurrido un ```internal server error```