### PR TITLE
FIX na legenda bibliografica (issue: 610) e outros ajustes menores

### DIFF
--- a/opac/webapp/controllers.py
+++ b/opac/webapp/controllers.py
@@ -13,7 +13,7 @@ import xlsxwriter
 import tweepy
 
 from collections import OrderedDict
-from legendarium.formatter import descriptive_short_format
+from legendarium.formatter import descriptive_very_short_format
 from slugify import slugify
 from opac_schema.v1.models import (
     Journal,
@@ -163,9 +163,11 @@ def get_journal_json_data(journal, language='pt'):
         "is_active": true,
         "issues_count": 64,
         "last_issue": {
+            "legend": "LEGENDA BIBLIOGRAFICA DO ISSUE",
             "number": "123",
             "volume": 456,
-            "year": 2016
+            "year": 2016,
+            "url_segment": "/foo"
         },
         "links": {
             "about": "#",
@@ -195,17 +197,12 @@ def get_journal_json_data(journal, language='pt'):
     }
 
     if journal.last_issue:
-        last_issue_legend = descriptive_short_format(
-            title='',           # não queremos o nome do periódico
-            short_title='',     # não queremos o nome do periódico
+        last_issue_legend = descriptive_very_short_format(
             pubdate=str(journal.last_issue.year),
             volume=journal.last_issue.volume,
             number=journal.last_issue.number,
             suppl=journal.last_issue.suppl_text,
             language=language)
-
-        if last_issue_legend.startswith(', '):
-            last_issue_legend = last_issue_legend.replace(', ', '', 1)  # removemos a primeira vírgula
 
         j_data['last_issue'] = {
             'legend': last_issue_legend,

--- a/opac/webapp/main/views.py
+++ b/opac/webapp/main/views.py
@@ -528,10 +528,11 @@ def issue_toc(url_seg, url_seg_issue):
 
     issue = controllers.get_issue_by_url_seg(url_seg, url_seg_issue)
 
-    issue_legend = descriptive_short_format(
-        title=issue.journal.title, short_title=issue.journal.short_title,
-        pubdate=str(issue.year), volume=issue.volume, number=issue.number,
-        suppl=issue.suppl_text, language=language[:2].lower())
+    if issue and issue.journal:
+        issue_legend = descriptive_short_format(
+            title=issue.journal.title, short_title=issue.journal.short_title,
+            pubdate=str(issue.year), volume=issue.volume, number=issue.number,
+            suppl=issue.suppl_text, language=language[:2].lower())
 
     if not issue:
         abort(404, _('Número não encontrado'))

--- a/opac/webapp/templates/article/includes/recent_articles_row.html
+++ b/opac/webapp/templates/article/includes/recent_articles_row.html
@@ -8,7 +8,7 @@
       {% endif %}
 
       <div class="info">
-        {{ article.issue.legend }}
+        {{ latest_issue_legend|default('--', True) }}
         <br>
         <strong>{% trans%}continue lendo{% endtrans %} &raquo;</strong>
       </div>

--- a/opac/webapp/templates/collection/includes/tmpl_journal_list_row.html
+++ b/opac/webapp/templates/collection/includes/tmpl_journal_list_row.html
@@ -32,15 +32,11 @@
       <a href="/<%- journal.last_issue.url_segment %>"
         title="{% trans %}Número mais recente{% endtrans %}">
         {% trans %}Último{% endtrans %}:
-
-        {# <span class="journalLastVolume"><em>{% trans %}Volume{% endtrans %}</em> <%- journal.last_issue.volume %></span> #}
-        {# <span class="journalLastSuppl"><em>{% trans %}Nº{% endtrans %} <%- journal.last_issue.number %></em></span> - #}
-        {# <span class="journalLastPubDate"><%- journal.last_issue.year %></span> #}
         <span class="last-issue-legend"><%- journal.last_issue.legend %></span>
       </a>
     <% } %>
 
-    <% if (!journal.is_active) { %>({% trans %}inativo{% endtrans %})<% } %>
+    <% if (!journal.is_active) { %>({% trans %}descontinuado{% endtrans %})<% } %>
 
     <% if (journal.previous_journal_ref) { %>
       <span class="journalPreviousTitle">{% trans %}Continua como {% endtrans %}</span><%- journal.previous_journal_ref %>

--- a/opac/webapp/templates/collection/list_feed_content.html
+++ b/opac/webapp/templates/collection/list_feed_content.html
@@ -3,7 +3,7 @@
   <em>{% trans %}Volume{% endtrans %}</em> {{ last_issue.volume }}
   <em>{% trans %}Nº{% endtrans %} {{ last_issue.number }}</em> -
   {{ last_issue.year }}
-  {% if journal.current_status != 'current' %}({% trans %}inativo{% endtrans %}){% endif %}
+  {% if journal.current_status != 'current' %}({% trans %}descontinuado{% endtrans %}){% endif %}
 </a><strong>{% trans %}de{% endtrans %} {{ journal.issue_count }} {% trans %}números{% endtrans %}</strong>.
 {%- for section, article_list in articles.items() %}
     {%- if section %}

--- a/opac/webapp/templates/issue/includes/alternative_header.html
+++ b/opac/webapp/templates/issue/includes/alternative_header.html
@@ -33,7 +33,15 @@
               {% trans %}Número atual{% endtrans %}:
             </li>
             <li>
-                <strong><a href="{{ url_for('.issue_toc', url_seg=journal.url_segment, url_seg_issue=last_issue.url_segment) }}">{{ last_issue.legend }}</a></strong>
+                <strong>
+                  <a href="{{ url_for('.issue_toc', url_seg=journal.url_segment, url_seg_issue=last_issue.url_segment) }}">
+                    {% if latest_issue_legend %}
+                      {{ latest_issue_legend|default('--', True) }}
+                    {% elif issue_legend %}
+                      {{ issue_legend|default('--', True) }}
+                    {% endif %}
+                  </a>
+                </strong>
             </li>
           </ul>
         </li>

--- a/opac/webapp/templates/issue/toc.html
+++ b/opac/webapp/templates/issue/toc.html
@@ -63,7 +63,7 @@
               <div class="block summary collapseContent">
                   <a href="javascript:;" class="collapse-title"><h1>{% trans %}Sumário{% endtrans %}</h1></a>
                   <div class="collapse-content issueIndent">
-                    <strong>{{ issue.legend }}</strong>
+                    <strong>{{ issue_legend|default('--', True) }}</strong>
                     <ul>
 
                       {% if sections %}

--- a/opac/webapp/templates/journal/about.html
+++ b/opac/webapp/templates/journal/about.html
@@ -35,39 +35,50 @@
                         {% if content %}
                           {{ content|safe }}
                         {% else %}
-                          {% trans %} Conteúdo não cadastrado {% endtrans %}
+                          {% trans %}Conteúdo não cadastrado{% endtrans %}
                         {% endif %}
                     </div>
+
                     {% if journal.social_networks or journal.logo_url %}
-                    <div class="col-md-4 col-sm-4">
+                      <div class="col-md-4 col-sm-4">
+
                         {% if journal.logo_url %}
                           <a href="#" class="linkLogo">
-                              <img src="{{ journal.logo_url }}" alt="{% trans %}Logo {% endtrans %} {{ journal.title }}">
-                              {% trans %}Clique para ver a logo deste periódico {% endtrans %}
+                            <img src="{{ journal.logo_url }}" alt="{% trans %}Logo{% endtrans %} {{ journal.title }}">
+                            {% trans %}Clique para ver a logo deste periódico{% endtrans %}
                           </a>
                         {% endif %}
 
                         {% if journal.social_networks %}
                           <div class="linkSocial">
-                              <small>{% trans %}Siga este periódico nas redes sociais{% endtrans %}</small>
-                              <ul>
+                            <small>{% trans %}Siga este periódico nas redes sociais{% endtrans %}</small>
+                            <ul>
+                              {% for sn in journal.social_networks %}
+                                {% if sn.account %}
                                   <li>
-                                      <a href=""><span class="glyphBtn bigFacebook"></span> FACEBOOK</a>
+                                    <a href="{{ sn.account }}">
+                                      {% with network = sn.network|lower  %}
+                                        {% if network == 'twitter' %}
+                                           <span class="glyphBtn bigTwitter"></span> FACEBOOK
+                                        {% elif network == 'facebook' %}
+                                           <span class="glyphBtn bigFacebook"></span> TWITTER
+                                        {% elif network == 'google+' or network == 'google' %}
+                                           <span class="glyphBtn bigGooglePlus"></span> GOOGLE+
+                                        {% else %}
+                                           <span class="glyphBtn"></span> {{ network|upper }}
+                                        {% endif %}
+                                      {% endwith %}
+                                    </a>
                                   </li>
-                                  <li>
-                                      <a href=""><span class="glyphBtn bigTwitter"></span> TWITTER</a>
-                                  </li>
-                                  <li>
-                                      <a href=""><span class="glyphBtn bigGooglePlus"></span> GOOGLE+</a>
-                                  </li>
-                              </ul>
+                                {% endif %}
+                              {% endfor %}
+                            </ul>
                           </div>
                         {% endif %}
-                    </div>
+                      </div>
                     {% endif %}
                 </div>
             </div>
-
             <div class="clearfix"></div>
         </div>
     </section>

--- a/opac/webapp/templates/journal/detail.html
+++ b/opac/webapp/templates/journal/detail.html
@@ -77,14 +77,14 @@
         {# last issue #}
         {% if journal.last_issue %}
           <div class="block lastIssue">
-            <div class="col-md-6 col-sm-6">
+            <div class="col-md-12 col-sm-12">
               <a href="{{ url_for('.issue_toc', url_seg=journal.url_segment, url_seg_issue=last_issue.url_segment) }}">
                 {% if journal.last_issue.cover_url %}
                   <img src="{{ latest_issue.cover_url }}" class="image" alt="{% trans %}Capa do número mais recente{% endtrans %}" /> <!-- a imagem é opcional -->
                 {% endif %}
                 <span class="text">
                   <small>{% trans %}Número mais recente{% endtrans %}</small>
-                    <h2>{{ journal.legend_last_issue }}</h2>
+                  <h2>{{ latest_issue_legend|default('--', True) }}</h2>
                 </span>
               </a>
             </div>

--- a/opac/webapp/templates/journal/includes/alternative_header.html
+++ b/opac/webapp/templates/journal/includes/alternative_header.html
@@ -33,7 +33,11 @@
               {% trans %}Número atual{% endtrans %}:
             </li>
             <li>
-              <strong><a href="{{ url_for('.issue_toc', url_seg=journal.url_segment, url_seg_issue=last_issue.url_segment) }}">{{ last_issue.legend }}</a></strong>
+              <strong>
+                <a href="{{ url_for('.issue_toc', url_seg=journal.url_segment, url_seg_issue=last_issue.url_segment) }}">
+                  {{ latest_issue_legend|default('--', True) }}
+                </a>
+              </strong>
             </li>
           </ul>
         </li>

--- a/opac/webapp/templates/journal/includes/header.html
+++ b/opac/webapp/templates/journal/includes/header.html
@@ -35,7 +35,7 @@
               {{ journal.title }}
             </h1>
             <span class="publisher">
-              {% trans %}Publicação de: {% endtrans %} <strong>{{ journal.publisher_name}}</strong>
+              {% trans %}Publicação de:{% endtrans %} <strong>{{ journal.publisher_name}}</strong>
             </span>
             </br>
             <span class="theme">


### PR DESCRIPTION
- FIX: #610
- FIX: tirando espácos em branco de tags {% trans %}
- FIX: indentação em 2 espaços nos tempaltes
- FIX: lista de redes socials na página about agora iterar nos dados. Antes estava cravado.