### PR TITLE
#254 - remover redes socials periodicos

### DIFF
--- a/opac/manager.py
+++ b/opac/manager.py
@@ -29,8 +29,8 @@ from webapp import create_app, dbsql, dbmongo, mail
 from opac_schema.v1.models import Collection, Sponsor, Journal, Issue, Article
 from webapp import controllers
 from webapp.utils import reset_db, create_db_tables, create_user, create_image
-from flask.ext.script import Manager, Shell
-from flask.ext.migrate import Migrate, MigrateCommand
+from flask_script import Manager, Shell
+from flask_migrate import Migrate, MigrateCommand
 from webapp.admin.forms import EmailForm
 from flask import current_app
 

--- a/opac/tests/base.py
+++ b/opac/tests/base.py
@@ -10,7 +10,7 @@ import subprocess
 import pymongo
 from opac_schema.v1 import models as schema_models
 from flask import current_app
-from flask.ext.testing import TestCase
+from flask_testing import TestCase
 from webapp import dbsql
 
 

--- a/opac/tests/test_admin_custom_filters.py
+++ b/opac/tests/test_admin_custom_filters.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 
 from base import BaseTestCase
-from flask.ext.admin.contrib.mongoengine.tools import parse_like_term
+from flask_admin.contrib.mongoengine.tools import parse_like_term
 from flask_babelex import lazy_gettext as __
 from uuid import uuid4
 from webapp.admin.custom_filters import (

--- a/opac/tests/test_admin_views.py
+++ b/opac/tests/test_admin_views.py
@@ -2,7 +2,7 @@
 
 import unittest
 import re
-from flask.ext.testing import TestCase
+from flask_testing import TestCase
 from flask import current_app, url_for, g
 from flask_admin.contrib.sqla import form as admin_form
 from flask_login import current_user, login_user

--- a/opac/tests/test_interface_journal_home.py
+++ b/opac/tests/test_interface_journal_home.py
@@ -88,3 +88,165 @@ class JournalHomeTestCase(BaseTestCase):
 
             self.assertIn(u"This journal is aiming xpto",
                           response.data.decode('utf-8'))
+
+    def test_journal_without_social_networks_show_no_links(self):
+        """
+        COM:
+            - Periódico sem redes socials
+        QUANDO:
+            - Acessarmos a home do periódico
+        VERIFICAMOS:
+            - Que não aparece a seção de redes sociais
+            - O div com class="journalLinks" deve aparecer
+        """
+
+        with current_app.app_context():
+            # with
+            collection = utils.makeOneCollection()
+            journal = utils.makeOneJournal({'collection': collection})
+            with self.client as c:
+                # when
+                response = c.get(url_for('main.journal_detail', journal_id=journal.jid))
+                # then
+                self.assertEqual(journal.social_networks, [])
+                self.assertStatus(response, 200)
+                social_networks_class = u"journalLinks"
+                self.assertIn(social_networks_class, response.data.decode('utf-8'))
+                twitter_btn_class = u"bigTwitter"
+                self.assertNotIn(twitter_btn_class, response.data.decode('utf-8'))
+                facebook_btn_class = u"bigFacebook"
+                self.assertNotIn(facebook_btn_class, response.data.decode('utf-8'))
+                google_btn_class = u"bigGooglePlus"
+                self.assertNotIn(google_btn_class, response.data.decode('utf-8'))
+
+    def test_journal_with_twitter_social_networks_show_links(self):
+        """
+        COM:
+            - Periódico COM redes socials
+        QUANDO:
+            - Acessarmos a home do periódico
+        VERIFICAMOS:
+            - Que SIM aparece a seção de redes sociais
+            - O div com class="journalLinks" deve aparecer
+        """
+
+        with current_app.app_context():
+            # with
+            collection = utils.makeOneCollection()
+            journal_data = {
+                'collection': collection,
+                'social_networks': [
+                    {
+                        'network': u'twitter',
+                        'account': u'http://twitter.com/@foo'
+                    }
+                ]
+            }
+            journal = utils.makeOneJournal(journal_data)
+            with self.client as c:
+                # when
+                response = c.get(url_for('main.journal_detail', journal_id=journal.jid))
+                # then
+                self.assertStatus(response, 200)
+                social_networks_class = u"journalLinks"
+                self.assertIn(social_networks_class, response.data.decode('utf-8'))
+                twitter_btn_class = u"bigTwitter"
+                self.assertIn(twitter_btn_class, response.data.decode('utf-8'))
+                facebook_btn_class = u"bigFacebook"
+                self.assertNotIn(facebook_btn_class, response.data.decode('utf-8'))
+                google_btn_class = u"bigGooglePlus"
+                self.assertNotIn(google_btn_class, response.data.decode('utf-8'))
+
+                expected_social_link = u'<a href="{account}" data-toggle="tooltip" title="{network}">'.format(
+                    account=journal_data['social_networks'][0]['account'],
+                    network=journal_data['social_networks'][0]['network'].title(),
+                )
+                self.assertIn(expected_social_link, response.data.decode('utf-8'))
+
+    def test_journal_with_facebook_social_networks_show_links(self):
+        """
+        COM:
+            - Periódico COM redes socials
+        QUANDO:
+            - Acessarmos a home do periódico
+        VERIFICAMOS:
+            - Que SIM aparece a seção de redes sociais
+            - O div com class="journalLinks" deve aparecer
+        """
+
+        with current_app.app_context():
+            # with
+            collection = utils.makeOneCollection()
+            journal_data = {
+                'collection': collection,
+                'social_networks': [
+                    {
+                        'network': u'facebook',
+                        'account': u'http://facebook.com/foo'
+                    }
+                ]
+            }
+            journal = utils.makeOneJournal(journal_data)
+            with self.client as c:
+                # when
+                response = c.get(url_for('main.journal_detail', journal_id=journal.jid))
+                # then
+                self.assertStatus(response, 200)
+                social_networks_class = u"journalLinks"
+                self.assertIn(social_networks_class, response.data.decode('utf-8'))
+                twitter_btn_class = u"bigTwitter"
+                self.assertNotIn(twitter_btn_class, response.data.decode('utf-8'))
+                facebook_btn_class = u"bigFacebook"
+                self.assertIn(facebook_btn_class, response.data.decode('utf-8'))
+                google_btn_class = u"bigGooglePlus"
+                self.assertNotIn(google_btn_class, response.data.decode('utf-8'))
+
+                expected_social_link = u'<a href="{account}" data-toggle="tooltip" title="{network}">'.format(
+                    account=journal_data['social_networks'][0]['account'],
+                    network=journal_data['social_networks'][0]['network'].title(),
+                )
+                self.assertIn(expected_social_link, response.data.decode('utf-8'))
+
+    def test_journal_with_googleplus_social_networks_show_links(self):
+        """
+        COM:
+            - Periódico COM redes socials
+        QUANDO:
+            - Acessarmos a home do periódico
+        VERIFICAMOS:
+            - Que SIM aparece a seção de redes sociais
+            - O div com class="journalLinks" deve aparecer
+        """
+
+        with current_app.app_context():
+            # with
+            collection = utils.makeOneCollection()
+            journal_data = {
+                'collection': collection,
+                'social_networks': [
+                    {
+                        'network': u'google',
+                        'account': u'http://plus.google.com/+foo'
+                    }
+                ]
+            }
+            journal = utils.makeOneJournal(journal_data)
+            with self.client as c:
+                # when
+                response = c.get(url_for('main.journal_detail', journal_id=journal.jid))
+                # then
+                self.assertStatus(response, 200)
+                social_networks_class = u"journalLinks"
+                self.assertIn(social_networks_class, response.data.decode('utf-8'))
+                twitter_btn_class = u"bigTwitter"
+                self.assertNotIn(twitter_btn_class, response.data.decode('utf-8'))
+                facebook_btn_class = u"bigFacebook"
+                self.assertNotIn(facebook_btn_class, response.data.decode('utf-8'))
+                google_btn_class = u"bigGooglePlus"
+                self.assertIn(google_btn_class, response.data.decode('utf-8'))
+
+                expected_social_link = u'<a href="{account}" data-toggle="tooltip" title="{network}">'.format(
+                    account=journal_data['social_networks'][0]['account'],
+                    network=journal_data['social_networks'][0]['network'].title(),
+                )
+                self.assertIn(expected_social_link, response.data.decode('utf-8'))

--- a/opac/tests/test_interface_menu.py
+++ b/opac/tests/test_interface_menu.py
@@ -76,12 +76,14 @@ class MenuTestCase(BaseTestCase):
         Verficamos que o link do menú "Sobre o Scielo" tem o css:
         "selected" quando acessamos a view "about"
         """
-        response = self.client.get(url_for('main.about_collection'))
+        with current_app.app_context():
+            collection = utils.makeOneCollection({'name': 'dummy collection'})
+            response = self.client.get(url_for('main.about_collection'))
 
-        self.assertStatus(response, 200)
-        self.assertTemplateUsed('collection/about.html')
-        expected_anchor = u'<a href="/collection/about"\n         class="btn single dropdown-toggle selected">\n        <span class="glyphBtn infoMenu"></span>\n        <span class="hidden-sm">Sobre o SciELO</span>'
-        self.assertIn(expected_anchor, response.data.decode('utf-8'))
+            self.assertStatus(response, 200)
+            self.assertTemplateUsed('collection/about.html')
+            expected_anchor = u'<a href="/collection/about"\n         class="btn single dropdown-toggle selected">\n        <span class="glyphBtn infoMenu"></span>\n        <span class="hidden-sm">Sobre o SciELO</span>'
+            self.assertIn(expected_anchor, response.data.decode('utf-8'))
 
     # Hamburger Menu
     def test_links_in_hamburger_menu(self):

--- a/opac/tests/test_main_views.py
+++ b/opac/tests/test_main_views.py
@@ -2,7 +2,7 @@
 import unittest
 import flask
 import warnings
-from flask.ext.testing import TestCase
+from flask_testing import TestCase
 from flask import url_for, request, g, current_app
 from webapp import create_app, dbsql, dbmongo
 

--- a/opac/tests/utils.py
+++ b/opac/tests/utils.py
@@ -83,6 +83,15 @@ def makeOneJournal(attrib=None):
     default_id = attrib.get('_id', str(uuid4().hex))
     default_title = "journal-%s" % default_id
 
+    if 'social_networks' in attrib.keys():
+        social_networks = []
+        for sn in attrib['social_networks']:
+            social_account = models.SocialNetwork(
+                account=sn['account'],
+                network=sn['network'])
+            social_networks.append(social_account)
+        attrib['social_networks'] = social_networks
+
     journal = {
         '_id': default_id,
         'jid': attrib.get('jid', default_id),

--- a/opac/webapp/__init__.py
+++ b/opac/webapp/__init__.py
@@ -16,15 +16,13 @@ from werkzeug.contrib.fixers import ProxyFix
 import jinja_filters
 from opac_schema.v1.models import Collection, Sponsor, Journal, Issue, Article, Resource, News, Pages
 
+
+login_manager = LoginManager()
 assets = Environment()
 dbmongo = MongoEngine()
 dbsql = SQLAlchemy()
 mail = Mail()
 babel = Babel()
-
-login_manager = LoginManager()
-login_manager.session_protection = 'strong'
-login_manager.login_view = 'admin.login_view'
 
 
 def create_app():
@@ -36,6 +34,10 @@ def create_app():
     # Configurações
     app.config.from_object('webapp.config.default')  # Configuração basica
     app.config.from_envvar('OPAC_CONFIG', silent=True)  # configuração do ambiente
+    # login
+    login_manager.session_protection = 'strong'
+    login_manager.login_view = 'admin.login_view'
+    login_manager.init_app(app)
 
     # Minificando o HTML
     if not app.config['DEBUG']:
@@ -62,9 +64,7 @@ def create_app():
     assets.init_app(app)
     # i18n
     babel.init_app(app)
-    # login
-    login_manager.init_app(app)
-
+    # Debug Toolbar
     if app.config['DEBUG']:
         # Toolbar
         from flask_debugtoolbar import DebugToolbarExtension

--- a/opac/webapp/__init__.py
+++ b/opac/webapp/__init__.py
@@ -2,7 +2,7 @@
 import os
 
 from flask import Flask
-from flask.ext.htmlmin import HTMLMIN
+from flask_htmlmin import HTMLMIN
 from flask_assets import Environment, Bundle
 from flask_mongoengine import MongoEngine
 from flask_login import LoginManager

--- a/opac/webapp/admin/custom_filters.py
+++ b/opac/webapp/admin/custom_filters.py
@@ -1,11 +1,11 @@
 # coding: utf-8
 
-from flask.ext.admin.contrib.mongoengine.filters import (
+from flask_admin.contrib.mongoengine.filters import (
     FilterEqual, FilterNotEqual, FilterLike, FilterNotLike,
     FilterEmpty, FilterInList, FilterNotInList, FilterConverter)
-from flask.ext.admin.contrib.mongoengine.tools import parse_like_term
-from flask.ext.admin.model import filters
-from flask.ext.admin.contrib import sqla
+from flask_admin.contrib.mongoengine.tools import parse_like_term
+from flask_admin.model import filters
+from flask_admin.contrib import sqla
 from mongoengine import ReferenceField, EmbeddedDocumentField, ListField, StringField
 from mongoengine.queryset import Q
 from opac_schema.v1.models import Journal, Issue

--- a/opac/webapp/admin/views.py
+++ b/opac/webapp/admin/views.py
@@ -17,8 +17,8 @@ from wtforms import fields as wtforms_fields
 from flask_admin.model.form import InlineFormAdmin
 import flask_login as login
 from flask import url_for, redirect, request, flash, abort, current_app
-from flask.ext.admin.contrib import sqla, mongoengine
-from flask.ext.admin.contrib.mongoengine.tools import parse_like_term
+from flask_admin.contrib import sqla, mongoengine
+from flask_admin.contrib.mongoengine.tools import parse_like_term
 from mongoengine import StringField, EmailField, URLField, ReferenceField, EmbeddedDocumentField
 from mongoengine.base.datastructures import BaseList
 

--- a/opac/webapp/config/default.py
+++ b/opac/webapp/config/default.py
@@ -209,3 +209,21 @@ RSS_NEWS_FEEDS = {
     'url': 'http://blog.scielo.org/en/feed/',
   },
 }
+
+# paineis do flask-debug-toolbar somente ativos quando DEBUG = True
+
+DEBUG_TB_PANELS = [
+    # default:
+    'flask_debugtoolbar.panels.versions.VersionDebugPanel',
+    'flask_debugtoolbar.panels.timer.TimerDebugPanel',
+    'flask_debugtoolbar.panels.headers.HeaderDebugPanel',
+    'flask_debugtoolbar.panels.request_vars.RequestVarsDebugPanel',
+    'flask_debugtoolbar.panels.config_vars.ConfigVarsDebugPanel',
+    'flask_debugtoolbar.panels.template.TemplateDebugPanel',
+    'flask_debugtoolbar.panels.sqlalchemy.SQLAlchemyDebugPanel',
+    'flask_debugtoolbar.panels.logger.LoggingPanel',
+    'flask_debugtoolbar.panels.route_list.RouteListDebugPanel',
+    'flask_debugtoolbar.panels.profiler.ProfilerDebugPanel',
+    # Mongo:
+    'flask_mongoengine.panels.MongoDebugPanel'
+]

--- a/opac/webapp/controllers.py
+++ b/opac/webapp/controllers.py
@@ -14,7 +14,7 @@ import cStringIO
 from opac_schema.v1.models import Journal, Issue, Article, Collection, News, Pages
 from flask import current_app, url_for
 from flask_babelex import lazy_gettext as __
-from flask.ext.mongoengine import Pagination
+from flask_mongoengine import Pagination
 from webapp import dbsql
 from models import User
 from choices import INDEX_NAME

--- a/opac/webapp/main/views.py
+++ b/opac/webapp/main/views.py
@@ -28,7 +28,7 @@ def url_external(endpoint, **kwargs):
     return urljoin(request.url_root, url)
 
 
-@main.before_request
+@main.before_app_request
 def add_collection_to_g():
     if not hasattr(g, 'collection'):
         try:
@@ -515,7 +515,7 @@ def about_collection():
 
     context = {}
 
-    for page in g.collection.about:
+    for page in g.collection.get('about', []):
         if page.language == language:
             context = {'content': page.content}
 

--- a/opac/webapp/main/views.py
+++ b/opac/webapp/main/views.py
@@ -32,10 +32,11 @@ def url_external(endpoint, **kwargs):
 def add_collection_to_g():
     if not hasattr(g, 'collection'):
         try:
-            g.collection = controllers.get_current_collection()
+            collection = controllers.get_current_collection()
+            setattr(g, 'collection', collection)
         except Exception, e:
             # discutir o que fazer aqui
-            g.collection = {}
+            setattr(g, 'collection', {})
 
 
 @babel.localeselector
@@ -515,7 +516,7 @@ def about_collection():
 
     context = {}
 
-    for page in g.collection.get('about', []):
+    for page in getattr(g.collection, 'about', []):
         if page.language == language:
             context = {'content': page.content}
 

--- a/opac/webapp/models.py
+++ b/opac/webapp/models.py
@@ -11,7 +11,7 @@ from sqlalchemy.event import listens_for
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy_utils.types.choice import ChoiceType
 from werkzeug.security import generate_password_hash, check_password_hash
-from flask.ext.login import UserMixin
+from flask_login import UserMixin
 from flask import current_app
 from webapp.utils import thumbgen_filename
 from . import dbsql as db

--- a/opac/webapp/templates/journal/includes/contact_footer.html
+++ b/opac/webapp/templates/journal/includes/contact_footer.html
@@ -5,33 +5,54 @@
         <span class="glyphBtn pin"></span>
       </div>
       <div class="col-md-10 col-sm-9">
-        <strong>{{ journal['publisher_name'] }}</strong>
-        {% if journal['publisher_address'] %}
-          {{ journal['publisher_address'] }} -
+        <strong>{{ journal.publisher_name }}</strong>
+        {% if journal.publisher_address %}
+          {{ journal.publisher_address }} -
         {% endif %}
-        {% if journal['publisher_city'] %}
-          {{ journal['publisher_city'] }} -
+        {% if journal.publisher_city %}
+          {{ journal.publisher_city }} -
         {% endif %}
-        {% if journal['publisher_state'] %}
-           {{ journal['publisher_state'] }} -
+        {% if journal.publisher_state %}
+           {{ journal.publisher_state }} -
         {% endif %}
-        {% if journal['publisher_country'] %}
-           {{ journal['publisher_country'] }} <br/>
+        {% if journal.publisher_country %}
+           {{ journal.publisher_country }} <br/>
         {% endif %}
-        {% if journal['publisher_telephone'] %}
-          Tel/Fax: {{ journal['publisher_telephone'] }}
+        {% if journal.publisher_telephone %}
+          Tel/Fax: {{ journal.publisher_telephone }}
         {% endif %}
       </div>
     </div>
     <div class="col-md-4 col-sm-4 journalLinks">
-      <a href="#" class="showTooltip" title="Facebook"><span class="glyphBtn bigFacebook"></span></a>
-      <a href="#" class="showTooltip" title="Twitter"><span class="glyphBtn bigTwitter"></span></a>
-      <a href="#" class="showTooltip" title="Google+"><span class="glyphBtn bigGooglePlus"></span></a>
-      <span class="text">{% trans %}Siga este periódico nas redes sociais{% endtrans %}</span>
+      {% for sn in journal.social_networks %}
+        <a href="{{sn.account}}" data-toggle="tooltip" title="{{sn.network|title}}">
+          <span
+            {% with network = sn.network|lower  %}
+              {% if network == 'twitter' %}
+                 class="glyphBtn bigTwitter"
+              {% elif network == 'facebook' %}
+                 class="glyphBtn bigFacebook"
+              {% elif network == 'google+' or network == 'google' %}
+                 class="glyphBtn bigGooglePlus"
+              {% else %}
+                 class="glyphBtn"
+              {% endif %}
+            {% endwith %}
+            >
+          </span>
+        </a>
+        {% if loop.last %}
+          <span class="text">{% trans %}Siga este periódico nas redes sociais{% endtrans %}</span>
+        {% endif %}
+      {% endfor %}
     </div>
     <div class="col-md-3 col-sm-3 journalLinks">
-      <a href="{{ url_for('main.journal_feed', journal_id=journal.jid)}}" class="showTooltip" title="Atom" target="_blank"><span class="glyphBtn bigRSS"></span></a>
-      <span class="text" style="width: 70%;">{% trans %}Acompanhe os números deste periódico no seu leitor de RSS{% endtrans %}</span>
+      <a href="{{ url_for('main.journal_feed', journal_id=journal.jid)}}" data-toggle="tooltip" title="Atom" target="_blank">
+        <span class="glyphBtn bigRSS"></span>
+      </a>
+      <span class="text" style="width: 70%;">
+        {% trans %}Acompanhe os números deste periódico no seu leitor de RSS{% endtrans %}
+      </span>
     </div>
     <div class="clearfix"></div>
   </div>

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,6 +1,4 @@
 Flask-DebugToolbar==0.10.0
-Flask-Testing==0.4.2
-mock==1.3.0
-coverage==4.0.3
-requests==2.9.1
--e git+https://github.com/scieloorg/xylose@1.2.3#egg=xylose
+Flask-Testing==0.5.0
+mock==2.0.0
+coverage==4.1

--- a/requirements.production.txt
+++ b/requirements.production.txt
@@ -1,3 +1,3 @@
 chaussette==1.3.0
-gevent==1.1.0
-gunicorn
+gevent==1.1.1
+gunicorn==19.6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,22 +1,22 @@
-Flask==0.10.1
+Flask==0.11.1
 mongoengine==0.10.0
-flask-mongoengine==0.7.4
+flask-mongoengine==0.7.5
 Flask-Assets==0.11
-jsmin==2.1.6
+jsmin==2.2.1
 cssmin==0.2.0
 webassets==0.11.1
-Flask-Admin==1.4.0
+Flask-Admin==1.4.2
 Flask-SQLAlchemy==2.1
-SQLAlchemy-Utils==0.32.1
-Flask-Security==1.7.4
+SQLAlchemy-Utils==0.32.9
+Flask-Security==1.7.5
 Flask-Login==0.3.2
 Flask-Script==2.0.5
 Flask-Mail==0.9.1
-Pillow==3.1.1
-Flask-BabelEx==0.9.2
-Flask-Migrate==1.7.0
+Pillow==3.3.0
+Flask-BabelEx==0.9.3
+Flask-Migrate==1.8.1
 unicodecsv==0.14.1
 feedparser==5.2.1
 -e git+https://git@github.com/scieloorg/opac_schema@v2.10#egg=opac_schema
 # -e git+https://git@github.com/scieloorg/opac@v0.8-dev#egg=opac
-Flask-HTMLmin==1.1
+Flask-HTMLmin==1.2


### PR DESCRIPTION
FIX: #254 

- atualização de dependências
- ajustes nos imports (``flask.ext.*`` levanta DeprecationWarning a partir de ``Flask==0.11``)
- Flask debug toolbar agora mostra as queries do MongoDB (quando ``DEBUG=True``)
- As redes sociais do Periódico, serão exibidas somente quando são cadastradas.