### PR TITLE
Improve cache clean with patterns

### DIFF
--- a/opac/webapp/main/views.py
+++ b/opac/webapp/main/views.py
@@ -17,6 +17,7 @@ from webapp import babel
 from webapp import cache
 from webapp import controllers
 from webapp.utils import utils
+from webapp.utils.caching import cache_key_with_lang, cache_key_with_lang_with_qs
 from webapp import forms
 
 logger = logging.getLogger(__name__)
@@ -29,12 +30,6 @@ ARTICLE_UNPUBLISH = _("O artigo está indisponível por motivo de: ")
 def url_external(endpoint, **kwargs):
     url = url_for(endpoint, **kwargs)
     return urljoin(request.url_root, url)
-
-
-def cache_key_with_lang():
-    default_lang = current_app.config.get('BABEL_DEFAULT_LOCALE')
-    language = session.get('lang', default_lang)
-    return "lang/%s/path/%s" % (language, request.path)
 
 
 @main.before_app_request
@@ -191,7 +186,7 @@ def collection_list_feed():
 
 
 @main.route("/collection/about/", methods=['GET'])
-@cache.cached(key_prefix=cache_key_with_lang, query_string=True)
+@cache.cached(key_prefix=cache_key_with_lang_with_qs)
 def about_collection():
     default_lang = current_app.config.get('BABEL_DEFAULT_LOCALE')
     language = session.get('lang', default_lang) or default_lang
@@ -215,7 +210,7 @@ def about_collection():
 
 
 @main.route('/scielo.php/')
-@cache.cached(key_prefix=cache_key_with_lang, query_string=True)
+@cache.cached(key_prefix=cache_key_with_lang_with_qs)
 def router_legacy():
 
     script_php = request.args.get('script')
@@ -440,7 +435,7 @@ def about_journal(url_seg):
 
 
 @main.route("/journals/search/alpha/ajax/", methods=['GET', ])
-@cache.cached(key_prefix=cache_key_with_lang, query_string=True)
+@cache.cached(key_prefix=cache_key_with_lang_with_qs)
 def journals_search_alpha_ajax():
 
     if not request.is_xhr:
@@ -457,7 +452,7 @@ def journals_search_alpha_ajax():
 
 
 @main.route("/journals/search/group/by/filter/ajax/", methods=['GET'])
-@cache.cached(key_prefix=cache_key_with_lang, query_string=True)
+@cache.cached(key_prefix=cache_key_with_lang_with_qs)
 def journals_search_by_theme_ajax():
 
     if not request.is_xhr:
@@ -483,7 +478,7 @@ def journals_search_by_theme_ajax():
 
 
 @main.route("/journals/download/<string:list_type>/<string:extension>/", methods=['GET', ])
-@cache.cached(key_prefix=cache_key_with_lang, query_string=True)
+@cache.cached(key_prefix=cache_key_with_lang_with_qs)
 def download_journal_list(list_type, extension):
     if extension.lower() not in ['csv', 'xls']:
         abort(401, _('Parámetro "extension" é inválido, deve ser "csv" ou "xls".'))
@@ -548,7 +543,7 @@ def issue_grid(url_seg):
 
 
 @main.route('/toc/<string:url_seg>/<regex("\d{4}\.(\w+[-\.]?\w+[-\.]?)"):url_seg_issue>/')
-@cache.cached(key_prefix=cache_key_with_lang, query_string=True)
+@cache.cached(key_prefix=cache_key_with_lang_with_qs)
 def issue_toc(url_seg, url_seg_issue):
     # idioma da sessão
     default_lang = current_app.config.get('BABEL_DEFAULT_LOCALE')
@@ -755,7 +750,7 @@ def article_detail(url_seg, url_seg_issue, url_seg_article, lang_code=''):
 
 @main.route('/readcube/epdf/')
 @main.route('/readcube/epdf.php')
-@cache.cached(key_prefix=cache_key_with_lang, query_string=True)
+@cache.cached(key_prefix=cache_key_with_lang_with_qs)
 def article_epdf():
     doi = request.args.get('doi', None, type=str)
     pid = request.args.get('pid', None, type=str)
@@ -774,7 +769,7 @@ def article_epdf():
         return render_template("article/epdf.html", **context)
 
 
-@cache.cached(key_prefix=cache_key_with_lang, query_string=True)
+@cache.cached(key_prefix=cache_key_with_lang_with_qs)
 def get_content_from_ssm(resource_ssm_media_path):
     resource_ssm_full_url = current_app.config['SSM_BASE_URI'] + resource_ssm_media_path
     try:
@@ -798,7 +793,7 @@ def media_assets_proxy(relative_media_path):
 
 
 @main.route('/article/ssm/content/raw/')
-@cache.cached(key_prefix=cache_key_with_lang, query_string=True)
+@cache.cached(key_prefix=cache_key_with_lang_with_qs)
 def article_ssm_content_raw():
     resource_ssm_path = request.args.get('resource_ssm_path', None)
     if not resource_ssm_path:
@@ -878,7 +873,7 @@ def article_detail_pdf(url_seg, url_seg_issue, url_seg_article, lang_code=''):
 
 
 @main.route('/pdf/<string:journal_acron>/<string:issue_info>/<string:pdf_filename>.pdf')
-@cache.cached(key_prefix=cache_key_with_lang, query_string=True)
+@cache.cached(key_prefix=cache_key_with_lang_with_qs)
 def router_legacy_pdf(journal_acron, issue_info, pdf_filename):
     default_lang = current_app.config.get('BABEL_DEFAULT_LOCALE')
     language = session.get('lang', default_lang) or default_lang
@@ -925,7 +920,7 @@ def router_legacy_pdf(journal_acron, issue_info, pdf_filename):
 
 
 @main.route("/metasearch/", methods=['GET'])
-@cache.cached(key_prefix=cache_key_with_lang, query_string=True)
+@cache.cached(key_prefix=cache_key_with_lang_with_qs)
 def metasearch():
     url = request.args.get('url', current_app.config['URL_SEARCH'], type=str)
     params = {}

--- a/opac/webapp/utils/caching.py
+++ b/opac/webapp/utils/caching.py
@@ -1,0 +1,60 @@
+# Redis Cache Key Generation:
+import hashlib
+from flask import current_app, request, session
+
+
+def _make_querystring_hash():
+    """
+    Função que gera o hash a partir dos dados da querystring do request
+    """
+
+    args_as_sorted_tuple = tuple(
+        sorted(
+            (pair for pair in request.args.items(multi=True))
+        )
+    )
+    args_as_bytes = str(args_as_sorted_tuple).encode()
+    return str(hashlib.md5(args_as_bytes).hexdigest())
+
+
+def _cache_key_format(lang_code, request_path, qs_hash=None):
+    """
+    função que retorna o string que será a chave no cache.
+    formata o string usando os parâmetros da função:
+    - lang_code: código do idioma: [pt_BR|es|en]
+    - request_path: o path do request
+    - qs_hash: o hash gerado a partir dos parametros da querystring (se não for None)
+    """
+
+    cache_key = "/LANG=%s/PATH=%s" % (lang_code, request_path)
+    if qs_hash is not None:
+        cache_key = "%s?QS=%s" % (cache_key, qs_hash)
+    return cache_key
+
+
+def cache_key_with_lang():
+    """
+    Função chamada no decorator @cache.cached
+    Retorna a chave para usar no cache (redis) usando:
+    - o códiog do idioma armazenado na sessão (ou o default se não tiver)
+    - o path do request
+    """
+
+    default_lang = current_app.config.get('BABEL_DEFAULT_LOCALE')
+    language = session.get('lang', default_lang)
+    return _cache_key_format(language, request.path)
+
+
+def cache_key_with_lang_with_qs():
+    """
+    Função chamada no decorator @cache.cached
+    Retorna a chave para usar no cache (redis) usando:
+    - o códiog do idioma armazenado na sessão (ou o default se não tiver)
+    - o path do request
+    - o hash gerado a partir dos parametros da querystring
+    """
+
+    default_lang = current_app.config.get('BABEL_DEFAULT_LOCALE')
+    language = session.get('lang', default_lang)
+    qs_hash = _make_querystring_hash()
+    return _cache_key_format(language, request.path, qs_hash)

--- a/opac/webapp/utils/utils.py
+++ b/opac/webapp/utils/utils.py
@@ -365,3 +365,4 @@ def utc_to_local(utc_dt):
     local_dt = utc_dt.replace(tzinfo=pytz.utc).astimezone(local_tz)
 
     return local_tz.normalize(local_dt)
+


### PR DESCRIPTION
FIX: #785 

## Como testar:

1. Acessar o shell do opac
2. Executar o comando `python manage.py invalidate_cache_pattern <ARGS>`

## Args:
- `--force` (opcional) quando indicado, não vai pedir confirmação para o usuário;
- `--pattern` (obrigatorio, posicional) valor do pattern para filtar (tem que estar entre aspas)

## Exemplos:

1. `$ make dev_compose_exec_shell_webapp` acessamos o shell do container de dev;
2. `cd opac/` vamos para o diretório do projeto;
3. Vemos as opções para usar o comando:  `python manager.py invalidate_cache_pattern -?`. Saida:
```
usage: manager.py invalidate_cache_pattern [-?] [-f] pattern

positional arguments:
  pattern

optional arguments:
  -?, --help         show this help message and exit
  -f, --force_clear
```

### Limpar todo o cache:

- `python manager.py invalidate_cache_pattern '*'` (vai pedir confirmação do usuário);
- `python manager.py invalidate_cache_pattern '*' --force` (**não** vai pedir confirmação do usuário).

### Limpar objetos de um idioma inglês:
- `python manager.py invalidate_cache_pattern '*/LANG=en/*'` (vai pedir confirmação do usuário);
- `python manager.py invalidate_cache_pattern '*/LANG=en/*' --force` (**não** vai pedir confirmação do usuário).

### Limpar objetos filtrando pelo acrônimo da URL:
- `python manager.py invalidate_cache_pattern '*/csp/*'` (vai pedir confirmação do usuário);
- `python manager.py invalidate_cache_pattern '*/csp/*' --force` (**não** vai pedir confirmação do usuário).

### Limpar objetos filtrando pelo label de issue da URL:
- `python manager.py invalidate_cache_pattern '*v1n10*'` (vai pedir confirmação do usuário);
- `python manager.py invalidate_cache_pattern '*v1n10*' --force` (**não** vai pedir confirmação do usuário).