### PR TITLE
inclusao da tag  {% include "journal/includes/contact_footer.html" %}…

### DIFF
--- a/opac/webapp/templates/journal/about.html
+++ b/opac/webapp/templates/journal/about.html
@@ -86,6 +86,8 @@
 
   {% endblock %}
 
+  {% include "journal/includes/contact_footer.html" %}
+
   {% include "includes/footer.html" %}
 
   {% include "journal/includes/alternative_header.html" %}


### PR DESCRIPTION
fix #777

foi incluida a tag {% include "journal/includes/contact_footer.html" %}… para adicionar o endereço do periódico na pagina de about.