### PR TITLE
Adicionando comando para carregar as páginas secundárias

### DIFF
--- a/opac/webapp/__init__.py
+++ b/opac/webapp/__init__.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 
-from raven.contrib.flask import Sentry
 import logging
+from raven.contrib.flask import Sentry
 
 from flask import Flask
 from flask_htmlmin import HTMLMIN

--- a/opac/webapp/config/default.py
+++ b/opac/webapp/config/default.py
@@ -213,6 +213,7 @@ MEDIA_ROOT = os.environ.get('OPAC_MEDIA_ROOT', DEFAULT_MEDIA_ROOT)
 IMAGE_ROOT = os.path.join(MEDIA_ROOT, 'images')
 FILE_ROOT = os.path.join(MEDIA_ROOT, 'files')
 MEDIA_URL = os.environ.get('OPAC_MEDIA_URL', '/media')
+PAGE_PATH = os.path.abspath(os.path.join(PROJECT_PATH, '../../data/pages'))
 
 # extensions
 FILES_ALLOWED_EXTENSIONS = ('txt', 'pdf', 'csv', 'xls', 'doc', 'ppt', 'xlsx', 'docx', 'pptx', 'html', 'htm')


### PR DESCRIPTION
Fixes #630 

É necessário termos uma pasta montada no servidor do OPAC com o path para as páginas secundárias.