### PR TITLE
FIXES (879): datas de criação e atualização de pag.info

### DIFF
--- a/opac/webapp/admin/views.py
+++ b/opac/webapp/admin/views.py
@@ -664,7 +664,17 @@ class PagesAdminView(OpacBaseAdminView):
         content=__('Conteúdo'),
         journal=__('Periódico'),
         description=__('Descrição'),
+        created_at=__('Data de Criação'),
+        updated_at=__('Data de Atualização'),
     )
+
+    column_filters = [
+        'name', 'language', 'journal', 'created_at', 'updated_at',
+    ]
+
+    column_searchable_list = [
+        'name', 'description', 'content',
+    ]
 
     create_template = 'admin/pages/edit.html'
     edit_template = 'admin/pages/edit.html'
@@ -681,12 +691,13 @@ class PagesAdminView(OpacBaseAdminView):
                      [(journal.acronym, journal.title) for journal in controllers.get_journals()]),
     )
 
-    def _content_formatter(self, context, model, name):
-        return Markup(model.content)
+    form_excluded_columns = ('created_at', 'updated_at')
 
-    column_formatters = {
-        'content': _content_formatter,
-    }
+    column_formatters = dict(
+        content=lambda v, c, m, p: Markup(m.content),
+        created_at=lambda v, c, m, p: m.created_at.strftime('%Y-%m-%d %H:%M:%S'),
+        updated_at=lambda v, c, m, p: m.updated_at.strftime('%Y-%m-%d %H:%M:%S'),
+    )
 
     def on_model_change(self, form, model, is_created):
         # é necessario definir um valor para o campo ``_id`` na criação.

--- a/opac/webapp/choices.py
+++ b/opac/webapp/choices.py
@@ -14,9 +14,9 @@ LANGUAGES_CHOICES = [
 ]
 
 INDEX_NAME = {
-    'SCIE':  'Science Citation Index',
-    'SSCI':  'Social Science Citation',
-    'A&HCI':  'Arts & Humanities Citation',
+    'SCIE': 'Science Citation Index',
+    'SSCI': 'Social Science Citation',
+    'A&HCI': 'Arts & Humanities Citation',
 }
 
 ISO3166_ALPHA2 = {

--- a/opac/webapp/main/views.py
+++ b/opac/webapp/main/views.py
@@ -430,6 +430,8 @@ def about_journal(url_seg):
 
     if page:
         context['content'] = page.content
+        if page.updated_at:
+            context['page_updated_at'] = page.updated_at
 
     return render_template("journal/about.html", **context)
 

--- a/opac/webapp/templates/collection/about.html
+++ b/opac/webapp/templates/collection/about.html
@@ -6,6 +6,11 @@
 
 <section class="collection collectionAbout">
     <div class="container">
+        {% if page %}
+            {% with page_updated_at=page.updated_at  %}
+                {% include "includes/page_updated_at_info.html" %}
+            {% endwith %}
+        {% endif %}
 
         {% if pages %}
 

--- a/opac/webapp/templates/includes/page_updated_at_info.html
+++ b/opac/webapp/templates/includes/page_updated_at_info.html
@@ -1,0 +1,21 @@
+<style type="text/css">
+  .page-updated-at {
+    float:right;
+    font-size: .75em;
+    color: #7f7a71;
+  }
+</style>
+
+{% if page_updated_at %}
+  <span class="page-updated-at">
+    {% with html_lang=session.get('lang', config.get('BABEL_DEFAULT_LOCALE')) %}
+      {% if html_lang == 'pt_BR' %}
+        (Atualizado: {{ page_updated_at.strftime('%d/%m/%Y %H:%M:%S') }})
+      {% elif html_lang == 'en' %}
+        (Updated: {{ page_updated_at.strftime('%m/%d/%Y %H:%M:%S') }})
+      {% elif html_lang == 'es' %}
+        (Actualizado: {{ page_updated_at.strftime('%d/%m/%Y %H:%M:%S') }})
+      {% endif %}
+    {% endwith %}
+  </span>
+{% endif %}

--- a/opac/webapp/templates/journal/about.html
+++ b/opac/webapp/templates/journal/about.html
@@ -30,6 +30,7 @@
             </div>
 
             <div class="col-md-12 content journalSecundary">
+                {% include "includes/page_updated_at_info.html" %}
                 <div class="row">
                     <div class="{% if journal.social_networks %}col-md-8 col-sm-8{% else %}col-md-12 col-sm-12{%endif%}">
                         {% if content %}


### PR DESCRIPTION
FIX: #879

AJUSTES:
- labels traduzíveis: `Data de Criação`, `Data de Atualização`
- adicionado filtros pelas colunas: 'name', 'language', 'journal', 'created_at', 'updated_at'
- adicionado search pelas colunas: 'name', 'description', 'content',
- formatação de datas na listagem de Pages no admin
- os campos de datas foram removidos do form de create/update


### screenshots:

#### colunas de datas no admin
<img width="521" alt="screenshot 2018-02-16 10 52 30" src="https://user-images.githubusercontent.com/805749/36309279-f1c2f4fc-131b-11e8-8faa-aed9c4b9b0fb.png">

#### filtros no admin
<img width="186" alt="screenshot 2018-02-16 10 52 43" src="https://user-images.githubusercontent.com/805749/36309280-f1f6fad6-131b-11e8-9df8-2c844a022889.png">

#### search pelo conteúdo da página
<img width="1159" alt="screenshot 2018-02-16 10 53 25" src="https://user-images.githubusercontent.com/805749/36309281-f21e3d8a-131b-11e8-86a6-cfd42360507e.png">

#### labels e formatação de datas no detail view
<img width="576" alt="screenshot 2018-02-16 10 53 40" src="https://user-images.githubusercontent.com/805749/36309282-f25ec076-131b-11e8-9e09-d728a80459b9.png">

#### exibição de data de atualização no site público:
##### nas páginas informativas da coleção
<img width="222" alt="screenshot 2018-02-16 10 53 55" src="https://user-images.githubusercontent.com/805749/36309283-f29bbb8e-131b-11e8-94d6-251117107d90.png">

##### nas páginas informativas do periódico
<img width="319" alt="screenshot 2018-02-16 11 12 02" src="https://user-images.githubusercontent.com/805749/36309284-f2c92c04-131b-11e8-9b89-b5b5fe8f01b3.png">

