### PR TITLE
FIX: habilitando o widget de upload de imagem simples

### DIFF
--- a/opac/webapp/static/js/ckeditor/config.js
+++ b/opac/webapp/static/js/ckeditor/config.js
@@ -30,7 +30,7 @@ CKEDITOR.editorConfig = function( config ) {
     // The default plugins included in the basic setup define some buttons that
     // are not needed in a basic editor. They are removed here.
     // config.removeButtons = 'Cut,Copy,Paste,Undo,Redo,Anchor,Underline,Strike,Subscript,Superscript';
-    config.removeButtons = 'NewPage,Preview,Scayt,HiddenField,Form,Checkbox,Radio,TextField,Textarea,Select,Button,ImageButton,CreateDiv,Image,Flash,Smiley,SpecialChar,PageBreak,Iframe,About,Templates,Save,Print';
+    config.removeButtons = 'NewPage,Preview,Scayt,HiddenField,Form,Checkbox,Radio,TextField,Textarea,Select,Button,ImageButton,CreateDiv,Flash,Smiley,SpecialChar,PageBreak,Iframe,About,Templates,Save,Print';
 
     config.height = 500;
 


### PR DESCRIPTION
Ajuste para permitir a inserção de imagens no conteúdo, previamente precisa conhecer a URL da imagem:

#### exemplo:

![screenshot 2018-01-29 14 45 03](https://user-images.githubusercontent.com/805749/35522635-c9f0e354-0514-11e8-9783-1236aa8a45ad.png)
