### PR TITLE
ajustes_conteudo_paginas_secundarias

### DIFF
--- a/opac/manager.py
+++ b/opac/manager.py
@@ -30,7 +30,7 @@ else:
 from webapp import create_app, dbsql, dbmongo, mail  # noqa
 from opac_schema.v1.models import Collection, Sponsor, Journal, Issue, Article  # noqa
 from webapp import controllers  # noqa
-from webapp.utils import reset_db, create_db_tables, create_user, create_image, create_page, extract_images, open_file  # noqa
+from webapp.utils import reset_db, create_db_tables, create_user, create_image, create_page, extract_images, open_file, fix_page_content  # noqa
 from flask_script import Manager, Shell  # noqa
 from flask_migrate import Migrate, MigrateCommand  # noqa
 from webapp.admin.forms import EmailForm  # noqa
@@ -301,22 +301,22 @@ def populate_journal_pages(directory=app.config['PAGE_PATH']):
                 except IOError as e:
                     print(e)
                 else:
-                    content += fp.read()
+                    content += fix_page_content(file, fp.read())
 
-                images_list = extract_images(content)
+            images_list = extract_images(content)
 
-                for image in images_list:
-                    image_name = '%s_%s' % (acron, os.path.basename(image))
-                    image_path = os.path.join(journal_dir, os.path.basename(image))
+            for image in images_list:
+                image_name = '%s_%s' % (acron, os.path.basename(image))
+                image_path = os.path.join(journal_dir, os.path.basename(image))
 
-                    try:
-                        # Verifica se a imagem existe
-                        open_file(image_path, mode='r')
-                    except IOError as e:
-                        print(e)
-                    else:
-                        img = create_image(image_path, image_name, thumbnail=True)
-                        content = content.replace(image, img.get_absolute_url)
+                try:
+                    # Verifica se a imagem existe
+                    open_file(image_path, mode='r')
+                except IOError as e:
+                    print(e)
+                else:
+                    img = create_image(image_path, image_name, thumbnail=True)
+                    content = content.replace(image, img.get_absolute_url)
 
             if content:
                 create_page('Página secundária %s (%s)' % (acron.upper(), lang),

--- a/opac/webapp/controllers.py
+++ b/opac/webapp/controllers.py
@@ -31,7 +31,7 @@ from flask_mongoengine import Pagination
 from webapp import dbsql
 from .models import User
 from .choices import INDEX_NAME
-from . import utils
+from .utils import utils
 from uuid import uuid4
 
 from mongoengine import Q

--- a/opac/webapp/main/views.py
+++ b/opac/webapp/main/views.py
@@ -15,7 +15,7 @@ from legendarium.formatter import descriptive_short_format
 from . import main
 from webapp import babel
 from webapp import controllers
-from webapp import utils
+from webapp.utils import utils
 from webapp import forms
 
 logger = logging.getLogger(__name__)

--- a/opac/webapp/notifications.py
+++ b/opac/webapp/notifications.py
@@ -6,7 +6,7 @@
 """
 
 from flask import url_for, render_template
-from . import utils
+from .utils import utils
 import six
 
 

--- a/opac/webapp/utils/journal_static_page.py
+++ b/opac/webapp/utils/journal_static_page.py
@@ -1,0 +1,66 @@
+# coding=utf-8
+
+
+class JournalStaticPage(object):
+
+    # about, editors, instructions, contact
+    # 'iaboutj.htm', 'iedboard.htm', 'iinstruc.htm'
+    anchors = {
+        'about': 'about',
+        'editors': 'edboard',
+        'instructions': 'instruc',
+    }
+
+    def __init__(self, filename, content):
+        self.filename = filename
+        self.content = content
+
+    @property
+    def header(self):
+        _header = None
+        if '<table' in self.content:
+            _header = self.content[self.content.find('<table'):]
+            _header = _header[:_header.find('</table>')+len('</table>')]
+            _header = _header.strip()
+            if _header.startswith('<table') and _header.endswith('</table>'):
+                pass
+            else:
+                print(self.filename, 'header', 'unexpected format')
+                _header = None
+        return _header
+
+    @property
+    def footer(self):
+        _footer = None
+        if 'script=sci_serial' in self.content:
+            p = self.content.rfind('script=sci_serial')
+            _footer = self.content[:p]
+            p = _footer.rfind('<p ')
+            _footer = self.content[p:]
+            _footer = _footer[:_footer.find('</body>')]
+            _footer = _footer.strip()
+            if _footer.startswith('<p') and _footer.endswith('</p>'):
+                pass
+            else:
+                print(self.filename, 'footer', 'unexpected format')
+                _footer = None
+        return _footer
+
+    @property
+    def anchor(self):
+        _anchor = None
+        for anchor_name, name in self.anchors.items():
+            if name in self.filename:
+                _anchor = anchor_name
+                break
+        if _anchor is not None:
+            return '<a name="{}">'.format(_anchor)
+        return ''
+
+    @property
+    def body(self):
+        if all([self.header, self.footer]):
+            new = self.content.replace(self.header, self.anchor)
+            new = new.replace(self.footer, '<hr noshade="" size="1"/>')
+            return new
+        return self.content

--- a/opac/webapp/utils/utils.py
+++ b/opac/webapp/utils/utils.py
@@ -10,7 +10,8 @@ from werkzeug import secure_filename
 from itsdangerous import URLSafeTimedSerializer
 from flask_mail import Message
 from flask import current_app
-from . import models
+from ... import models
+from journal_static_page import JournalStaticPage
 import webapp
 import requests
 
@@ -304,6 +305,14 @@ def create_page(name, language, content, journal=None, description=None):
     page.save()
 
     return page
+
+
+def fix_page_content(filename, content):
+    """
+    Extract the header and the footer of the page
+    Insert the anchor based on filename
+    """
+    return JournalStaticPage(filename, content).body
 
 
 def extract_images(content):


### PR DESCRIPTION
- remove o header e o footer das páginas secundárias que são padronizados pois fazem parte de um template dreamweaver
- retira de dentro de um for o bloco de tratamento das imagens
- cria uma pasta utils e dentro dela passa a ter utils + journal_static_page