### PR TITLE
Agregados tests para notifications

### DIFF
--- a/app/notifications.py
+++ b/app/notifications.py
@@ -7,6 +7,7 @@
 
 from flask import url_for, render_template
 import utils
+import six
 
 
 def send_confirmation_email(recipient_email):
@@ -14,9 +15,9 @@ def send_confirmation_email(recipient_email):
     Envia um email de confirmação para ``recipient_email``
     Retorna:
      - (True, '') em caso de sucesso.
-     - (Flase, 'MENSAGEM DE ERRO/EXCEÇÃO') em caso de exceção/erro
+     - (False, 'MENSAGEM DE ERRO/EXCEÇÃO') em caso de exceção/erro
     """
-    if not recipient_email:
+    if not isinstance(recipient_email, six.string_types) or not utils.REGEX_EMAIL.match(recipient_email):
         raise ValueError(u'recipient_email é inválido!')
     try:
         ts = utils.get_timed_serializer()
@@ -37,8 +38,10 @@ def send_reset_password_email(recipient_email):
     Envia um email com as intruccões para recuperar a senha para: ``recipient_email``
     Retorna:
      - (True, '') em caso de sucesso.
-     - (Flase, 'MENSAGEM DE ERRO/EXCEÇÃO') em caso de exceção/erro
+     - (False, 'MENSAGEM DE ERRO/EXCEÇÃO') em caso de exceção/erro
     """
+    if not isinstance(recipient_email, six.string_types) or not utils.REGEX_EMAIL.match(recipient_email):
+        raise ValueError(u'recipient_email é inválido!')
     try:
         ts = utils.get_timed_serializer()
         token = ts.dumps(recipient_email, salt='recover-key')

--- a/app/utils.py
+++ b/app/utils.py
@@ -6,8 +6,10 @@ from itsdangerous import URLSafeTimedSerializer
 from flask_mail import Message
 from flask import current_app
 from . import dbsql, controllers, mail, models
+import re
 
 CSS = "/static/css/style_article_html.css"  # caminho para o CSS a ser incluído no HTML do artigo
+REGEX_EMAIL = re.compile(r"[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?", re.IGNORECASE) #RFC 2822 (simplified)
 
 
 def get_timed_serializer():

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,3 +1,4 @@
 Flask-DebugToolbar==0.10.0
 Flask-Testing==0.4.2
 coverage==4.0.3
+mock==1.3.0

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,4 +1,4 @@
 Flask-DebugToolbar==0.10.0
 Flask-Testing==0.4.2
-coverage==4.0.3
 mock==1.3.0
+coverage==4.0.3

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -1,0 +1,91 @@
+# coding: utf-8
+
+from flask import url_for, render_template
+from app.notifications import send_confirmation_email, send_reset_password_email
+from app import utils
+from base import BaseTestCase
+from mock import patch
+from itsdangerous import URLSafeTimedSerializer
+
+
+class NotificationsTestCase(BaseTestCase):
+
+    def test_empty_recipient_email(self):
+
+        recipient_email = None
+
+        with self.assertRaises(ValueError):
+            send_confirmation_email(recipient_email)
+
+        with self.assertRaises(ValueError):
+            send_reset_password_email(recipient_email)
+
+    def test_invalid_recipient_email(self):
+
+        recipient_email = 'foo@bar'
+
+        with self.assertRaises(ValueError):
+            send_confirmation_email(recipient_email)
+
+        with self.assertRaises(ValueError):
+            send_reset_password_email(recipient_email)
+
+    def test_invalid_token(self):
+
+        recipient_email = 'foo@bar.baz'
+
+        with patch('app.utils.get_timed_serializer') as mock:
+            mock.return_value = URLSafeTimedSerializer(None)
+
+            expected = None
+            try:
+                ts = utils.get_timed_serializer()
+                ts.dumps(recipient_email)
+            except Exception, e:
+                expected = (False, 'Invalid Token: %s' % str(e))
+
+            result = send_confirmation_email(recipient_email)
+            self.assertEqual(expected, result)
+
+            result = send_reset_password_email(recipient_email)
+            self.assertEqual(expected, result)
+
+    def test_send_confirmation_email(self):
+
+        recipient_email = 'foo@bar.baz'
+        ts = utils.get_timed_serializer()
+        token = ts.dumps(recipient_email, salt='email-confirm-key')
+        confirm_url = url_for('admin.confirm_email', token=token, _external=True)
+
+        with patch('app.utils.send_email') as mock:
+
+            result = send_confirmation_email(recipient_email)
+            expected = (True, '')
+
+            mock.assert_called_with(
+                recipient_email,
+                "Confirmação de email",
+                render_template('email/activate.html', confirm_url=confirm_url)
+            )
+
+            self.assertEqual(expected, result)
+
+    def test_send_reset_password_email(self):
+
+        recipient_email = 'foo@bar.baz'
+        ts = utils.get_timed_serializer()
+        token = ts.dumps(recipient_email, salt='recover-key')
+        recover_url = url_for('admin.reset_with_token', token=token, _external=True)
+
+        with patch('app.utils.send_email') as mock:
+
+            result = send_reset_password_email(recipient_email)
+            expected = (True, '')
+
+            mock.assert_called_with(
+                recipient_email,
+                "Instruções para recuperar sua senha",
+                render_template('email/recover.html', recover_url=recover_url)
+            )
+
+            self.assertEqual(expected, result)


### PR DESCRIPTION
Fix #95

Cobertura de las pruebas de 87%, no se bien como reproducir las excepciones:
https://github.com/scieloorg/opac/blob/master/app/notifications.py#L24
https://github.com/scieloorg/opac/blob/master/app/notifications.py#L45

Hasta donde veo solo se podría reproducir una excepción  de [Bad Data,](http://pythonhosted.org/itsdangerous/#itsdangerous.BadData) pero ahora se verifica que `recipient_email` sea un correo electrónico válido, entonces no si se exista otra forma de entrar a la excepciones? 