### PR TITLE
FIX 370 - Adicionar o ano no índice h5

### DIFF
--- a/opac/webapp/admin/views.py
+++ b/opac/webapp/admin/views.py
@@ -1,7 +1,6 @@
 # coding: utf-8
 import logging
 import socket
-from datetime import datetime
 from uuid import uuid4
 from jinja2 import Markup
 from flask_babelex import gettext as _

--- a/opac/webapp/main/views.py
+++ b/opac/webapp/main/views.py
@@ -291,6 +291,10 @@ def journal_detail(url_seg):
     else:
         sections = []
 
+    current_year = datetime.now().year
+    total_h5_index_year = current_year
+    total_h5_median_year = current_year
+
     context = {
         'next_issue': None,
         'previous_issue': previous_issue,
@@ -300,7 +304,9 @@ def journal_detail(url_seg):
         # condicional para verificar se issues contém itens
         'last_issue': issues[0] if issues else None,
         'sections': sections if sections else None,
-        'news': news
+        'news': news,
+        'total_h5_index_year': total_h5_index_year,
+        'total_h5_median_year': total_h5_median_year,
     }
 
     return render_template("journal/detail.html", **context)

--- a/opac/webapp/templates/journal/detail.html
+++ b/opac/webapp/templates/journal/detail.html
@@ -25,17 +25,17 @@
       </div>
       <div class="col-md-12 content journalHome">
 
-        {# mission #}
         <div class="block mission">
+          {# mission #}
           {% if journal.mission %}
             <div class="col-md-6 col-sm-6">
                 <h1>{% trans %}Nossa Missão{% endtrans %}</h1>
                 {% if session.lang %}
-                    <p>{{ journal.get_mission_by_lang(session.lang[:2])|default(_("Periódico sem missão cadastrada"), true) }}</p>
+                    <p>{{ journal.get_mission_by_lang(session.lang[:2])|safe|default(_("Periódico sem missão cadastrada"), true) }}</p>
                 {% endif %}
             </div>
           {% endif %}
-        {# mission #}
+          {# mission #}
 
           {# analytics #}
           <div class="col-md-6 col-sm-6">
@@ -44,10 +44,28 @@
               <li><a target="_blank" href="http://analytics.scielo.org/?journal={{ journal.scielo_issn or journal.eletronic_issn or journal.print_issn }}&collection={{ config.OPAC_COLLECTION }}">SciELO</a>
               <li><a href="">Google Scholar</a>
                 <div>
-                  <small>{% trans %}Índice h5{% endtrans %}:</small> <strong>{{ journal.metrics.total_h5_index|default(_("Não possui"), True) }}</strong>
+                  <small>
+                    {% trans %}Índice h5{% endtrans %}:
+                    {% if journal.metrics.total_h5_index and total_h5_index_year %}
+                      {# o índice é obtido sempre para o ano atual #}
+                      ({% trans %}ano{% endtrans %}: {{ total_h5_index_year }})
+                    {% endif %}
+                  </small>
+                  <strong>
+                    {{ journal.metrics.total_h5_index|default(_("Não possui"), True) }}
+                  </strong>
                 </div>
                 <div>
-                  <small>{% trans %}Mediana h5{% endtrans %}:</small> <strong>{{ journal.metrics.total_h5_median|default(_("Não possui"), True)  }}</strong>
+                  <small>
+                    {% trans %}Mediana h5{% endtrans %}:
+                    {% if journal.metrics.total_h5_median and total_h5_median_year %}
+                      {# a mediana é obtida sempre para o ano atual #}
+                      ({% trans %}ano{% endtrans %}: {{ total_h5_median_year }})
+                    {% endif %}
+                  </small>
+                  <strong>
+                    {{ journal.metrics.total_h5_median|default(_("Não possui"), True)  }}
+                  </strong>
                 </div>
               </li>
             </ul>


### PR DESCRIPTION
FIX #370

- Adicionado o ano atual junto ao índice e mediana. Porque cada h5m5 processado é com o ano atual;
- Adicionado o filtro `|safe` no texto da missão pq vem com tags html (exemplo, periódico `resp`);
- removido `import datetime` não utilizado.