### PR TITLE
FIX 399 - acrescentar instrução HEALTHCHECK no Dockefile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ LABEL org.label-schema.build-date=$OPAC_BUILD_DATE \
       org.label-schema.schema-version="1.0"
 
 RUN apk --update add --no-cache \
-    git gcc build-base zlib-dev jpeg-dev
+    git gcc build-base zlib-dev jpeg-dev curl
 
 COPY . /app
 WORKDIR /app
@@ -34,5 +34,8 @@ RUN chown -R nobody:nogroup /app
 VOLUME /app/data
 USER nobody
 EXPOSE 8000
+
+HEALTHCHECK --interval=5m --timeout=3s \
+  CMD curl -f http://localhost:8000/ || exit 1
 
 CMD gunicorn --workers 3 --bind 0.0.0.0:8000 manager:app --chdir=/app/opac --timeout 150 --log-level INFO

--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -21,7 +21,7 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
       org.label-schema.schema-version="1.0"
 
 RUN apk --update add --no-cache \
-    git gcc build-base zlib-dev jpeg-dev
+    git gcc build-base zlib-dev jpeg-dev curl
 
 
 COPY ./requirements.txt /app/requirements.txt
@@ -34,5 +34,8 @@ USER nobody
 
 EXPOSE 8000
 WORKDIR /app
+
+HEALTHCHECK --interval=5m --timeout=3s \
+  CMD curl -f http://localhost:8000/ || exit 1
 
 CMD gunicorn --workers 3 --bind 0.0.0.0:8000 manager:app --chdir=/app/opac --log-level DEBUG


### PR DESCRIPTION
FIX #399

Agora na saída do comando: `docker ps` (ou `docker container ls`) deve aparecer após os primeiros 5 mintuos de execução:
`Up 5 minutes (healthy)` na linha do container apac_webapp

Obs: precisa instalar o `curl`