### PR TITLE
suporte para urls de PDF do legado

### DIFF
--- a/opac/webapp/controllers.py
+++ b/opac/webapp/controllers.py
@@ -675,14 +675,14 @@ def get_issue_by_url_seg(url_seg, url_seg_issue):
     return Issue.objects.filter(journal=journal, url_segment=url_seg_issue).first()
 
 
-def get_issue_by_journal_and_label(issue_label, journal):
-    if not issue_label:
-        raise ValueError(__('Obrigatório um issue_label.'))
+def get_issue_by_journal_and_assets_code(assets_code, journal):
+    if not assets_code:
+        raise ValueError(__('Obrigatório um assets_code.'))
 
     if not journal:
         raise ValueError(__('Obrigatório um journal.'))
 
-    return Issue.objects.filter(label__icontains=issue_label, journal=journal).first()
+    return Issue.objects.filter(assets_code=assets_code, journal=journal).first()
 
 
 # -------- ARTICLE --------

--- a/opac/webapp/controllers.py
+++ b/opac/webapp/controllers.py
@@ -675,6 +675,16 @@ def get_issue_by_url_seg(url_seg, url_seg_issue):
     return Issue.objects.filter(journal=journal, url_segment=url_seg_issue).first()
 
 
+def get_issue_by_journal_and_label(issue_label, journal):
+    if not issue_label:
+        raise ValueError(__('Obrigatório um issue_label.'))
+
+    if not journal:
+        raise ValueError(__('Obrigatório um journal.'))
+
+    return Issue.objects.filter(label__icontains=issue_label, journal=journal).first()
+
+
 # -------- ARTICLE --------
 
 def get_article_by_aid(aid, **kwargs):

--- a/opac/webapp/main/views.py
+++ b/opac/webapp/main/views.py
@@ -848,7 +848,7 @@ def router_legacy_pdf(journal_acron, issue_info, pdf_filename):
         abort(404, JOURNAL_UNPUBLISH + _(journal.unpublish_reason))
 
     # issue = Issues.objects.filter(label=issue_info, journal=journal).first()
-    issue = controllers.get_issue_by_journal_and_label(issue_label=issue_info, journal=journal)
+    issue = controllers.get_issue_by_journal_and_assets_code(assets_code=issue_info, journal=journal)
 
     if not issue:
         abort(404, _('Número não encontrado'))

--- a/opac/webapp/main/views.py
+++ b/opac/webapp/main/views.py
@@ -833,6 +833,49 @@ def article_detail_pdf(url_seg, url_seg_issue, url_seg_article, lang_code=''):
     return render_template("article/detail_pdf.html", **context)
 
 
+@main.route('/pdf/<string:journal_acron>/<string:issue_info>/<string:pdf_filename>.pdf')
+def router_legacy_pdf(journal_acron, issue_info, pdf_filename):
+    default_lang = current_app.config.get('BABEL_DEFAULT_LOCALE')
+    language = session.get('lang', default_lang) or default_lang
+    pdf_filename = '%s.pdf' % pdf_filename
+
+    journal = controllers.get_journal_by_acron(journal_acron)
+
+    if not journal:
+        abort(404, _('Periódico não encontrado'))
+
+    if not journal.is_public:
+        abort(404, JOURNAL_UNPUBLISH + _(journal.unpublish_reason))
+
+    # issue = Issues.objects.filter(label=issue_info, journal=journal).first()
+    issue = controllers.get_issue_by_journal_and_label(issue_label=issue_info, journal=journal)
+
+    if not issue:
+        abort(404, _('Número não encontrado'))
+
+    if not issue.is_public:
+        abort(404, ISSUE_UNPUBLISH + _(issue.unpublish_reason))
+
+    pdf_lang = language
+
+    # procuramos entre os artigos, qual tem um pdf nesse idioma com esse filename
+    article_match = None
+    for article in controllers.get_articles_by_iid(iid=issue.iid):
+        if article.pdfs:
+            for pdf in article.pdfs:
+                if pdf['url'].endswith(pdf_filename):
+                    article_match = article
+                    pdf_lang = pdf['lang']
+                    break
+
+    if article_match is None:
+        abort(404, _('PDF do artigo não foi encontrado'))
+    else:
+        return article_detail_pdf(
+            url_seg=journal.url_segment,
+            url_seg_issue=issue.url_segment,
+            url_seg_article=article_match.url_segment, lang_code=pdf_lang)
+
 # ##################################Search#######################################
 
 

--- a/opac/webapp/main/views.py
+++ b/opac/webapp/main/views.py
@@ -847,7 +847,7 @@ def router_legacy_pdf(journal_acron, issue_info, pdf_filename):
     if not journal.is_public:
         abort(404, JOURNAL_UNPUBLISH + _(journal.unpublish_reason))
 
-    # issue = Issues.objects.filter(label=issue_info, journal=journal).first()
+    # procuramos o issue filtrando pelo campo: assets_code e o journal
     issue = controllers.get_issue_by_journal_and_assets_code(assets_code=issue_info, journal=journal)
 
     if not issue:

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ Flask-Migrate==2.0.4
 unicodecsv==0.14.1
 feedparser==5.2.1
 legendarium==2.0.0
--e git+https://git@github.com/scieloorg/opac_schema@v2.32#egg=opac_schema
+-e git+https://git@github.com/scieloorg/opac_schema@v2.33#egg=opac_schema
 Flask-HTMLmin==1.2.1
 python-slugify==1.2.4
 requests==2.18.1


### PR DESCRIPTION
FIX: #689

- falta ajustar a query para filtar por um novo campo: `assets_code`
- atualizar o OPAC Schema com o novo campo: `assets_code`

Refs:
- campo `assets_code` no XYLOSE article: https://github.com/scieloorg/xylose/blob/e585f7f6944ab048b0b4cd625bf399b8a30d418f/xylose/scielodocument.py#L1556