### PR TITLE
Several interface itens

### DIFF
--- a/opac/tests/test_interface_menu.py
+++ b/opac/tests/test_interface_menu.py
@@ -32,7 +32,7 @@ class MenuTestCase(BaseTestCase):
 
         self.assertStatus(response, 200)
         self.assertTemplateUsed('collection/list_journal.html')
-        expected_anchor = u'<a href="/journals/#alpha">\n              Lista alfabética de periódicos\n            </a>'
+        expected_anchor = u'<a href="/journals/#alpha" class="tab_link">\n              Lista alfab\xe9tica de peri\xf3dicos\n            </a>'
         self.assertIn(expected_anchor, response.data.decode('utf-8'))
 
     def test_theme_link_is_selected_for_list_theme(self):
@@ -44,7 +44,7 @@ class MenuTestCase(BaseTestCase):
 
         self.assertStatus(response, 200)
         self.assertTemplateUsed('collection/list_journal.html')
-        expected_anchor = u'<a href="/journals/#theme">\n              Lista temática de periódicos\n            </a>'
+        expected_anchor = u'<a href="/journals/#theme" class="tab_link">\n              Lista temática de periódicos\n            </a>'
         self.assertIn(expected_anchor, response.data.decode('utf-8'))
 
     def test_institution_link_is_selected_for_list_institution(self):
@@ -56,7 +56,7 @@ class MenuTestCase(BaseTestCase):
 
         self.assertStatus(response, 200)
         self.assertTemplateUsed('collection/list_journal.html')
-        expected_anchor = u'<a href="/journals/#publisher">\n              Lista de periódicos por editoras\n            </a>'
+        expected_anchor = u'<a href="/journals/#publisher" class="tab_link">\n              Lista de periódicos por editoras\n            </a>'
         self.assertIn(expected_anchor, response.data.decode('utf-8'))
 
     # Hamburger Menu
@@ -74,11 +74,11 @@ class MenuTestCase(BaseTestCase):
                 self.assertStatus(response, 200)
                 expected_anchor1 = u"""<a href="%s">\n        <strong>%s</strong>""" % (url_for('.index'), collection.name or __('NOME DA COLEÇÃO!!'))
                 self.assertIn(expected_anchor1, response_data)
-                expected_anchor2 = u"""<li>\n            <a href="%s">\n              %s\n            </a>\n          </li>""" % (url_for('.collection_list') + '#alpha', __(u'Lista alfabética de periódicos'))
+                expected_anchor2 = u"""<li>\n            <a href="%s" class="tab_link">\n              %s\n            </a>\n          </li>""" % (url_for('.collection_list') + '#alpha', __(u'Lista alfabética de periódicos'))
                 self.assertIn(expected_anchor2, response_data)
-                expected_anchor3 = u"""<li>\n            <a href="%s">\n              %s\n            </a>\n          </li>""" % (url_for('.collection_list') + '#theme', __(u'Lista temática de periódicos'))
+                expected_anchor3 = u"""<li>\n            <a href="%s" class="tab_link">\n              %s\n            </a>\n          </li>""" % (url_for('.collection_list') + '#theme', __(u'Lista temática de periódicos'))
                 self.assertIn(expected_anchor3, response_data)
-                expected_anchor4 = u"""<li>\n            <a href="%s">\n              %s\n            </a>\n          </li>""" % (url_for('.collection_list') + '#publisher', __(u'Lista de periódicos por editoras'))
+                expected_anchor4 = u"""<li>\n            <a href="%s" class="tab_link">\n              %s\n            </a>\n          </li>""" % (url_for('.collection_list') + '#publisher', __(u'Lista de periódicos por editoras'))
                 self.assertIn(expected_anchor4, response_data)
                 expected_anchor5 = u"""<li>\n            <a href="%s">\n              %s\n            </a>\n          </li>""" % (url_for('.search'), __(u'Busca'))
                 self.assertIn(expected_anchor5, response_data)

--- a/opac/webapp/controllers.py
+++ b/opac/webapp/controllers.py
@@ -318,14 +318,20 @@ def get_journals_grouped_by(grouper_field, title_query='', query_filter='', is_p
 def get_journal_generator_for_csv(list_type='alpha', title_query='', is_public=True, order_by='title_slug'):
 
     def format_csv_row(list_type, journal):
+
+        last_issue_volume = journal.last_issue.volume or ''
+        last_issue_number = journal.last_issue.number or ''
+        last_issue_year = journal.last_issue.year or ''
+
         common_fields = [
             unicode(journal.title),
             unicode(journal.issue_count),
-            unicode(journal.last_issue.volume) or u'',
-            unicode(journal.last_issue.number) or u'',
-            unicode(journal.last_issue.year) or u'',
+            unicode(last_issue_volume) or u'',
+            unicode(last_issue_number) or u'',
+            unicode(last_issue_year) or u'',
             unicode(journal.current_status == 'current'),
         ]
+
         if list_type == 'alpha':
             return common_fields
         elif list_type == 'areas':
@@ -335,7 +341,7 @@ def get_journal_generator_for_csv(list_type='alpha', title_query='', is_public=T
         else:  # publisher_name
             return [journal.publisher_name] + common_fields
 
-    common_headers = ['Title', '# issues', 'Last volume', 'Last number', 'Last year', 'Is active?']
+    common_headers = ['Title', 'issues', 'Last volume', 'Last number', 'Last year', 'Is active?']
     if list_type == 'alpha':
         CSV_HEADERS = common_headers
         order_by = 'title'

--- a/opac/webapp/main/views.py
+++ b/opac/webapp/main/views.py
@@ -273,7 +273,7 @@ def journal_feed(url_seg):
         if feed_language not in article.languages:
             article_lang = article.original_language
 
-        feed.add(article.title,
+        feed.add(article.title or 'NO TITLE',
                  render_template("issue/feed_content.html", article=article),
                  content_type='html',
                  author=article.authors,

--- a/opac/webapp/templates/article/includes/alternative_header.html
+++ b/opac/webapp/templates/article/includes/alternative_header.html
@@ -32,7 +32,7 @@
                   </a>
                   <ul class="dropdown-menu" role="menu">
                     <li class="dropdown-header">
-                      {{journal.short_title}} {% trans %}vol.{% endtrans %}{{ journal.last_issue.volume }} {% trans %}no.{% endtrans %}{{ journal.last_issue.number }} {{ journal.last_issue.publisher_city }} {{ journal.last_issue.start_month }}/{{ journal.last_issue.end_month }} {{ journal.last_issue.year }}
+                      {{ article.legend }}
                     </li>
                     <li><strong>{{ article.get_title_by_lang(session.lang) }}</strong></li>
                     <li class="author">H. Rodríguez-Angulo; J. Toro-Mendoza; J. Marques; R. Bonfante-Cabarcas; A. Mijares;</li>

--- a/opac/webapp/templates/collection/includes/nav.html
+++ b/opac/webapp/templates/collection/includes/nav.html
@@ -6,17 +6,17 @@
       </a>
       <ul>
           <li>
-            <a href="{{ url_for('.collection_list') }}#alpha">
+            <a href="{{ url_for('.collection_list') }}#alpha" class="tab_link">
               {% trans %}Lista alfabética de periódicos{% endtrans %}
             </a>
           </li>
           <li>
-            <a href="{{ url_for('.collection_list') }}#theme">
+            <a href="{{ url_for('.collection_list') }}#theme" class="tab_link">
               {% trans %}Lista temática de periódicos{% endtrans %}
             </a>
           </li>
           <li>
-            <a href="{{ url_for('.collection_list') }}#publisher">
+            <a href="{{ url_for('.collection_list') }}#publisher" class="tab_link">
               {% trans %}Lista de periódicos por editoras{% endtrans %}
             </a>
           </li>

--- a/opac/webapp/templates/collection/index.html
+++ b/opac/webapp/templates/collection/index.html
@@ -31,13 +31,13 @@
             <div class="col-md-2 col-sm-2">
               <ul>
                 <li>
-                  <a href="{{ analytics.urls.downloads }}">{% trans %}Downloads{% endtrans %}</a>
+                  <a href="{{ analytics.urls.downloads }}" target="_blank">{% trans %}Downloads{% endtrans %}</a>
                 </li>
                 <li>
-                  <a href="{{ analytics.urls.references }}">{% trans %}Citações{% endtrans %}</a>
+                  <a href="{{ analytics.urls.references }}" target="_blank">{% trans %}Citações{% endtrans %}</a>
                 </li>
                 <li>
-                  <a href="{{ analytics.urls.other }}">{% trans %}Outros indicadores{% endtrans %}</a>
+                  <a href="{{ analytics.urls.other }}" target="_blank">{% trans %}Outros indicadores{% endtrans %}</a>
                 </li>
               </ul>
             </div>

--- a/opac/webapp/templates/collection/list_journal.html
+++ b/opac/webapp/templates/collection/list_journal.html
@@ -100,17 +100,6 @@
               </div>
             <!-- Theme content -->
 
-            <script id="template_collection_list_table" type="text/template">
-              {% with template_collection_list_table_body_id='template_collection_list_table_body' %}
-              {% include "collection/includes/tmpl_journal_list_grouper_table_container.html" %}
-              {% endwith %}
-            </script>
-
-            <script id="template_collection_list_table_body" type="text/template">
-              {% with template_journal_row_id='template_journal_row' %}
-              {% include "collection/includes/tmpl_journal_list_grouper_table_row.html" %}
-              {% endwith %}
-            </script>
         </div>
         <!-- Theme -->
 
@@ -127,18 +116,6 @@
               </div>
 
             </div>
-
-          <script id="template_collection_list_table" type="text/template">
-            {% with template_collection_list_table_body_id='template_collection_list_table_body' %}
-              {% include "collection/includes/tmpl_journal_list_grouper_table_container.html" %}
-            {% endwith %}
-          </script>
-
-          <script id="template_collection_list_table_body" type="text/template">
-            {% with template_journal_row_id='template_journal_row' %}
-              {% include "collection/includes/tmpl_journal_list_grouper_table_row.html" %}
-            {% endwith %}
-          </script>
 
         </div>
         <!-- Publisher -->
@@ -166,6 +143,18 @@
     </div>
   </section>
 
+  <script id="template_collection_list_table" type="text/template">
+    {% with template_collection_list_table_body_id='template_collection_list_table_body' %}
+      {% include "collection/includes/tmpl_journal_list_grouper_table_container.html" %}
+    {% endwith %}
+  </script>
+
+  <script id="template_collection_list_table_body" type="text/template">
+    {% with template_journal_row_id='template_journal_row' %}
+      {% include "collection/includes/tmpl_journal_list_grouper_table_row.html" %}
+    {% endwith %}
+  </script>
+
   <script id="template_journal_row" type="text/template">
     {% include "collection/includes/tmpl_journal_list_row.html" %}
   </script>
@@ -186,18 +175,61 @@
 
   <script>
 
+    var listAplhaInit = JournalListAlpha.initialize(
+      "{{ url_for('main.journals_search_alpha_ajax') }}",
+      "#template_journal_row",
+      "#journals_table_body",
+      "#query",
+      "query_filter",
+      ".collectionListLoading",
+      "#template_error_msg",
+      "#template_empty_msg"
+    );
+    /* Grandes áreas do conhecimento */
+    var listThemeInit = Object.create(JournalCategorizedList);
+    listThemeInit.initialize(
+        '#areas_list_table_container',
+        '#query_areas',
+        "query_filter_areas",
+        '.collectionListLoadingAreas',
+        'areas',
+        "{{ url_for('main.journals_search_by_theme_ajax') }}",
+        "#template_error_msg",
+        "#template_empty_msg",
+        "{% trans %}Título{% endtrans %}",
+        "{% trans %}grandes áreas{% endtrans %}"
+    );
+    /* Áreas temáticas do Web of Science */
+    var listWosInit = Object.create(JournalCategorizedList);
+    listWosInit.initialize(
+        '#wos_list_table_container',
+        '#query_wos',
+        "query_filter_wos",
+        '.collectionListLoadingWos',
+        'wos',
+        "{{ url_for('main.journals_search_by_theme_ajax') }}",
+        "#template_error_msg",
+        "#template_empty_msg",
+        "{% trans %}Título{% endtrans %}",
+        "{% trans %}áreas WOS{% endtrans %}"
+    );
+    var listPublisherInit = Object.create(JournalCategorizedList);
+    listPublisherInit.initialize(
+        '#list_table_container',
+        '#query_publisher',
+        "query_filter_publisher",
+        '.collectionListLoading',
+        'publisher',
+        "{{ url_for('main.journals_search_by_theme_ajax') }}",
+        "#template_error_msg",
+        "#template_empty_msg",
+        "{% trans %}Editoras{% endtrans %}",
+        "{% trans %}editoras{% endtrans %}"
+    )
+
     function listAlpha(){
 
-      var list = JournalListAlpha.initialize(
-          "{{ url_for('main.journals_search_alpha_ajax') }}",
-          "#template_journal_row",
-          "#journals_table_body",
-          "#query",
-          "query_filter",
-          ".collectionListLoading",
-          "#template_error_msg",
-          "#template_empty_msg"
-        ).search(true);
+      var list = listAplhaInit.search(true);
 
         /* download links */
         $('.collectionListDownloadXLS').click(function(event) {
@@ -213,36 +245,9 @@
 
     }
 
-    function listTheme(){
-      /* Grandes áreas do conhecimento */
-      var areas_list = Object.create(JournalCategorizedList);
-      areas_list.initialize(
-        '#areas_list_table_container',
-        '#query_areas',
-        "query_filter_areas",
-        '.collectionListLoadingAreas',
-        'areas',
-        "{{ url_for('main.journals_search_by_theme_ajax') }}",
-        "#template_error_msg",
-        "#template_empty_msg",
-        "{% trans %}Título{% endtrans %}",
-        "{% trans %}temas{% endtrans %}"
-      ).search();
+    function listThemeAreas(){
 
-      /* Áreas temáticas do Web of Science */
-      var wos_list = Object.create(JournalCategorizedList);
-      wos_list.initialize(
-        '#wos_list_table_container',
-        '#query_wos',
-        "query_filter_wos",
-        '.collectionListLoadingWos',
-        'wos',
-        "{{ url_for('main.journals_search_by_theme_ajax') }}",
-        "#template_error_msg",
-        "#template_empty_msg",
-        "{% trans %}Título{% endtrans %}",
-        "{% trans %}temas{% endtrans %}"
-      ).search();
+      var areas_list = listThemeInit.search();
 
       /* download links */
       $('#areas_list_table_container').on('results_loaded', function(event) {
@@ -257,6 +262,12 @@
           open_download_url(target_url, '#query_areas');
         });
       });
+
+    }
+
+    function listThemeWos(){
+
+      var wos_list = listWosInit.search();
 
       $('#temasWoS').on('results_loaded', function(event) {
         $('#temasWoS .collectionListDownloadXLS').click(function(event) {
@@ -275,19 +286,7 @@
 
     function listPublisher(){
 
-      var list = Object.create(JournalCategorizedList);
-      list.initialize(
-        '#list_table_container',
-        '#query_publisher',
-        "query_filter_publisher",
-        '.collectionListLoading',
-        'publisher',
-        "{{ url_for('main.journals_search_by_theme_ajax') }}",
-        "#template_error_msg",
-        "#template_empty_msg",
-        "{% trans %}Editoras{% endtrans %}",
-        "{% trans %}editoras{% endtrans %}"
-      ).search();
+      var list = listPublisherInit.search();
 
       /* download links */
       $('#list_table_container').on('results_loaded', function(event) {
@@ -308,7 +307,8 @@
     $(function() {
 
         $('.tab_link').each(function(){
-            $(this).click(function(){
+            $(this).click(function(event){
+                event.preventDefault();
                 hash = $(this).attr('href').replace(/^.*?#/,'');
                 $('[href=#' + hash + ']').tab('show');
             });
@@ -316,32 +316,44 @@
 
         // hash switch
         switch(window.location.hash) {
-          case '#alpha':
-              listAlpha()
-              break;
-          case '#theme':
-              listTheme()
-              break;
-          case '#publisher':
-              listPublisher()
-              break;
-          default:
-              listAlpha()
+            case '#alpha':
+                listAlpha();
+                break;
+            case '#theme':
+                listThemeAreas();
+                break;
+            case '#publisher':
+                listPublisher();
+                break;
+            case '#temasWoS':
+                listThemeWos();
+                break;
+            case '#areasConhecimento':
+                listThemeAreas();
+                break;
+            default:
+                listAlpha();
         }
 
       // tab ativa
       $('a[data-toggle="tab"]').on('shown.bs.tab', function (e) {
-        var target = $(e.target).attr("href")
+        var target = $(e.target).attr("href");
 
         switch(target) {
             case '#alpha':
-                listAlpha()
+                listAlpha();
                 break;
             case '#theme':
-                listTheme()
+                listThemeAreas();
                 break;
             case '#publisher':
-                listPublisher()
+                listPublisher();
+                break;
+             case '#temasWoS':
+                listThemeWos();
+                break;
+            case '#areasConhecimento':
+                listThemeAreas();
                 break;
             default:
                 listAlpha()

--- a/opac/webapp/templates/collection/list_journal.html
+++ b/opac/webapp/templates/collection/list_journal.html
@@ -307,6 +307,13 @@
 
     $(function() {
 
+        $('.tab_link').each(function(){
+            $(this).click(function(){
+                hash = $(this).attr('href').replace(/^.*?#/,'');
+                $('[href=#' + hash + ']').tab('show');
+            });
+        });
+
         // hash switch
         switch(window.location.hash) {
           case '#alpha':

--- a/opac/webapp/templates/issue/base.html
+++ b/opac/webapp/templates/issue/base.html
@@ -9,6 +9,5 @@
 
   {% include "includes/footer.html" %}
 
-  {% include "journal/includes/alternative_header.html" %}
 {% endblock %}
 

--- a/opac/webapp/templates/issue/grid.html
+++ b/opac/webapp/templates/issue/grid.html
@@ -106,4 +106,8 @@
 
   {% include "journal/includes/contact_footer.html" %}
 
+  {% with page='grid' %}
+    {% include "issue/includes/alternative_header.html" %}
+  {% endwith %}
+
 {% endblock %}

--- a/opac/webapp/templates/issue/includes/alternative_header.html
+++ b/opac/webapp/templates/issue/includes/alternative_header.html
@@ -33,7 +33,15 @@
               {% trans %}Número atual{% endtrans %}:
             </li>
             <li>
-              <strong>{{ journal.legend }}</strong>
+
+              {% if page=='toc' %}
+                <strong>{{ issue.legend }}</strong>
+              {% endif %}
+
+              {% if page=='grid' %}
+                <strong>{{ last_issue.legend }}</strong>
+              {% endif %}
+
             </li>
           </ul>
         </li>

--- a/opac/webapp/templates/issue/toc.html
+++ b/opac/webapp/templates/issue/toc.html
@@ -146,4 +146,8 @@
 
   {% include "journal/includes/contact_footer.html" %}
 
+  {% with page='toc' %}
+    {% include "issue/includes/alternative_header.html" %}
+  {% endwith %}
+
 {% endblock %}

--- a/opac/webapp/templates/journal/detail.html
+++ b/opac/webapp/templates/journal/detail.html
@@ -25,14 +25,16 @@
       </div>
       <div class="col-md-12 content journalHome">
         <div class="block mission">
-          <div class="col-md-6 col-sm-6">
-            {% if journal.mission %}
-              <h1>{% trans %}Nossa Missão{% endtrans %}</h1>
-              {% if session.lang %}
-                <p>{{ journal.get_mission_by_lang(session.lang[:2]) }}</p>
-              {% endif %}
-            {% endif %}
-          </div>
+          {% if journal.mission %}
+            <div class="col-md-6 col-sm-6">
+                <h1>{% trans %}Nossa Missão{% endtrans %}</h1>
+                {% if session.lang %}
+                  {% if journal.get_mission_by_lang(session.lang[:2]) %}
+                    <p>{{ journal.get_mission_by_lang(session.lang[:2]) }}</p>
+                  {% endif %}
+                {% endif %}
+            </div>
+          {% endif %}
           <div class="col-md-6 col-sm-6">
             <h3>{% trans %}Métricas deste periódico{% endtrans %}</h3>
             <ul>

--- a/opac/webapp/templates/journal/detail.html
+++ b/opac/webapp/templates/journal/detail.html
@@ -29,9 +29,7 @@
             <div class="col-md-6 col-sm-6">
                 <h1>{% trans %}Nossa Missão{% endtrans %}</h1>
                 {% if session.lang %}
-                  {% if journal.get_mission_by_lang(session.lang[:2]) %}
-                    <p>{{ journal.get_mission_by_lang(session.lang[:2]) }}</p>
-                  {% endif %}
+                    <p>{{ journal.get_mission_by_lang(session.lang[:2])|default("", true) }}</p>
                 {% endif %}
             </div>
           {% endif %}

--- a/opac/webapp/templates/journal/includes/header.html
+++ b/opac/webapp/templates/journal/includes/header.html
@@ -21,9 +21,14 @@
       </div>
       <div class="col-md-8 col-sm-6 brandLogo">
         <div class="row">
-          <div class="col-md-3 hidden-sm">
-            <img src="{{ journal.logo_url or '' }}" class="image" alt="Logomarca do periódico: {{ journal.title }}" />
-          </div>
+          {% if journal.logo_url %}
+            <div class="col-md-3 hidden-sm">
+              <img src="{{ journal.logo_url or '' }}" class="image" alt="Logomarca do periódico: {{ journal.title }}" />
+            </div>
+          {% else %}
+            <div class="col-md-1 hidden-sm">
+            </div>
+          {% endif %}
           <div class="col-md-9 col-md-offset-0 col-sm-11 col-sm-offset-1">
             <h1>{{ journal.title }}</h1>
             <span class="publisher">{% trans %}Publicação de: {% endtrans %} <strong>{{ journal.publisher_name}}</strong></span>


### PR DESCRIPTION
Itens realizados nesse PR: 

* Ajustes nos links hambuger quanto esta na mesma página (tabs).
* Na listagem por área temática garantir que o cabeçalho da tabela seja coerente com Grandes Areas e Web of Science
* Ajustes nos templates de download nas listagens para que não esteja com None ou caracteres estranhos (None #issue etc)
* Garantir que os links para as métricas abra em outra janela não perdendo o contexto do site SciELO
* Evitado mostrar None quando não tem missão
* No Menu superior adicionar a legenda bibliográfica, contextualizado por fascículo e por periódico
* Garantindo que não tenha um erro 500 no feed da home do periódico
* Não apresentar o espaço para o logo caso não exista logo para o periódico
