### PR TITLE
Fix 411 - Ajuste das unpublishing reasons

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ LABEL org.label-schema.build-date=$OPAC_BUILD_DATE \
       org.label-schema.schema-version="1.0"
 
 RUN apk --update add --no-cache \
-    git gcc build-base zlib-dev jpeg-dev
+    git gcc build-base zlib-dev jpeg-dev curl
 
 COPY . /app
 WORKDIR /app
@@ -34,5 +34,8 @@ RUN chown -R nobody:nogroup /app
 VOLUME /app/data
 USER nobody
 EXPOSE 8000
+
+HEALTHCHECK --interval=5m --timeout=3s \
+  CMD curl -f http://localhost:8000/ || exit 1
 
 CMD gunicorn --workers 3 --bind 0.0.0.0:8000 manager:app --chdir=/app/opac --timeout 150 --log-level INFO

--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -21,7 +21,7 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
       org.label-schema.schema-version="1.0"
 
 RUN apk --update add --no-cache \
-    git gcc build-base zlib-dev jpeg-dev
+    git gcc build-base zlib-dev jpeg-dev curl
 
 
 COPY ./requirements.txt /app/requirements.txt
@@ -34,5 +34,8 @@ USER nobody
 
 EXPOSE 8000
 WORKDIR /app
+
+HEALTHCHECK --interval=5m --timeout=3s \
+  CMD curl -f http://localhost:8000/ || exit 1
 
 CMD gunicorn --workers 3 --bind 0.0.0.0:8000 manager:app --chdir=/app/opac --log-level DEBUG

--- a/opac/tests/test_controller.py
+++ b/opac/tests/test_controller.py
@@ -608,7 +608,7 @@ class IssueControllerTestCase(BaseTestCase):
         Testando alterar o valor de um conjunto de issues com o motivo, param
         ``reason``.
         """
-
+        unpublish_reason = 'plágio'
         self._make_one(attrib={'_id': '012ijs9y24', 'is_public': True})
         self._make_one(attrib={'_id': '2183ikos90', 'is_public': True})
         self._make_one(attrib={'_id': '9298wjso89', 'is_public': True})
@@ -621,7 +621,7 @@ class IssueControllerTestCase(BaseTestCase):
         issues = controllers.get_issues_by_iid(ids)
 
         for issue in issues.values():
-            self.assertEqual('plágio', issue.unpublish_reason)
+            self.assertEqual(unpublish_reason, issue.unpublish_reason)
 
     def test_set_issue_is_public_bulk_without_iids(self):
         """

--- a/opac/tests/test_main_views.py
+++ b/opac/tests/test_main_views.py
@@ -322,16 +322,16 @@ class MainTestCase(BaseTestCase):
         com atributo is_public=False, deve retorna uma página com ``status_code``
         404 e msg cadastrada no atributo ``reason``.
         """
-
+        unpublish_reason = 'plágio'
         journal = utils.makeOneJournal({
             'is_public': False,
-            'unpublish_reason': 'plágio'})
+            'unpublish_reason': unpublish_reason})
 
         response = self.client.get(url_for('main.journal_detail',
                                            url_seg=journal.url_segment))
 
         self.assertStatus(response, 404)
-        self.assertIn('plágio', response.data.decode('utf-8'))
+        self.assertIn(unpublish_reason, response.data.decode('utf-8'))
 
     def test_journal_feed(self):
         """
@@ -379,16 +379,16 @@ class MainTestCase(BaseTestCase):
         com atributo is_public=False, deve retorna uma página com ``status_code``
         404 e msg cadastrada no atributo ``reason``.
         """
-
+        unpublish_reason = 'plágio'
         journal = utils.makeOneJournal({
             'is_public': False,
-            'unpublish_reason': 'plágio'})
+            'unpublish_reason': unpublish_reason})
 
         response = self.client.get(url_for('main.journal_feed',
                                            url_seg=journal.url_segment))
 
         self.assertStatus(response, 404)
-        self.assertIn('plágio', response.data.decode('utf-8'))
+        self.assertIn(unpublish_reason, response.data.decode('utf-8'))
 
     # ISSUE
 
@@ -465,16 +465,15 @@ class MainTestCase(BaseTestCase):
         com atributo is_public=False, deve retorna uma página com ``status_code``
         404 e msg cadastrada no atributo ``reason``.
         """
-
+        unpublish_reason = 'Problema de Direito Autoral'
         journal = utils.makeOneJournal({'is_public': False,
-                                       'unpublish_reason': 'Problema de Direito Autoral'})
+                                       'unpublish_reason': unpublish_reason})
 
         response = self.client.get(url_for('main.issue_grid',
                                            url_seg=journal.url_segment))
 
         self.assertStatus(response, 404)
-        self.assertIn('Problema de Direito Autoral',
-                      response.data.decode('utf-8'))
+        self.assertIn(unpublish_reason, response.data.decode('utf-8'))
 
     def test_issue_toc(self):
         """
@@ -529,11 +528,11 @@ class MainTestCase(BaseTestCase):
         com atributo is_public=False, deve retorna uma página com ``status_code``
         404 e msg cadastrada no atributo ``reason``.
         """
+        unpublish_reason = 'Fascículo incorreto'
         journal = utils.makeOneJournal()
-
         issue = utils.makeOneIssue({
             'is_public': False,
-            'unpublish_reason': 'Fascículo incorreto',
+            'unpublish_reason': unpublish_reason,
             'journal': journal})
 
         response = self.client.get(url_for('main.issue_toc',
@@ -541,7 +540,7 @@ class MainTestCase(BaseTestCase):
                                            url_seg_issue=issue.url_segment))
 
         self.assertStatus(response, 404)
-        self.assertIn('Fascículo incorreto', response.data.decode('utf-8'))
+        self.assertIn(unpublish_reason, response.data.decode('utf-8'))
 
     def test_issue_toc_with_journal_attrib_is_public_false(self):
         """
@@ -550,10 +549,10 @@ class MainTestCase(BaseTestCase):
         is_public=False deve retorna uma página com ``status_code`` 404 e msg
         cadastrada no atributo ``reason`` do periódico.
         """
-
+        unpublish_reason = 'Revista removida da coleção'
         journal = utils.makeOneJournal({
             'is_public': False,
-            'unpublish_reason': 'Revista removida da coleção'})
+            'unpublish_reason': unpublish_reason})
         issue = utils.makeOneIssue({
             'is_public': True,
             'journal': journal.id})
@@ -563,7 +562,7 @@ class MainTestCase(BaseTestCase):
                                            url_seg_issue=issue.url_segment))
 
         self.assertStatus(response, 404)
-        self.assertIn('Revista removida da coleção', response.data.decode('utf-8'))
+        self.assertIn(unpublish_reason, response.data.decode('utf-8'))
 
     def test_issue_feed(self):
         """
@@ -619,11 +618,11 @@ class MainTestCase(BaseTestCase):
         404 e msg cadastrada no atributo ``reason``.
         """
 
+        unpublish_reason = 'Fascículo incorreto'
         journal = utils.makeOneJournal()
-
         issue = utils.makeOneIssue({
             'is_public': False,
-            'unpublish_reason': 'Fascículo incorreto',
+            'unpublish_reason': unpublish_reason,
             'journal': journal})
 
         response = self.client.get(url_for('main.issue_feed',
@@ -640,10 +639,10 @@ class MainTestCase(BaseTestCase):
         is_public=False deve retorna uma página com ``status_code`` 404 e msg
         cadastrada no atributo ``reason`` do periódico.
         """
-
+        unpublish_reason = 'Revista removida da coleção'
         journal = utils.makeOneJournal({
             'is_public': False,
-            'unpublish_reason': 'Revista removida da coleção'})
+            'unpublish_reason': unpublish_reason})
         issue = utils.makeOneIssue({
             'is_public': True,
             'journal': journal.id})
@@ -653,7 +652,7 @@ class MainTestCase(BaseTestCase):
                                            url_seg_issue=issue.url_segment))
 
         self.assertStatus(response, 404)
-        self.assertIn('Revista removida da coleção', response.data.decode('utf-8'))
+        self.assertIn(unpublish_reason, response.data.decode('utf-8'))
 
     # ARTICLE
 
@@ -714,10 +713,10 @@ class MainTestCase(BaseTestCase):
         is_public=False deve retorna uma página com ``status_code`` 404 e msg
         cadastrada no atributo ``reason`` do periódico.
         """
-
+        unpublish_reason = 'Revista removida da coleção'
         journal = utils.makeOneJournal({
             'is_public': False,
-            'unpublish_reason': 'Revista removida da coleção'})
+            'unpublish_reason': unpublish_reason})
 
         issue = utils.makeOneIssue({
             'is_public': True,
@@ -734,7 +733,7 @@ class MainTestCase(BaseTestCase):
                                            lang_code='pt'))
 
         self.assertStatus(response, 404)
-        self.assertIn('Revista removida da coleção', response.data.decode('utf-8'))
+        self.assertIn(unpublish_reason, response.data.decode('utf-8'))
 
     def test_article_detail_with_issue_attrib_is_public_false(self):
         """
@@ -744,11 +743,11 @@ class MainTestCase(BaseTestCase):
         cadastrada no atributo ``reason`` do fascículo.
         """
 
+        unpublish_reason = 'Facículo rejeitado'
         journal = utils.makeOneJournal()
-
         issue = utils.makeOneIssue({
             'is_public': False,
-            'unpublish_reason': 'Facículo rejeitado',
+            'unpublish_reason': unpublish_reason,
             'journal': journal.id})
 
         article = utils.makeOneArticle({
@@ -762,7 +761,7 @@ class MainTestCase(BaseTestCase):
                                            lang_code='pt'))
 
         self.assertStatus(response, 404)
-        self.assertIn('Facículo rejeitado', response.data.decode('utf-8'))
+        self.assertIn(unpublish_reason, response.data.decode('utf-8'))
 
     def test_article_detail_with_article_attrib_is_public_false(self):
         """
@@ -771,13 +770,13 @@ class MainTestCase(BaseTestCase):
          ``status_code`` 404 e msg cadastrada no atributo ``reason`` do artigo.
         """
 
+        unpublish_reason = 'Artigo com problemas de licença'
         journal = utils.makeOneJournal()
-
         issue = utils.makeOneIssue({'journal': journal.id})
 
         article = utils.makeOneArticle({
             'is_public': False,
-            'unpublish_reason': 'Artigo com problemas de licença',
+            'unpublish_reason': unpublish_reason,
             'issue': issue,
             'journal': journal})
 
@@ -788,7 +787,7 @@ class MainTestCase(BaseTestCase):
                                            lang_code='pt'))
 
         self.assertStatus(response, 404)
-        self.assertIn('Artigo com problemas de licença', response.data.decode('utf-8'))
+        self.assertIn(unpublish_reason, response.data.decode('utf-8'))
 
     # HOMEPAGE
 

--- a/opac/webapp/admin/views.py
+++ b/opac/webapp/admin/views.py
@@ -561,7 +561,7 @@ class IssueAdminView(OpacBaseAdminView):
     # Veja: https://github.com/scieloorg/opac/issues/411#issuecomment-265515533
     @action('unpublish_default', _('Despublicar por %s' % choices.UNPUBLISH_REASONS[0]), ACTION_UNPUBLISH_CONFIRMATION_MSG)
     def unpublish_default(self, ids):
-        self.unpublish_journals(ids, choices.UNPUBLISH_REASONS[0])
+        self.unpublish_issues(ids, choices.UNPUBLISH_REASONS[0])
 
 
 class ArticleAdminView(OpacBaseAdminView):
@@ -641,7 +641,7 @@ class ArticleAdminView(OpacBaseAdminView):
     # Veja: https://github.com/scieloorg/opac/issues/411#issuecomment-265515533
     @action('unpublish_default', _('Despublicar por %s' % choices.UNPUBLISH_REASONS[0]), ACTION_UNPUBLISH_CONFIRMATION_MSG)
     def unpublish_default(self, ids):
-        self.unpublish_journals(ids, choices.UNPUBLISH_REASONS[0])
+        self.unpublish_articles(ids, choices.UNPUBLISH_REASONS[0])
 
 
 class PagesAdminView(OpacBaseAdminView):

--- a/opac/webapp/admin/views.py
+++ b/opac/webapp/admin/views.py
@@ -490,17 +490,10 @@ class JournalAdminView(OpacBaseAdminView):
                     ex=str(ex)),
                   'error')
 
-    @action('unpublish_by_copyright', _('Despublicar por %s' % choices.UNPUBLISH_REASONS[0]), ACTION_UNPUBLISH_CONFIRMATION_MSG)
-    def unpublish_by_copyright(self, ids):
+    # Veja: https://github.com/scieloorg/opac/issues/411#issuecomment-265515533
+    @action('unpublish_default', _('Despublicar por %s' % choices.UNPUBLISH_REASONS[0]), ACTION_UNPUBLISH_CONFIRMATION_MSG)
+    def unpublish_default(self, ids):
         self.unpublish_journals(ids, choices.UNPUBLISH_REASONS[0])
-
-    @action('unpublish_plagiarism', _('Despublicar por %s' % choices.UNPUBLISH_REASONS[1]), ACTION_UNPUBLISH_CONFIRMATION_MSG)
-    def unpublish_plagiarism(self, ids):
-        self.unpublish_journals(ids, choices.UNPUBLISH_REASONS[1])
-
-    @action('unpublish_abuse', _('Despublicar por %s' % choices.UNPUBLISH_REASONS[2]), ACTION_UNPUBLISH_CONFIRMATION_MSG)
-    def unpublish_abuse(self, ids):
-        self.unpublish_journals(ids, choices.UNPUBLISH_REASONS[2])
 
 
 class IssueAdminView(OpacBaseAdminView):
@@ -565,17 +558,10 @@ class IssueAdminView(OpacBaseAdminView):
                     ex=str(ex)),
                   'error')
 
-    @action('unpublish_by_copyright', _('Despublicar por %s' % choices.UNPUBLISH_REASONS[0]), ACTION_UNPUBLISH_CONFIRMATION_MSG)
-    def unpublish_by_copyright(self, ids):
-        self.unpublish_issues(ids, choices.UNPUBLISH_REASONS[0])
-
-    @action('unpublish_plagiarism', _('Despublicar por %s' % choices.UNPUBLISH_REASONS[1]), ACTION_UNPUBLISH_CONFIRMATION_MSG)
-    def unpublish_plagiarism(self, ids):
-        self.unpublish_issues(ids, choices.UNPUBLISH_REASONS[1])
-
-    @action('unpublish_abuse', _('Despublicar por %s' % choices.UNPUBLISH_REASONS[2]), ACTION_UNPUBLISH_CONFIRMATION_MSG)
-    def unpublish_abuse(self, ids):
-        self.unpublish_issues(ids, choices.UNPUBLISH_REASONS[2])
+    # Veja: https://github.com/scieloorg/opac/issues/411#issuecomment-265515533
+    @action('unpublish_default', _('Despublicar por %s' % choices.UNPUBLISH_REASONS[0]), ACTION_UNPUBLISH_CONFIRMATION_MSG)
+    def unpublish_default(self, ids):
+        self.unpublish_journals(ids, choices.UNPUBLISH_REASONS[0])
 
 
 class ArticleAdminView(OpacBaseAdminView):
@@ -652,17 +638,10 @@ class ArticleAdminView(OpacBaseAdminView):
                     ex=str(ex)),
                   'error')
 
-    @action('unpublish_by_copyright', _('Despublicar por %s' % choices.UNPUBLISH_REASONS[0]), ACTION_UNPUBLISH_CONFIRMATION_MSG)
-    def unpublish_by_copyright(self, ids):
-        self.unpublish_articles(ids, choices.UNPUBLISH_REASONS[0])
-
-    @action('unpublish_plagiarism', _('Despublicar por %s' % choices.UNPUBLISH_REASONS[1]), ACTION_UNPUBLISH_CONFIRMATION_MSG)
-    def unpublish_plagiarism(self, ids):
-        self.unpublish_articles(ids, choices.UNPUBLISH_REASONS[1])
-
-    @action('unpublish_abuse', _('Despublicar por %s' % choices.UNPUBLISH_REASONS[2]), ACTION_UNPUBLISH_CONFIRMATION_MSG)
-    def unpublish_abuse(self, ids):
-        self.unpublish_articles(ids, choices.UNPUBLISH_REASONS[2])
+    # Veja: https://github.com/scieloorg/opac/issues/411#issuecomment-265515533
+    @action('unpublish_default', _('Despublicar por %s' % choices.UNPUBLISH_REASONS[0]), ACTION_UNPUBLISH_CONFIRMATION_MSG)
+    def unpublish_default(self, ids):
+        self.unpublish_journals(ids, choices.UNPUBLISH_REASONS[0])
 
 
 class PagesAdminView(OpacBaseAdminView):

--- a/opac/webapp/choices.py
+++ b/opac/webapp/choices.py
@@ -4,9 +4,7 @@ from flask_babelex import gettext as _
 from flask_babelex import lazy_gettext as __
 
 UNPUBLISH_REASONS = [
-    _('Problema de Direito Autoral'),
-    _('Plágio'),
-    _('Abuso ou Conteúdo Indevido'),
+    _('Conteúdo temporariamente indisponível'),
 ]
 
 LANGUAGES_CHOICES = [


### PR DESCRIPTION
FIX #411

Antes tinhamos 3 opções:

- 'Problema de Direito Autoral'
- 'Plágio'
- 'Abuso ou Conteúdo Indevido'

Mas em discussão com a equipe, foi decidido deixar só uma:

- 'Conteúdo temporariamente indisponível'