### PR TITLE
[tk985] Melhorias no procedimento de carga das páginas informativas

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ LABEL org.label-schema.build-date=$OPAC_BUILD_DATE \
       org.label-schema.schema-version="1.0"
 
 RUN apk --update add --no-cache \
-    git gcc build-base zlib-dev jpeg-dev curl
+    git gcc build-base zlib-dev jpeg-dev curl libxml2-dev libxslt-dev py3-lxml
 
 COPY . /app
 WORKDIR /app

--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -21,7 +21,7 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
       org.label-schema.schema-version="1.0"
 
 RUN apk --update add --no-cache \
-    git gcc build-base zlib-dev jpeg-dev curl
+    git gcc build-base zlib-dev jpeg-dev curl libxml2-dev libxslt-dev py3-lxml
 
 
 COPY ./requirements.txt /app/requirements.txt

--- a/opac/manager.py
+++ b/opac/manager.py
@@ -5,12 +5,18 @@ import sys
 import json
 import fnmatch
 import unittest
+import logging
 from uuid import uuid4
+
+from slugify import slugify
+
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 WEBAPP_PATH = os.path.abspath(os.path.join(HERE, 'webapp'))
 sys.path.insert(0, HERE)
 sys.path.insert(1, WEBAPP_PATH)
+
+LOGGING_LEVEL = os.environ.get('LOGGING_LEVEL', 'DEBUG')
 
 FLASK_COVERAGE = os.environ.get('FLASK_COVERAGE', None)
 
@@ -30,7 +36,7 @@ else:
 from webapp import create_app, dbsql, dbmongo, mail, cache  # noqa
 from opac_schema.v1.models import Collection, Sponsor, Journal, Issue, Article  # noqa
 from webapp import controllers  # noqa
-from webapp.utils import reset_db, create_db_tables, create_user, create_image, create_page, extract_images, open_file, fix_page_content  # noqa
+from webapp.utils import reset_db, create_db_tables, create_user, create_image, create_page, extract_images, open_file, fix_page  # noqa
 from flask_script import Manager, Shell  # noqa
 from flask_migrate import Migrate, MigrateCommand  # noqa
 from webapp.admin.forms import EmailForm  # noqa
@@ -327,10 +333,14 @@ def populate_database(domain="http://127.0.0.1", filename="fixtures/default_info
 
 
 @manager.command
-def populate_journal_pages(directory=app.config['PAGE_PATH']):
+def populate_journal_pages(
+        pages_source_path=app.config['JOURNAL_PAGES_SOURCE_PATH'],
+        images_source_path=app.config['JOURNAL_IMAGES_SOURCE_PATH']
+        ):
     """
-    Esse comando cadastra as páginas secundárias dos periódicos localizado em
-    data/pages.
+    Esse comando faz o primeiro registro das páginas secundárias
+    dos periódicos localizado em /data/pages.
+    Cada vez que executa cria um novo registro.
 
     As páginas dos periódico SciELO contém a seguinte estrutura:
 
@@ -348,8 +358,11 @@ def populate_journal_pages(directory=app.config['PAGE_PATH']):
 
 
     """
-    acron_list = [journal.acronym for journal in Journal.objects.all()]
+    logging.basicConfig(level=LOGGING_LEVEL,
+                        filename='journal_pages.log',
+                        filemode='w')
 
+    acron_list = [journal.acronym for journal in Journal.objects.all()]
     file_names = {'en': ['iaboutj.htm',
                          'iedboard.htm',
                          'iinstruc.htm'],
@@ -360,43 +373,60 @@ def populate_journal_pages(directory=app.config['PAGE_PATH']):
                          'eedboard.htm',
                          'einstruc.htm'],
                   }
-
-    for acron in acron_list:
-        journal_dir = os.path.join(directory, acron)
-
+    j_total = len(acron_list)
+    done = 0
+    for j, acron in enumerate(sorted(acron_list)):
+        journal_pages_path = os.path.join(pages_source_path, acron)
+        print('{}/{} {}'.format(j, j_total, acron))
         for lang, files in file_names.items():
-            content = ''
 
-            print("Cadastrando as páginas do periódico com acrônimo: %s idioma: %s" % (acron, lang))
-
-            for file in files:
-                file_path = os.path.join(journal_dir, file)
-
-                try:
-                    fp = open_file(file_path, 'r', encoding='iso-8859-1')
-                except IOError as e:
-                    print(e)
-                else:
-                    content += fix_page_content(file, fp.read())
-
-            images_list = extract_images(content)
-
-            for image in images_list:
-                image_name = '%s_%s' % (acron, os.path.basename(image))
-                image_path = os.path.join(journal_dir, os.path.basename(image))
-
-                try:
-                    # Verifica se a imagem existe
-                    open_file(image_path, mode='r')
-                except IOError as e:
-                    print(e)
-                else:
-                    img = create_image(image_path, image_name, thumbnail=True)
-                    content = content.replace(image, img.get_absolute_url)
+            content = fix_page(journal_pages_path, files)
 
             if content:
-                create_page('Página secundária %s (%s)' % (acron.upper(), lang),
-                            lang, content, acron, 'Página secundária do periódico %s' % acron)
+                images_in_file = list(set(extract_images(content)))
+                images_in_file = [img
+                                  for img in images_in_file
+                                  if '://' not in img]
+
+                new_images = []
+                names_list = []
+                for img_in_file in images_in_file:
+                    img_basename = os.path.basename(img_in_file)
+                    name, ext = os.path.splitext(img_basename)
+                    names_list.append(name)
+                    if '/img/revistas/' in img_in_file:
+                        img_src_path = os.path.join(
+                            images_source_path,
+                            img_in_file[img_in_file.find('/img/revistas/') +
+                                        len('/img/revistas/'):])
+                    else:
+                        img_src_path = os.path.join(
+                            journal_pages_path, img_basename)
+                    try:
+                        # Verifica se a imagem existe
+                        open_file(img_src_path, mode='r')
+                    except IOError as e:
+                        logging.error(
+                            u'%s (corresponding to %s)' % (e, img_in_file))
+                    else:
+                        new_images.append((img_src_path, name, ext))
+
+                for img_src_path, img_name, ext in list(set(new_images)):
+                    alt_name = slugify(img_name)
+                    if alt_name not in names_list:
+                        img_name = alt_name
+
+                    img_dest_name = '%s_%s%s' % (acron, img_name, ext)
+                    img = create_image(
+                        img_src_path, img_dest_name, thumbnail=True)
+                    content = content.replace(
+                        img_in_file, img.get_absolute_url)
+                done += 1
+                create_page(
+                    'Página secundária %s (%s)' % (acron.upper(), lang),
+                    lang, content, acron,
+                    'Página secundária do periódico %s' % acron)
+    print('Páginas criadas: {}/{}'.format(done, j_total))
 
 
 if __name__ == '__main__':

--- a/opac/tests/pages/aa/eedboard.htm
+++ b/opac/tests/pages/aa/eedboard.htm
@@ -1,0 +1,158 @@
+<!--Data da &uacute;ltima atualiza&ccedil;&atilde;o: 09/10/2015 -->
+<html>
+<!-- #BeginTemplate "/Templates/aa_template.dwt" -->
+<head>
+<link rel="STYLESHEET" type="text/css" href="/css/revistas.css">
+<!-- #BeginEditable "doctitle" -->
+<title>Acta Amaz. - Cuerpo editorial</title>
+<!-- #EndEditable -->
+</head>
+<style>
+
+
+
+.rodape { font-family: Verdana, Arial, Helvetica, sans-serif; font-size: 8pt; color: #666666; text-align: center; font-weight: normal; font-style: normal}
+
+
+
+</style>
+<body>
+<table width="100%" border="0">
+ <tr>
+  <td width="30%" align="center" valign="top"><p><!-- #BeginEditable "link" --><a href="/scielo.php?script=sci_serial&pid=0044-5967&lng=es&nrm=iso"><img
+
+
+
+ src="/img/revistas/aa/plogo.gif" border="0"></a><!-- #EndEditable --></p>
+   <p align="center" class="issn">ISSN 0044-5967 <!-- #BeginEditable "impresso" --><i>versi&oacute;n 
+  
+  
+  
+  impresa</i><!-- #EndEditable --><br>
+   </p></td>
+  <td width="70%" valign="top" align="left"><!-- #BeginEditable "topo" -->
+  <blockquote>
+  <p class="titulo">CUERPO EDITORIAL</p>
+  <ul>
+   <li><a href="#001">Editor-Jefe</a></li>
+   <li><a href="#0011">Editor-Jefe Sustituto</a></li>
+   <li><a href="#002">Comisi&oacute;n editorial</a></li>
+   <li><a href="#003">Producci&oacute;n Editorial</a></li>
+  </ul>
+  </blockquote>
+  <!-- #EndEditable --></td>
+ </tr>
+</table>
+<!-- #BeginEditable "texto" -->
+<p>&nbsp;</p>
+<p class="subtitulo"><a name="001">Editor-Jefe</a></p>
+<table border="0" width="100%">
+ <tr>
+ <td width="15%"></td>
+ <td width="70%"><ul>
+  <li>Claudia Keller, Instituto Nacional de Pesquisas da Amazônia - INPA, Manaus, AM, Brasil<br>
+    <a title="mailto:claudiakeller23@gmail.com  CTRL + Click to follow link" href="mailto:claudiakeller23@gmail.com" target="_blank">claudiakeller23@gmail.com</a></li>
+  </ul></td>
+ <td width="15%"></td>
+ </tr>
+</table>
+<p>&nbsp;</p>
+<p class="subtitulo"><a name="0011"></a>Editor-Jefe Sustituto</p>
+<table border="0" width="100%">
+  <tr>
+    <td width="13%"></td>
+    <td width="70%"><ul>
+      <li>Luiz Antonio Candido, Instituto Nacional de Pesquisas da Amazônia - INPA, Manaus, AM, Brasil.</li>
+      <li>João Vicente Braga de Souza, Instituto Nacional de Pesquisas da Amazônia - INPA, Manaus, AM, Brasil.</li>
+    </ul></td>
+    <td width="15%"></td>
+  </tr>
+</table>
+<p></p>
+<p class="subtitulo">Comisi&oacute;n editorial</p>
+<table border="0" width="100%">
+ <tr>
+ <td width="15%"></td>
+ <td width="70%">
+      <ul><li> Alexandre Pio Viana, Universidade Estadual do Norte Fluminense Darcy Ribeiro, Campos dos Goytacazes, RJ, Brasil.<br>
+     <li> Alfredo Kingo Oyama Homma, Embrapa Amaz&ocirc;nia Oriental, Belem, PA, Brasil.<br>
+       <li> Ana Herrera, Universidad Central de Venezuela, Caracas, Venezuela.<br>
+        <li> Antonio Carlos de Azevedo, ESALQ - Universidade de S&atilde;o Paulo, Piracicaba, SP, Brasil.<br>
+        <li> Antonio Rodrigues Fernandes, Universidade Federal Rural da Amaz&ocirc;nia, Bel&eacute;m, PA, Brasil.<br>
+        <li> Carlos Jos&eacute; Sousa Passos, Universidade de Bras&iacute;lia, Bras&iacute;lia, DF. Brasil.<br>
+        <li> C&aacute;tia Henriques Callado, Universidade do Estado do Rio de Janeiro, Rio de Janeiro, RJ, Brasil.   
+        <li>Charlotte M. Taylor, Missouri Botanical Garden, St. Louis, MO, EUA.<br>
+        <li> Eraldo Rodrigues Lima, Universidade Federal de Vi&ccedil;osa, Vi&ccedil;osa, MG, Brasil.<br>
+        <li> Francesco Ripullone, Universit&agrave; degli Studi della Basilicata, Potenza, Italia.   
+        <li>Gilberto Fisch, Instituto de Aeronáutica e Espaço, São José dos Campos, SP, Brasil.<br>
+        <li> Jos&eacute; C&acirc;ndido Stevaux, Universidade Estadual Paulista, Rio Claro, SP, Brasil.        
+        <li>Jorge Mauricio David - Universidade Federal da Bahia, BA, Brasil<br>
+        <li> Linda Basson, University of the Free State, Bloemfontein, Sud&aacute;frica. 
+          <br>
+        <li> Marcos Tavares Dias, Embrapa Amap&aacute;, Macapa, AP, Brasil.          <br>
+        <li> Nat&aacute;lia Macedo Ivanauskas, Instituto Florestal, S&atilde;o Paulo, SP, Brasil.        
+        <li>Paulo Estefano Dineli Bobrowiec, Instituto Nacional de Pesquisas da Amazônia - INPA, Manaus, AM, Brasil.<br>
+        <li> Pit&aacute;goras da Concei&ccedil;&atilde;o Bispo, Universidade Estadual Paulista, Assis, SP, Brasil.<br>
+        <li> Ricarda Riina, Real Jard&iacute;n Bot&aacute;nico, Madrid, Espa&ntilde;a.<br>
+        <li> Rodrigo del Rio do Valle,Universidade Paulista, S&atilde;o Paulo, SP, Brasil.<br>
+        <li> Rosalee Albuquerque Coelho Netto, Instituto Nacional de Pesquisas da Amaz&ocirc;nia, Manaus, AM, Brasil.<br>
+        <li> Rosy Mary dos Santos Isaias, Universidade Federal de Minas Gerais, Belo Horizonte, MG, Brasil.   
+        <li>Steel Silva Vasconcelos, Embrapa Amazônia Oriental, Belem, PA, Brasil.<br>
+        <li>Tomas Ferreira Domingues, Universidade de S&atilde;o Paulo, Ribeir&atilde;o Preto, SP, Brasil.</li>
+ </ul></td><td width="15%"></td>
+ </tr>
+</table>
+<p>&nbsp;</p>
+<p class="subtitulo"><a name="003"></a>Producci&oacute;n Editorial</p>
+<table border="0" width="100%">
+ <tr>
+ <td width="15%"></td>
+ <td width="70%"><ul>
+  <li>Tito L&iacute;vio do Nascimento Fernandes, Instituto Nacional de Pesquisas 
+   
+   
+   
+   da Amaz&ocirc;nia - INPA.
+  <li>Rodrigo Verçosa<strong>, </strong>Instituto Nacional de Pesquisas da Amazônia - INPA, Manaus, AM, Brasil.  
+  
+ </ul></td>
+ <td width="15%"></td>
+ </tr>
+</table>
+<p>&nbsp;</p>
+<p align="center">[<a href="/scielo.php?script=sci_serial&pid=0044-5967&lng=es&nrm=iso">Home</a>] 
+ 
+ 
+ 
+ [<a href="eaboutj.htm">Acerca de esta revista</a>] [<a href="einstruc.htm">Instrucciones 
+ 
+ 
+ 
+ a los autores</a>] [<a href="esubscrp.htm">Subscripci&oacute;n</a>]</p>
+<hr size="1" noshade>
+<p class="rodape"><a href="http://creativecommons.org/licenses/by/4.0/" class="rodape"><img alt="Creative Commons License" style="border-width:0" src="http://i.creativecommons.org/l/by/4.0/80x15.png" border="0"></a> Todo el contenido de la revista, excepto d&oacute;nde est&aacute; identificado, est&#225; 
+ 
+ 
+ 
+ bajo una <a rel="license" href="http://creativecommons.org/licenses/by/4.0/deed.es" class="rodape">Licencia 
+ 
+ 
+ 
+ Creative Commons</a></p>
+<!-- #EndEditable -->
+<p><a name="end"></a></p>
+<p align="center" class="rodapep">Av. Andr&eacute; Araujo, 2936 Aleixo<br>
+ CEP 69011-970 Manaus AM Brasil<br>
+ Caixa Postal 478<br>
+ Tel.: +55 92 3642-3438 <br>
+ Fax: +55 92 3643-3223<br>
+</p>
+<p align="center"><img
+
+
+
+src="/img/revistas/e-mailt.gif" border="0"><br>
+ <a href="mailto:acta@inpa.gov.br">acta@inpa.gov.br</a></p>
+</body>
+<!-- #EndTemplate -->
+</html>

--- a/opac/tests/pages/abb/einstruc.htm
+++ b/opac/tests/pages/abb/einstruc.htm
@@ -1,0 +1,85 @@
+<html><!-- #BeginTemplate "/Templates/abb_template.dwt" --><!-- DW6 -->
+<head>
+<link rel="STYLESHEET" type="text/css" href="/css/revistas.css">
+<!-- #BeginEditable "doctitle" --> 
+
+<title>Mensaje de la revista</title>
+
+<!-- #EndEditable --> 
+</head>
+<style>
+.rodape {  font-family: Verdana, Arial, Helvetica, sans-serif; font-size: 8pt; color: #666666; text-align: center; font-weight: normal; font-style: normal}
+</style>
+<body>
+<table width="100%" border="0">
+  <tr> 
+    <td width="30%" align="center" valign="top"> 
+      <p><!-- #BeginEditable "link" --><a href="/scielo.php?script=sci_serial&pid=0102-3306&lng=es&nrm=iso"><img
+
+    src="/img/revistas/abb/plogo.gif" border="0"></a><!-- #EndEditable --></p>
+      <p align="center" class="issn">ISSN 0102-3306 <!-- #BeginEditable "impresso" --><i>versi&oacute;n 
+
+        impresa</i><!-- #EndEditable --><br>
+        ISSN 1677-941X <!-- #BeginEditable "online" --><i>versi&oacute;n online</i><!-- #EndEditable --></p>
+    </td>
+    <td width="70%" valign="top" align="left"><!-- #BeginEditable "topo" --> 
+
+      <blockquote> 
+
+        <p class="titulo">MENSAJE DE LA REVISTA</p>
+      </blockquote>
+
+      <!-- #EndEditable --></td>
+  </tr>
+</table>
+<!-- #BeginEditable "texto" --> 
+<p>&nbsp;</p>
+
+<table border="0" width="100%">
+
+  <tr> 
+
+    <td width="15%"></td>
+
+    <td width="70%">
+
+      <p align="left">Informaci&oacute;n a&uacute;n no disponible. Favor consultar la versi&oacute;n de la revista en ingl&eacute;s.</p>
+
+    </td>
+
+    <td width="15%"></td>
+
+  </tr>
+
+</table>
+
+<p align="center">[<a href="javascript:history.back()">Volver</a>]</p>
+
+<table border="0" width="100%">
+
+</table>
+
+<hr size="1" noshade>
+
+<p class="rodape"><a href="http://creativecommons.org/licenses/by/4.0/" class="rodape"><img alt="Creative Commons License" style="border-width:0" src="http://i.creativecommons.org/l/by/4.0/80x15.png" border="0"></a> 
+
+  Todo el contenido de la revista, excepto d&oacute;nde est&aacute; identificado, est&#225; 
+
+  bajo una <a rel="license" href="http://creativecommons.org/licenses/by/4.0/deed.es" class="rodape">Licencia 
+
+  Creative Commons</a></p>
+
+<!-- #EndEditable --> 
+<p><a name="end"></a> 
+</p>
+<p align="center" class="rodapep"><b>Sociedade Bot&acirc;nica do Brasil<br>
+Av. Presidente Ant&ocirc;nio Carlos, 6627<br>
+  Campus Pampulha UFMG<br>
+  Biblioteca Central 300B</b><br>
+  <b>31270-901 Belo Horizonte, MG, Brazil<br>
+</b><b>Phone (55 31) 3409 3960, (55 31) 3409 2683</b></p>
+<p align="center"><img
+src="/img/revistas/e-mailt.gif" border="0"><br>
+<a href="mailto:acta@botanica.org.br">acta@botanica.org.br</a></p>
+</body>
+<!-- #EndTemplate --></html>

--- a/opac/tests/pages/abb/pinstruc.htm
+++ b/opac/tests/pages/abb/pinstruc.htm
@@ -1,0 +1,85 @@
+<html><!-- #BeginTemplate "/Templates/abb_template.dwt" --><!-- DW6 -->
+<head>
+<link rel="STYLESHEET" type="text/css" href="/css/revistas.css">
+<!-- #BeginEditable "doctitle" --> 
+
+<title>Mensagem da revista</title>
+
+<!-- #EndEditable --> 
+</head>
+<style>
+.rodape {  font-family: Verdana, Arial, Helvetica, sans-serif; font-size: 8pt; color: #666666; text-align: center; font-weight: normal; font-style: normal}
+</style>
+<body>
+<table width="100%" border="0">
+  <tr> 
+    <td width="30%" align="center" valign="top"> 
+      <p><!-- #BeginEditable "link" --><a href="/scielo.php?script=sci_serial&pid=0102-3306&lng=pt&nrm=iso"><img
+
+    src="/img/revistas/abb/plogo.gif" border="0"></a><!-- #EndEditable --></p>
+      <p align="center" class="issn">ISSN 0102-3306 <!-- #BeginEditable "impresso" --><i>vers&atilde;o impressa</i><!-- #EndEditable --><br>
+        ISSN 1677-941X <!-- #BeginEditable "online" --><i>vers&atilde;o online</i><!-- #EndEditable --></p>
+    </td>
+    <td width="70%" valign="top" align="left"><!-- #BeginEditable "topo" --> 
+
+      <blockquote> 
+
+        <p class="titulo">MENSAGEM DA REVISTA</p>
+      </blockquote>
+<!-- #EndEditable --></td>
+  </tr>
+</table>
+<!-- #BeginEditable "texto" --> 
+
+
+<p>&nbsp;</p>
+
+<table border="0" width="100%">
+
+  <tr> 
+
+    <td width="15%"></td>
+
+    <td width="70%">
+
+      <p align="left">Informa&ccedil;&atilde;o n&atilde;o dispon&iacute;vel. Por favor consultar a vers&atilde;o em ingl&ecirc;s.</p>
+
+    </td>
+
+    <td width="15%"></td>
+
+  </tr>
+
+</table>
+
+<p align="center">[<a href="javascript:history.back()">Voltar</a>]</p>
+
+<table border="0" width="100%">
+
+</table>
+
+<hr size="1" noshade>
+
+<p class="rodape"><a href="http://creativecommons.org/licenses/by/4.0/" class="rodape"><img alt="Creative Commons License" style="border-width:0" src="http://i.creativecommons.org/l/by/4.0/80x15.png" border="0"></a> 
+
+   Todo o conte&uacute;do do peri&oacute;dico, exceto onde est&aacute; identificado, est&aacute; licenciado 
+  
+  sob uma <a href="http://creativecommons.org/licenses/by/4.0/" class="rodape">Licen&ccedil;a 
+  
+  Creative Commons</a></p>
+
+
+<!-- #EndEditable --> 
+<p><a name="end"></a> 
+</p>
+<p align="center" class="rodapep"><b>Sociedade Bot&acirc;nica do Brasil<br>
+Av. Presidente Ant&ocirc;nio Carlos, 6627<br>
+  Campus Pampulha UFMG<br>
+  Biblioteca Central 300B</b><br>
+  <b>31270-901 Belo Horizonte, MG, Brazil<br>
+</b><b>Phone (55 31) 3409 3960, (55 31) 3409 2683</b></p>
+<p align="center"><img
+src="/img/revistas/e-mailt.gif" border="0"><br>
+<a href="mailto:acta@botanica.org.br">acta@botanica.org.br</a></p>
+</body>
+<!-- #EndTemplate --></html>

--- a/opac/tests/pages/ea/iinstruc.htm
+++ b/opac/tests/pages/ea/iinstruc.htm
@@ -1,0 +1,145 @@
+﻿<html><!-- #BeginTemplate "/Templates/ea_template.dwt" -->
+
+<head>
+
+<link rel="STYLESHEET" type="text/css" href="/css/revistas.css">
+
+<!-- #BeginEditable "doctitle" --> 
+
+<title>Estud. av. - Instructions to authors</title>
+
+<!-- #EndEditable -->
+
+</head>
+
+<style>
+
+.rodape {  font-family: Verdana, Arial, Helvetica, sans-serif; font-size: 8pt; color: #666666; text-align: center; font-weight: normal; font-style: normal}
+
+</style>
+
+<body>
+
+<!-- #BeginEditable "texto" --> 
+
+<table border="0" width="100%">
+
+  <tr> 
+
+    <td valign="top" rowspan="4" width="30%"> 
+
+      <p align="center"><a href="/scielo.php?script=sci_serial&lng=en&pid=0103-4014&nrm=iso"><img src="/img/revistas/ea/plogo.gif" border="0"></a></p>
+
+      <p align="center" class="issn">ISSN 0103-4014 <i>printed version</i><br>
+
+        ISSN 1806-9592 <i>online version</i></p>
+
+    </td>
+
+    <td valign="top" width="50%"> 
+
+      <blockquote> 
+
+        <p align="left" class="titulo">INSTRUCTIONS TO AUTHORS</p>
+
+      </blockquote>
+
+    </td>
+
+  </tr>
+
+  <tr> 
+
+    <td valign="top" rowspan="3" width="70%">&nbsp; </td>
+
+  </tr>
+
+</table>
+
+<p>&nbsp;</p>
+
+<table border="0" width="100%">
+
+  <tr> 
+
+    <td width="15%"></td>
+
+    <td width="70%"> 
+
+      <p>Journal  Profile</p>
+
+      <p>With a rather unique  editorial profile among Brazilian academic publications, <em>Estudos Avan&ccedil;ados</em> publishes articles on subjects of humanistic, scientific  and technological culture.</p>
+      <p>Readership</p>
+      <p>Readers include  teachers and students from public and private high schools, undergraduate and  graduate students from public and private institutions of higher learning,  university professors of public and private institutions, researchers,  scientists, professionals, community and social movement leaders, public administrators,  politicians, businesspeople and journalists, among others.</p>
+      <p>Consideration  of manuscripts</p>
+      <p>Original articles  submitted for consideration will be analyzed firstly by the Editorial Desk for  compliance to editorial standards, internal coherence, relevance to the journal's  editorial line, and contribution to innovation in its field of knowledge.  Important notice: in this stage, the original manuscript must not exceed 40,000  characters with spaces.</p>
+      <p> If approved in the  preliminary stage, the manuscript is forwarded for a merit analysis of its  contents. This is the peer review stage, where both the consultants and the authors  remain anonymous. The manuscript is analyzed by the  journal's assessment tool. Expert opinions submitted by the consultants  are reviewed by the Editorial Desk for compliance with the rules of  publication, content and relevance. After this process, the manuscript is sent back  to its authors with a statement of acceptance, reformulation or rejection.</p>
+      <p>There is no fee for submission and review articles.</p>
+      <p>The moral and intellectual rights of articles belong to the authors, not being property of the journal.</p>
+      <p>Submission  of manuscripts</p>
+      <p>Original articles may  be submitted for consideration by e-mail, at <a href="mailto:estudosavancados@usp.br">estudosavancados@usp.br</a>, or online  via Scielo (Scientific Electronic Library Online).</p>
+      <p>General  guidelines</p>
+      <ol>
+        <li>The Editorial Desk of <em>Estudos Avan&ccedil;ados</em> requests, receives and distributes original texts  to qualified consultants for analysis and assessment of merit.</li>
+        <li>Authors' credits should include their degrees,  job and the institution to which they are affiliated, and recent publications  (if any), followed by a personal email.</li>
+        <li>The manuscript should include an Abstract (up  to ten lines) and a list of keywords, in both Portuguese and English.</li>
+        <li>Quotations of up to five lines should be included  in the body of the text, highlighted by double quotes. Those with more than  five lines should be set apart in an indented paragraph in smaller font.</li>
+        <li>Notes should be limited to explanatory texts  and comments, if required, set at the end of the text, before the  bibliographical references.</li>
+        <li>Bibliographical references should be cited between  parentheses in the text, in abbreviated form with the author's name, the year of  publication and the page number. For example: (Le Goff, 1980, p.134).</li>
+        <li>Full bibliographical references should be  listed at the end of the text and follow the ABNT rules.</li>
+        <li>In addition to being inserted in their proper  place in the text itself, image files (tables and/or pictures, graphs, photos  etc., in color or B&amp;W) should be sent separately, in the format in which they  were originally created and in high resolution for print.</li>
+        <li>The Editorial Desk reserves the right to  request a reduction in the number of pages of a text.</li>
+        <li>The Editorial Desk reserves the right to request a reduction in the  number of characters of text titles.</li>
+      </ol>
+    </td>
+
+    <td width="15%"></td>
+
+  </tr>
+
+</table>
+
+<p>&nbsp;</p>
+
+<p align="center">[<a href="/scielo.php?script=sci_serial&lng=en&pid=0103-4014&nrm=iso">Home</a>] 
+
+  [<a href="iaboutj.htm">About the journal</a>] [<a href="iedboard.htm">Editorial 
+
+  Board</a>] [<a href="isubscrp.htm">Subscription</a>]</p>
+
+<hr size="1" noshade>
+
+<p class="rodape"><a href="http://creativecommons.org/licenses/by-nc/4.0/" class="rodape"><img alt="Creative Commons License" style="border-width:0" src="http://i.creativecommons.org/l/by-nc/4.0/80x15.png" border="0"></a> 
+
+  All the content of the journal, except where otherwise noted, is licensed under 
+
+  a <a rel="license" href="http://creativecommons.org/licenses/by-nc/4.0/" class="rodape">Creative 
+
+  Commons License</a></p>
+
+<!-- #EndEditable --> <a name="end"></a> 
+
+<p align="center" class="rodape">&nbsp;</p>
+
+<p align="center" class="rodapep"><i>Instituto de Estudos Avan&ccedil;ados da 
+
+  Universidade de S&atilde;o Paulo</i></p>
+
+<p align="center" class="rodapep">Rua da Reitoria, 109 - Cidade Universit&aacute;ria<br>
+
+  05508-900 S&atilde;o Paulo SP - Brasil<br>
+
+  Tel: +55 11 3091-1675 / 3091-1676<br>
+
+  Fax: +55 11 3091-4306<br>
+
+</p>
+
+<p align="center"><a href="mailto:"><img src="/img/revistas/e-mailt.gif" border="0"></a><br>
+
+  <a href="mailto:estavan@usp.br">estavan@usp.br</a></p>
+
+</body>
+
+<!-- #EndTemplate --></html>
+

--- a/opac/tests/pages/ea/pinstruc.htm
+++ b/opac/tests/pages/ea/pinstruc.htm
@@ -1,0 +1,142 @@
+﻿<html><!-- #BeginTemplate "/Templates/ea_template.dwt" -->
+
+<head>
+
+<link rel="STYLESHEET" type="text/css" href="/css/revistas.css">
+
+<!-- #BeginEditable "doctitle" --> 
+
+<title>Estud. av. - Instru&ccedil;&otilde;es aos autores</title>
+
+<!-- #EndEditable -->
+
+</head>
+
+<style>
+
+.rodape {  font-family: Verdana, Arial, Helvetica, sans-serif; font-size: 8pt; color: #666666; text-align: center; font-weight: normal; font-style: normal}
+
+</style>
+
+<body>
+
+<!-- #BeginEditable "texto" --> 
+
+<table border="0" width="100%">
+
+  <tr> 
+
+    <td valign="top" rowspan="4" width="30%"> 
+
+      <p align="center"><a href="/scielo.php?script=sci_serial&lng=pt&pid=0103-4014&nrm=iso"><img src="/img/revistas/ea/plogo.gif" border="0"></a></p>
+
+      <p align="center" class="issn">ISSN 0103-4014 <i>vers&atilde;o impressa</i><br>
+
+        ISSN 1806-9592 <i>vers&atilde;o online</i></p>
+
+    </td>
+
+    <td valign="top" width="50%"> 
+
+      <blockquote> 
+
+        <p align="left" class="titulo">INSTRU&Ccedil;&Otilde;ES AOS AUTORES</p>
+
+      </blockquote>
+
+    </td>
+
+  </tr>
+
+  <tr> 
+
+    <td valign="top" rowspan="3" width="70%">&nbsp;</td>
+
+  </tr>
+
+</table>
+
+<p>&nbsp;</p>
+
+<table border="0" width="100%">
+
+  <tr> 
+
+    <td width="15%"></td>
+
+    <td width="70%"><p>Perfil</p>
+      <p>Com perfil  editorial bastante singular entre as publica&ccedil;&otilde;es acad&ecirc;micas brasileiras, <em>Estudos Avan&ccedil;ados</em> publica trabalhos  sobre temas de cultura human&iacute;stica, cient&iacute;fica e tecnol&oacute;gica.</p>
+      <p>P&uacute;blico leitor</p>
+      <p>Seu p&uacute;blico &eacute;  formado por professores e alunos da rede p&uacute;blica e privada do Ensino M&eacute;dio,  estudantes de gradua&ccedil;&atilde;o e p&oacute;s-gradua&ccedil;&atilde;o de institui&ccedil;&otilde;es de n&iacute;vel superior  p&uacute;blicas e privadas, professores universit&aacute;rios de institui&ccedil;&otilde;es p&uacute;blicas e  privadas, pesquisadores, cientistas, profissionais liberais, lideran&ccedil;as  comunit&aacute;rias e de movimentos sociais, adminstradores p&uacute;blicos, pol&iacute;ticos,  empres&aacute;rios, jornalistas, entre outros.</p>
+      <p>Aprecia&ccedil;&atilde;o de manuscritos</p>
+      <p>Os originais submetidos para aprecia&ccedil;&atilde;o ser&atilde;o  analisados em uma primeira etapa pela Mesa editorial, quanto &agrave; observ&acirc;ncia do  atendimento das normas editoriais, coer&ecirc;ncia interna do texto, pertin&ecirc;ncia do  conte&uacute;do do original a linha editorial do peri&oacute;dico e contribui&ccedil;&atilde;o para a  inova&ccedil;&atilde;o do conhecimento na &aacute;rea. Importante: para que possam ser avaliados  nessa primeira fase, os originais n&atilde;o poder&atilde;o ultrapassar 40 mil caracteres com  espa&ccedil;o.</p>
+      <p> Sendo aprovados na etapa preliminar, os  originais s&atilde;o encaminhados para aprecia&ccedil;&atilde;o de m&eacute;rito de seu conte&uacute;do. Para  tanto, utiliza-se o modelo&nbsp;<em>peer review, </em>de forma a garantir o  sigilo quanto &agrave; identidade dos consultores e dos autores. A an&aacute;lise do texto &eacute;  feita com base no instrumento de avalia&ccedil;&atilde;o do peri&oacute;dico. Os pareceres  encaminhados pelos consultores s&atilde;o analisados pela Mesa editorial quanto ao  cumprimento das normas de publica&ccedil;&atilde;o, conte&uacute;do e pertin&ecirc;ncia. Ap&oacute;s esse  processo, s&atilde;o enviados aos autores com indica&ccedil;&atilde;o de aceita&ccedil;&atilde;o, reformula&ccedil;&atilde;o ou  recusa.</p>
+      <p>N&atilde;o h&aacute; taxa para submiss&atilde;o e avalia&ccedil;&atilde;o de artigos.</p>
+      <p>Os direitos morais e intelectuais dos artigos pertencem aos respectivos autores, não sendo propriedade da revista.</p>
+      <p>Envio de manuscritos</p>
+      <p>Os originais para aprecia&ccedil;&atilde;o podem ser  submetidos por meio do endere&ccedil;o eletr&ocirc;nico oficial da revista <em>Estudos  Avan&ccedil;ados </em>(<a href="mailto:estudosavancados@usp.br">estudosavancados@usp.br</a>), ou por meio de submiss&atilde;o&nbsp;<em>on-line</em> via Scielo (Scientific  Electronic Library Online). </p>
+      <p>Normas gerais</p>
+      <p>1. A Mesa Editorial de <em>Estudos Avan&ccedil;ados</em> solicita, recebe e  distribui textos a conselheiros qualificados para an&aacute;lise e aprecia&ccedil;&atilde;o de  m&eacute;rito.<br>
+        <br>
+        2. Os cr&eacute;ditos dos autores dever&atilde;o trazer  sua titula&ccedil;&atilde;o, fun&ccedil;&atilde;o e institui&ccedil;&atilde;o a que est&atilde;o vinculados, &uacute;ltimas publica&ccedil;&otilde;es  (se houver), seguidas de <em>e-mail</em> pessoal.</p>
+      <p>3. Os textos dever&atilde;o trazer Resumo (at&eacute; dez linhas) e Palavras-chave, com respectiva vers&atilde;o  inglesa (Abstract e Keywords).</p>
+      <p>4. Textos citados, com at&eacute; cinco linhas,  entrar&atilde;o no corpo do texto principal, destacados por aspas duplas. Os textos  citados com mais de cinco linhas  dever&atilde;o  entrar com destaque, de forma recuada, em corpo menor.  <br>
+        <br>
+        5. As Notas dever&atilde;o se restringir a  textos e coment&aacute;rios explicativos, se necess&aacute;rios, inseridas no final do texto,  antes das Refer&ecirc;ncias bibliogr&aacute;ficas.</p>
+      <p>6. As Refer&ecirc;ncias bibliogr&aacute;ficas dever&atilde;o ser citadas no  texto, de forma abreviada, entre par&ecirc;nteses, pelo nome do autor, ano da obra e  o n&uacute;mero de p&aacute;gina. Exemplo: (Le Goff, 1980, p.134).<br>
+        <br>
+        7. As Refer&ecirc;ncias bibliogr&aacute;ficas completas dever&atilde;o ser  listadas no final do texto, obedecendo-se &agrave;s regras da ABNT.</p>
+      <p>8. Al&eacute;m de inseridos no texto, os arquivos  de imagens (tabelas e/ou figuras, gr&aacute;ficos, fotos etc., em cores ou p&amp;b) dever&atilde;o  ser encaminhados em separado, na extens&atilde;o em que foram originalmente criados, e  em alta resolu&ccedil;&atilde;o para impress&atilde;o.</p>
+      <p>9. A Mesa Editorial se reserva o direito de solicitar a redu&ccedil;&atilde;o  do n&uacute;mero de p&aacute;ginas dos textos.</p>
+    10.  A Mesa Editorial se reserva o direito de solicitar a redu&ccedil;&atilde;o do n&uacute;mero de  caracteres dos t&iacute;tulos dos textos.</td>
+
+    <td width="15%"></td>
+
+  </tr>
+
+</table>
+
+<p>&nbsp;</p>
+
+<p align="center">[<a href="/scielo.php?script=sci_serial&lng=pt&pid=0103-4014&nrm=iso">Home</a>] 
+
+  [<a href="paboutj.htm">Sobre esta revista</a>] [<a href="pedboard.htm">Corpo 
+
+  editorial</a>] [<a href="psubscrp.htm">Assinaturas</a>]</p>
+
+<hr size="1" noshade>
+
+<p class="rodape"><a href="http://creativecommons.org/licenses/by-nc/4.0/" class="rodape"><img alt="Creative Commons License" style="border-width:0" src="http://i.creativecommons.org/l/by-nc/4.0/80x15.png" border="0"></a> 
+
+  Todo o conte&uacute;do do peri&oacute;dico, exceto onde est&aacute; identificado, est&aacute; licenciado 
+
+  sob uma <a href="http://creativecommons.org/licenses/by-nc/4.0/" class="rodape">Licen&ccedil;a 
+
+  Creative Commons</a></p>
+
+<!-- #EndEditable --> <a name="end"></a> 
+
+<p align="center" class="rodape">&nbsp;</p>
+
+<p align="center" class="rodapep"><i>Instituto de Estudos Avan&ccedil;ados da 
+
+  Universidade de S&atilde;o Paulo</i></p>
+
+<p align="center" class="rodapep">Rua da Reitoria, 109 - Cidade Universit&aacute;ria<br>
+
+  05508-900 S&atilde;o Paulo SP - Brasil<br>
+
+  Tel: +55 11 3091-1675 / 3091-1676<br>
+
+  Fax: +55 11 3091-4306<br>
+
+</p>
+
+<p align="center"><a href="mailto:"><img src="/img/revistas/e-mailt.gif" border="0"></a><br>
+
+  <a href="mailto:estavan@usp.br">estavan@usp.br</a></p>
+
+</body>
+
+<!-- #EndTemplate --></html>
+

--- a/opac/tests/pages/eagri/pedboard.htm
+++ b/opac/tests/pages/eagri/pedboard.htm
@@ -1,0 +1,183 @@
+<!--Atualizado em 07/03/13 -->
+<html><!-- #BeginTemplate "/Templates/eagri_template.dwt" --><!-- DW6 -->
+
+<head>
+
+<link rel="STYLESHEET" type="text/css" href="/css/revistas.css">
+
+<!-- #BeginEditable "doctitle" -->
+<title>Eng. Agr&iacute;c. - Corpo editorial</title>
+<!-- #EndEditable --> 
+
+</head>
+
+<body>
+
+<table width="100%" border="0">
+
+  <tr> 
+
+    <td width="30%" align="center" valign="top"> 
+
+      <p><!-- #BeginEditable "link" --><a href="/scielo.php?script=sci_serial&pid=0100-6916
+
+
+
+&lng=pt&nrm=iso"><img
+
+
+
+    src="/img/revistas/eagri/plogo.gif" border="0"></a><!-- #EndEditable --></p>
+
+      <p align="center" class="issn">ISSN 0100-6916 <!-- #BeginEditable "impressa" --><i> vers&atilde;o impresa</i><!-- #EndEditable --><br>
+
+        ISSN 1808-4389<i> <!-- #BeginEditable "cd-rom" -->versión CD-ROM<!-- #EndEditable --></i></p>
+
+    </td>
+
+    <td width="70%" valign="top" align="left"><!-- #BeginEditable "topo" -->
+      <blockquote>
+        <p class="titulo">CORPO EDITORIAL</p>
+      </blockquote>
+      <ul>
+        <li><a href="#001">Conselho editorial</a></li>
+        <li><a href="#002">Editores de &aacute;rea</a></li>
+		<li><a href="#0033">Secret&aacute;rios</a></li>
+        <li><a href="#003">Revis&atilde;o de textos</a></li>
+      </ul>
+      <!-- #EndEditable --></td>
+
+  </tr>
+
+</table>
+
+<!-- #BeginEditable "texto" -->
+<p>&nbsp;</p>
+<p class="subtitulo"><a name="001"></a>Conselho editorial</p>
+<table border="0" width="100%">
+  <tr>
+    <td width="15%"></td>
+    <td width="70%"><p><strong>Editor</strong><br>
+Rog&eacute;rio Teixeira de Faria &ndash; Faculdade de Ci&ecirc;ncias Agr&aacute;rias e Veterin&aacute;rias -  FCAV/UNESP, Jaboticabal, SP, Brasil <a href="mailto:rogeriofaria@fcav.unesp.br">rogeriofaria@fcav.unesp.br</a><br>
+<br>
+<strong>Editor Adjunto</strong><br>
+Luiz Carlos Pavani &ndash; Associa&ccedil;&atilde;o Brasileira de Engenharia Agr&iacute;cola - SBEA, Jaboticabal, SP, Brasil <a href="mailto:pavani.lc@gmail.com">pavani.lc@gmail.com</a><br>
+<br>
+    <strong>Editor Gerente</strong><br>
+Higor Tadeu Deluca &ndash; Associa&ccedil;&atilde;o Brasileira de Engenharia Agr&iacute;cola - SBEA,     Jaboticabal, SP, Brasil <a href="mailto:higor@sbea.org.br">higor@sbea.org.br</a><br>
+  </td>
+    <td width="15%"></td>
+  </tr>
+</table>
+<p>&nbsp;</p>
+<p class="subtitulo"><a name="002"></a>Editores de &aacute;rea</p>
+<table border="0" width="100%">
+  <tr>
+    <td width="15%"></td>
+    <td width="70%"><p> <strong>Constru&ccedil;&otilde;es Rurais e Ambi&ecirc;ncia</strong><br>
+      Daniella Jorge de Moura &ndash; Faculdade de Engenharia Agr&iacute;cola - FEAGRI/UNICAMP, Campinas-SP, Brasil <a href="emailto:daniella.moura@feagri.unicamp.br">daniella.moura@feagri.unicamp.br</a><br>
+      Danilo Florentino Pereira &ndash; Faculdade de Ci&ecirc;ncias e Engenharia - UNESP, Tup&atilde;, SP, Brasil <a href="emailto:danilo@tupa.unesp.br">danilo@tupa.unesp.br</a><br>
+      Edilson Costa &ndash; Universidade Estadual do Mato Grosso do Sul - UEMS, Cassil&acirc;ncia, MS, Brasil <a href="emailto:mestrine@uems.br">mestrine@uems.br</a><br>
+      <br>
+      <strong>Energia na Agricultura</strong><br>
+      Daniel Albiero &ndash; Universidade Federal do Cear&aacute; &ndash; UFC, Fortaleza, CE, Brasil <a href="emailto:daniel.albiero@gmail.com">daniel.albiero@gmail.com</a><br>
+      Luiz Ant&ocirc;nio Rossi - Faculdade de Engenharia Agr&iacute;cola - FEAGRI/UNICAMP, Campinas-SP, Brasil <a href="emailto:rossi@feagri.unicamp.br">rossi@feagri.unicamp.br</a><br>
+      <br>
+      <strong>Engenharia de &Aacute;gua e Solo</strong><br>
+      Adunias dos Santos Teixeira &ndash; Universidade Federal do Cear&aacute; &ndash; UFC, Fortaleza, CE, Brasil <a href="emailto:adunias@ufc.br">adunias@ufc.br</a><br>
+      Alexandre Barcellos Dalri Faculdade de Ci&ecirc;ncias Agr&aacute;rias e Veterin&aacute;rias - FCAV/UNESP, Jaboticabal, SP, Brasil <a href="emailto:dalri@fcav.unesp.br">dalri@fcav.unesp.br</a><br>
+      Ant&ocirc;nio Carlos Andrade Gon&ccedil;alves &ndash; Universidade Estadual de Maring&aacute; &ndash; UEM, Maring&aacute;, PR, Brasil <a href="emailto:goncalves.aca@gmail.com">goncalves.aca@gmail.com</a><br>
+      Danilton Luiz Flumignan &ndash; Empresa Brasileira de Pesquisa Agropecu&aacute;ria &ndash; EMBRAPA, Dourados, MS, Brasil <a href="emailto:danilton.flumignan@embrapa.br">danilton.flumignan@embrapa.br</a><br>
+      Edna Maria Bonfim-Silva &ndash; Universidade Federal do Mato Grosso &ndash;UFMT,  Rondon&oacute;polis, MT, Brasil <a href="emailto:embonfim@hotmail.com">embonfim@hotmail.com</a><br>
+      <br>
+      <strong>M&aacute;quinas e Mecaniza&ccedil;&atilde;o Agr&iacute;cola</strong><br>
+      Renato Levien &ndash; Universidade Federal do Rio grande do Sul &ndash; UFRGS, Porto Alegre, RS, Brasil <a href="emailto:renatole@ufrgs.br">renatole@ufrgs.br</a><br>
+      Jo&atilde;o Paulo Arantes Rodrigues da Cunha &ndash; Universidade Federal de Uberl&acirc;ndia &ndash; UFU,  Uberl&acirc;ndia, MG, Brasil <a href="emailto:goncalves.aca@gmail.com">jpcunha@ufu.br</a><br>
+      Murilo Mesquita Baesso &ndash; Universidade de S&atilde;o Paulo &ndash; USP, Pirassununga,SP, Brasil <a href="emailt:baesso@usp.br">baesso@usp.br</a><br>
+      <br>
+      <strong>Ci&ecirc;ncia e Tecnologia P&oacute;s-Colheita</strong><br>
+      Andr&eacute; Lu&iacute;s Duarte Goneli &ndash; Universidade Federal da Grande Dourados - UFGD, Dourados, MS, Brasil <a href="emailto:andregoneli@ufgd.edu.br">andregoneli@ufgd.edu.br</a><br>
+      Ednilton Tavares de Andrade  &ndash; Universidade Federal de Lavras -UFLA, Lavras, MG, Brasil <a href="emailto:edniltontavares@gmail.com">edniltontavares@gmail.com</a><br>
+      <br>
+      <strong>Geom&aacute;tica</strong><br>
+      Edson Eyji Sano &ndash; Empresa Brasileira de Pesquisa Agropecu&aacute;ria &ndash; EMBRAPA, Planaltina, GO, Brasil <a href="emailto:edson.sano@embrapa.br">edson.sano@embrapa.br</a><br>
+      Teresa Cristina Tarl&eacute; Pissarra &ndash; Faculdade de Ci&ecirc;ncias Agr&aacute;rias e Veterin&aacute;rias - FCAV/UNESP, Jaboticabal, SP, Brasil <a href="emailto:teresap@fcav.unesp.br">teresap@fcav.unesp.br</a><br>
+      <br>
+      <strong>Saneamento e Controle Ambiental</strong><br>
+      Ant&ocirc;nio Teixeira de Matos &ndash; Universidade Federal de Minas Gerais - UFMG, Belo Horizonte, MG, Brasil <br>
+      <a href="emailto:atmatos@ufv.br">atmatos@ufv.br</a><br>
+      Airton Kunz &ndash; Empresa Brasileira de Pesquisa Agropecu&aacute;ria &ndash; EMBRAPA,  Conc&oacute;rdia, SC, Brasil <a href="emailto:airton.kunz@embrapa.br">airton.kunz@embrapa.br</a><br>
+      <br>
+      <strong>Temas Interdisciplinares</strong><br>
+      Rivanildo Dallacort &ndash; Universidade do Estado de Mato Grosso &ndash;UNEMAT, Tangar&aacute; da Serra, MT, Brasil <a href="emailto:rivanildo@unemat.br">rivanildo@unemat.br</a><br>
+    </p></td>
+    <td width="15%"></td>
+  </tr>
+</table>
+<p>&nbsp;</p>
+<p class="subtitulo"><a name="0033"></a>Secret&aacute;rios:</p>
+<table border="0" width="100%">
+  <tr>
+    <td width="15%"></td>
+    <td width="70%"><p>Luana Martini Pugliano &ndash;  Associa&ccedil;&atilde;o Brasileira de Enhgenharia Agr&iacute;cola - SBEA, &nbsp;Jaboticabal, SP, Brasil <a href="emailto:contato.sbea@gmail.com">contato.sbea@gmail.com</a><strong> </strong></p></td>
+    <td width="15%"></td>
+  </tr>
+</table>
+<p></p>
+<p class="subtitulo"><a name="003"></a>Revis&atilde;o de textos</p>
+<table border="0" width="100%">
+  <tr>
+    <td width="15%"></td>
+    <td width="70%"><p> <strong>Ingl&ecirc;s</strong><br>
+      Servi&ccedil;os T&eacute;cnicos de Tradu&ccedil;&atilde;o e An&aacute;lises &ndash; STTA,  Ribeir&atilde;o Preto, SP, Brasil <a href="emailto:stta@stta.com.br">stta@stta.com.br</a><br>
+      </p></td>
+    <td width="15%"></td>
+  </tr>
+</table>
+<p>&nbsp;</p>
+<p align="center">[<a href="/scielo.php?script=sci_serial&lng=pt&pid=0100-6916&nrm=iso">Home</a>] 
+  
+  
+  
+  [<a href="paboutj.htm">Sobre esta revista</a>] [<a href="pinstruc.htm">Instru&ccedil;&otilde;es 
+  
+  
+  
+  aos autores</a>] [<a href="psubscrp.htm">Assinaturas</a>]</p>
+<hr size="1" noshade>
+<p class="rodape"><a href="http://creativecommons.org/licenses/by/4.0/" class="rodape"><img alt="Creative Commons License" style="border-width:0" src="http://i.creativecommons.org/l/by/4.0/80x15.png" border="0"></a> Todo o conte&uacute;do do peri&oacute;dico, exceto onde est&aacute; identificado, est&aacute; licenciado 
+  
+  
+  
+  sob uma <a href="http://creativecommons.org/licenses/by/4.0/" class="rodape">Licen&ccedil;a 
+  
+  
+  
+  Creative Commons</a></p>
+<!-- #EndEditable --> 
+
+<hr noshade>
+
+<a name="end"></a> 
+
+<p align="center" class="rodape"> Sociedade Brasileira de Engenharia Agr&iacute;cola</p>
+
+<p align="center" class="rodapep">Via de Acesso Prof. Paulo Donato Castellane, 
+
+  km 5<br>
+
+  FCAV/UNESP - Departamento de Engenharia Rural<br>
+
+  14884.900 - Jaboticabal - SP<br>
+
+  Tel./Fax.: +55 16 3203 3341</p>
+
+<p align="center"><img
+
+src="/img/revistas/e-mailt.gif" border="0"><br>
+
+  <a href="mailto:sbea@sbea.org.br" target="_blank">sbea@sbea.org.br</a></p>
+
+</body>
+
+<!-- #EndTemplate --></html>

--- a/opac/tests/pages/eins/eedboard.htm
+++ b/opac/tests/pages/eins/eedboard.htm
@@ -1,0 +1,39 @@
+<html>
+<head>
+<link rel="stylesheet" href="/css/revistas.css">
+<title>trocaabrev - Mensaje de la Revista</title>
+</head>
+<body>
+<table border="0" width="100%">
+  <tr> 
+    <td rowspan="4" width="20%"> 
+      <p align="center"><a href="/scielo.php?lng=es"><img
+    src="/img/revistas/fbpelogp.gif" alt="Scientific Electronic Library Online"
+    border="0"></a></p>
+      <p align="center"> 
+    </td>
+    <td valign="top" width="50%"> 
+      <blockquote> 
+        <p align="left" class="titulo"><b>MENSAJE DE LA REVISTA</b></p>
+      </blockquote>
+    </td>
+  </tr>
+  <tr> 
+    <td valign="top" rowspan="3" width="50%"></td>
+  </tr>
+</table>
+<p>&nbsp;</p>
+<table border="0" width="100%">
+  <tr> 
+    <td width="15%"></td>
+    <td width="70%"> 
+      <p align="left">Informaci&oacute;n a&uacute;n no disponible.</td>
+    <td width="15%"></td>
+  </tr>
+</table>
+<table border="0" width="100%">
+</table>
+<p align="center">[<a href="javascript:history.back()">Volver</a>]</p>
+<hr size="2" noshade>
+</body>
+</html>

--- a/opac/tests/test_utils_journal_static_page.py
+++ b/opac/tests/test_utils_journal_static_page.py
@@ -1,0 +1,149 @@
+# coding: utf-8
+
+import os
+from .base import BaseTestCase
+
+from . import utils
+
+from webapp.utils.journal_static_page import JournalStaticPageFile
+
+
+"""
+abb/eedboard.htm (unavailable)
+ea/eaboutj.htm (header contains 'href="#0')
+abb/iaboutj.htm
+    (header contains 'Editable')
+    <p class="subtitulo"><b><a name="03"></a>Intellectual Property</b></p>
+    <p class="subtitulo"><a name="04"><b>Sponsor</b></a></p>
+    footer padrao
+abb/iinstruc.htm
+    <p class="subtitulo"><em><a name="001"><b>Scope of the journal</b></a></em></p>
+    codificacao
+ea/eedboard.htm
+<p class="subtitulo"><a name="001"></a><b>Editor</b></p>
+"""
+
+FIXTURE_PATH = 'opac/tests/pages/'
+
+
+class JournalStaticPageTestCase(BaseTestCase):
+
+    html = {
+        'aa_eedboard': FIXTURE_PATH+'aa/eedboard.htm',
+        'ea_iinstruc': FIXTURE_PATH+'ea/iinstruc.htm',
+        'ea_pinstruc': FIXTURE_PATH+'ea/pinstruc.htm',
+        'abb_pinstruc': FIXTURE_PATH+'abb/pinstruc.htm',
+        'abb_einstruc': FIXTURE_PATH+'abb/einstruc.htm',
+        'eagri_pedboard': FIXTURE_PATH+'eagri/pedboard.htm',
+        'eins_eedboard': FIXTURE_PATH+'eins/eedboard.htm',
+    }
+
+    def test_insert_bold_to_p_subtitulo_aa_eedboard(self):
+        jspf = JournalStaticPageFile(self.html['aa_eedboard'])
+
+        self.assertEqual(jspf.body_content.count('class="subtitulo"'), 4)
+        self.assertTrue(
+            '<p class="subtitulo"><a name="001">Editor-Jefe</a></p>'
+            in jspf.body_content
+        )
+        self.assertTrue(
+            '<p class="subtitulo"><a name="0011"></a>Editor-Jefe Sustituto</p>'
+            in jspf.body_content)
+        self.assertTrue(
+            '<p class="subtitulo">Comisión editorial</p>' in
+            jspf.body_content)
+        jspf._insert_bold_to_p_subtitulo()
+        self.assertEqual(jspf.body_content.count('class="subtitulo"'), 0)
+        self.assertTrue(
+            '<p><b>Comisión editorial</b></p>' in jspf.body_content)
+        self.assertTrue(
+            '<p><b><a name="001">Editor-Jefe</a></b></p>' in jspf.body_content
+        )
+        self.assertTrue(
+            '<p><a name="0011"></a><b>Editor-Jefe Sustituto</b></p>'
+            in jspf.body_content)
+
+    def test_remove_anchors_abb_pinstruc(self):
+        jspf = JournalStaticPageFile(self.html['abb_pinstruc'])
+        self.assertTrue('<a name="end"></a>' in jspf.body_content)
+        jspf._remove_anchors()
+        self.assertTrue('<a name="end"></a>' not in jspf.body_content)
+
+    def test_remove_anchors_aa_eedboard(self):
+        jspf = JournalStaticPageFile(self.html['aa_eedboard'])
+
+        self.assertEqual(jspf.body_content.count('class="subtitulo"'), 4)
+        self.assertTrue(
+            '<p class="subtitulo"><a name="001">Editor-Jefe</a></p>'
+            in jspf.body_content
+        )
+        self.assertTrue(
+            '<p class="subtitulo"><a name="0011"></a>Editor-Jefe Sustituto</p>'
+            in jspf.body_content)
+
+        self.assertTrue('<a name="0011"' in jspf.body_content)
+        jspf._remove_anchors()
+        self.assertTrue(
+            '<p class="subtitulo">Editor-Jefe Sustituto</p>'
+            in jspf.body_content)
+
+    def test_middle_text_ea_pinstruc(self):
+        jspf = JournalStaticPageFile(self.html['ea_pinstruc'])
+        text = '<p>6. As Referências bibliográficas deverão ser citadas no  texto,'
+        self.assertTrue(text in jspf.middle_text)
+
+    def test_read_iso_8859_1_eagri_pedboard(self):
+        jspf = JournalStaticPageFile(self.html['eagri_pedboard'])
+        self.assertTrue('Agrícola' in jspf.body_content)
+        self.assertTrue('Associação' in jspf.body_content)
+
+    def test_indicate_middle_begin_abb_pinstruc(self):
+        jspf = JournalStaticPageFile(self.html['abb_pinstruc'])
+        self.assertTrue('Editable' in jspf.body_content)
+        self.assertFalse('"middle_begin"' in jspf.body_content)
+        jspf._indicate_middle_begin()
+        self.assertTrue('"middle_begin"' in jspf.body_content)
+
+    def test_indicate_middle_begin_aa_eedboard(self):
+        jspf = JournalStaticPageFile(self.html['aa_eedboard'])
+        self.assertTrue('href="#0' in jspf.body_content)
+        self.assertFalse('"middle_begin"' in jspf.body_content)
+        jspf._indicate_middle_begin()
+        self.assertTrue('"middle_begin"' in jspf.body_content)
+
+    def test_indicate_middle_begin_ea_iinstruc(self):
+        jspf = JournalStaticPageFile(self.html['ea_iinstruc'])
+        self.assertTrue('script=sci_serial' in jspf.body_content)
+        self.assertFalse('"middle_begin"' in jspf.body_content)
+        jspf._indicate_middle_begin()
+        self.assertTrue('"middle_begin"' in jspf.body_content)
+
+    def test_indicate_middle_begin_eins_eedboard(self):
+        jspf = JournalStaticPageFile(self.html['eins_eedboard'])
+        self.assertTrue('/scielo.php?lng=' in jspf.body_content)
+        self.assertFalse('"middle_begin"' in jspf.body_content)
+        jspf._indicate_middle_begin()
+        self.assertTrue('"middle_begin"' in jspf.body_content)
+
+    def test_middle_end_abb_pinstruc(self):
+        jspf = JournalStaticPageFile(self.html['abb_pinstruc'])
+        self.assertTrue('javascript:history.back()' in jspf.body_content)
+        self.assertFalse('"middle_end"' in jspf.body_content)
+        jspf._indicate_middle_end()
+        self.assertTrue('"middle_end"' in jspf.body_content)
+
+    def test_indicate_middle_end_aa_eedboard(self):
+        jspf = JournalStaticPageFile(self.html['aa_eedboard'])
+        self.assertTrue('script=sci_serial' in jspf.body_content)
+        self.assertTrue('Home' in jspf.body_content)
+        self.assertFalse('"middle_end"' in jspf.body_content)
+        jspf._indicate_middle_end()
+        self.assertTrue('"middle_end"' in jspf.body_content)
+
+    def test_unavailable_msg_es_abb_einstruc(self):
+        jspf = JournalStaticPageFile(self.html['abb_einstruc'])
+        self.assertTrue(jspf.ES_UNAVAILABLE_MSG in jspf.unavailable_message)
+
+    def test_unavailable_message_pt_abb_pinstruc(self):
+        jspf = JournalStaticPageFile(self.html['abb_pinstruc'])
+        self.assertTrue(jspf.PT_UNAVAILABLE_MSG in jspf.unavailable_message)

--- a/opac/webapp/config/default.py
+++ b/opac/webapp/config/default.py
@@ -250,13 +250,19 @@ GA_TRACKING_CODE = os.environ.get('GA_TRACKING_CODE', None)
 # debug toolbar:
 DEBUG_TB_INTERCEPT_REDIRECTS = False
 
+# paginas secundarias
+DATA_PATH = os.path.join(PROJECT_PATH, '../../data')
+JOURNAL_PAGES_SOURCE_PATH = os.environ.get(
+  'OPAC_JOURNAL_PAGES_SOURCE_PATH', os.path.join(DATA_PATH, 'pages'))
+JOURNAL_IMAGES_SOURCE_PATH = os.environ.get(
+  'OPAC_JOURNAL_IMAGES_SOURCE_PATH', os.path.join(DATA_PATH, 'img'))
+
 # media files
 DEFAULT_MEDIA_ROOT = os.path.abspath(os.path.join(PROJECT_PATH, 'media'))
 MEDIA_ROOT = os.environ.get('OPAC_MEDIA_ROOT', DEFAULT_MEDIA_ROOT)
 IMAGE_ROOT = os.path.join(MEDIA_ROOT, 'images')
 FILE_ROOT = os.path.join(MEDIA_ROOT, 'files')
 MEDIA_URL = os.environ.get('OPAC_MEDIA_URL', '/media')
-PAGE_PATH = os.path.abspath(os.path.join(PROJECT_PATH, '../../data/pages'))
 
 # extensions
 FILES_ALLOWED_EXTENSIONS = ('txt', 'pdf', 'csv', 'xls', 'doc', 'ppt', 'xlsx', 'docx', 'pptx', 'html', 'htm')

--- a/opac/webapp/utils/journal_static_page.py
+++ b/opac/webapp/utils/journal_static_page.py
@@ -1,5 +1,18 @@
 # coding=utf-8
 
+import os
+import logging
+
+from bs4 import BeautifulSoup, Comment, element
+
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
+
+fh = logging.FileHandler('journal_pages.log')
+fh.setLevel(logging.DEBUG)
+logger.addHandler(fh)
+
 
 class JournalStaticPage(object):
 
@@ -64,3 +77,222 @@ class JournalStaticPage(object):
             new = new.replace(self.footer, '<hr noshade="" size="1"/>')
             return new
         return self.content
+
+
+class JournalStaticPageFile(object):
+
+    # about, editors, instructions, contact
+    # 'iaboutj.htm', 'iedboard.htm', 'iinstruc.htm'
+    anchors = {
+        'about': 'about',
+        'editors': 'edboard',
+        'instructions': 'instruc',
+    }
+    versions = {'p': 'português', 'e': 'español', 'i': 'English'}
+    PT_UNAVAILABLE_MSG = 'Informação não disponível em português. ' + \
+                         'Consultar outra versão. '
+    ES_UNAVAILABLE_MSG = 'Información no disponible en español. ' + \
+                         'Consultar otra versión. '
+
+    def __init__(self, filename):
+        self.filename = filename
+        self.name = os.path.basename(filename)
+        self.version = self.versions[self.name[0]]
+        self.file_content = self._read()
+        self.tree = BeautifulSoup(self.file_content, 'lxml')
+
+    @property
+    def _body_tree(self):
+        if self.tree.body is not None:
+            return self.tree.body
+        return self.tree
+
+    @property
+    def content(self):
+        if self.tree is None:
+            return self.file_content
+        return str(self.tree)
+
+    @property
+    def body_content(self):
+        if self._body_tree is not None:
+            return str(self._body_tree)
+
+    def _info(self, msg):
+        logger.debug('%s %s' % (self.filename, msg))
+
+    def _read(self):
+        _content = None
+        try:
+            with open(self.filename, 'r', encoding='utf-8') as f:
+                _content = f.read()
+        except UnicodeError:
+            with open(self.filename, 'r', encoding='iso-8859-1') as f:
+                _content = f.read()
+                self._info('iso-8859-1')
+        except Exception as e:
+            self._info(u'%s' % e)
+            logging.error(u'%s' % e)
+        return _content or ''
+
+    def _remove_anchors(self):
+        items = self._body_tree.find_all('a')
+        for item in items:
+            name = item.get('name')
+            if name is not None:
+                if item.string:
+                    item.insert_after(item.string)
+                item.extract()
+
+    def _insert_bold_to_p_subtitulo(self):
+        p_items = self._body_tree.find_all('p')
+        for p in p_items:
+            style = p.get('class')
+            if style is not None:
+                if 'subtitulo' in list(style):
+                    if not p.find_all('b'):
+                        del p['class']
+                        for item in p.children:
+                            new_tag = self.tree.new_tag("b")
+                            wrap(item, new_tag)
+
+    def _indicate_middle_begin(self):
+        new_tag = self.tree.new_tag("p")
+        new_tag['id'] = 'middle_begin'
+        table = self._body_tree.find('table')
+        if table is not None:
+            header = str(table)
+
+            if 'Editable' in header and '<!--' in header and '-->' in header or \
+               'href="#0' in header or \
+               'script=sci_serial' in header or \
+               '/scielo.php?lng=' in header:
+                table.insert_after(new_tag)
+                return new_tag
+        self._info('no header found.')
+
+    def _indicate_middle_end(self):
+        p = None
+        href_items = []
+        a_items = self._body_tree.find_all('a')
+        for a in a_items:
+            href = a.get('href')
+            if href is not None:
+                href = str(href).strip()
+                href_items.append((a, href, a.text))
+                if 'script=sci_serial' in href and a.text.strip() == 'Home' or \
+                   'javascript:history.back()' == href:
+                    p = a.parent
+                    break
+        if p is not None:
+            new_tag = self.tree.new_tag("p")
+            new_tag['id'] = 'middle_end'
+            p.insert_before(new_tag)
+            return new_tag
+        self._info('no footer found.')
+
+    def _get_middle_children_eval_child(self, child, p_begin, p_end, task):
+        if task == 'find_p_begin':
+            if child == p_begin:
+                task = 'find_p_end'
+            return task, None
+        if task == 'find_p_end' and child == p_end:
+            return 'stop', None
+        if isinstance(child, Comment):
+            return task, None
+        return task, child
+
+    def _get_middle_children(self, p_begin, p_end):
+        task = 'find_p_begin'
+        items = []
+        for child in self._body_tree.children:
+            task, item = self._get_middle_children_eval_child(
+                child, p_begin, p_end, task)
+            if item is not None:
+                items.append(item)
+            elif task == 'stop':
+                break
+        return items
+
+    @property
+    def anchor_name(self):
+        for anchor_name, name in self.anchors.items():
+            if name in self.filename:
+                return anchor_name
+
+    @property
+    def anchor(self):
+        _anchor = self.anchor_name
+        if _anchor is not None:
+            return '<a name="{}"> </a>'.format(_anchor)
+        return ''
+
+    def _check_unavailable_message(self, content):
+        if self.version == 'português' and 'não disponível' in content:
+            return self.PT_UNAVAILABLE_MSG
+        elif self.version == 'español' and 'no disponible' in content:
+            return self.ES_UNAVAILABLE_MSG
+
+    def _get_unavailable_message(self):
+        self._unavailable_message = None
+        text = self._check_unavailable_message(self.body_content)
+        if text:
+            p_items = self.sorted_by_relevance
+            msg = self._check_unavailable_message(p_items[0][1])
+            if msg is not None:
+                self._unavailable_message = '<p>{}</p>'.format(msg)
+            self._info(p_items[0][1])
+
+    @property
+    def sorted_by_relevance(self):
+        return sorted([(len(p), p) for p in self.middle_items], reverse=True)
+
+    @property
+    def middle_children(self):
+        if not hasattr(self, '_middle_children'):
+            self._remove_anchors()
+            self._insert_bold_to_p_subtitulo()
+            begin = self._indicate_middle_begin()
+            end = self._indicate_middle_end()
+            self._middle_children = self._get_middle_children(begin, end)
+        return self._middle_children
+
+    @property
+    def middle_items(self):
+        if not hasattr(self, '_middle_items'):
+            self._middle_items = [tostring(item)
+                                  for item in self.middle_children]
+        return self._middle_items
+
+    @property
+    def middle_text(self):
+        if not hasattr(self, '_middle_text'):
+            self._middle_text = ''.join([str(item)
+                                         for item in self.middle_children])
+        return self._middle_text
+
+    @property
+    def unavailable_message(self):
+        self._get_unavailable_message()
+        return self._unavailable_message
+
+    @property
+    def body(self):
+        return '<!-- inicio {} -->'.format(self.filename) + \
+               self.anchor + self.middle_text + '<hr noshade="" size="1"/>' + \
+               '<!-- fim {} -->'.format(self.filename)
+
+
+def tostring(child):
+    if isinstance(child, element.Tag):
+        return child.text
+    elif isinstance(child, element.NavigableString):
+        return child
+
+
+def wrap(child, new_tag):
+    if isinstance(child, element.Tag):
+        if child.string is not None:
+            child.wrap(new_tag)
+    elif isinstance(child, element.NavigableString):
+        return child.wrap(new_tag)

--- a/opac/webapp/utils/utils.py
+++ b/opac/webapp/utils/utils.py
@@ -4,6 +4,7 @@ import os
 import re
 import pytz
 import shutil
+import logging
 from uuid import uuid4
 
 from werkzeug import secure_filename
@@ -14,6 +15,7 @@ from flask import current_app
 import webapp
 import requests
 from utils.journal_static_page import JournalStaticPage
+from utils.journal_static_page import JournalStaticPageFile
 from webapp import models
 
 from opac_schema.v1.models import Pages
@@ -27,6 +29,7 @@ CSS = "/static/css/style_article_html.css"  # caminho para o CSS a ser incluído
 REGEX_EMAIL = re.compile(
     r"[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?",
     re.IGNORECASE)  # RFC 2822 (simplified)
+logger = logging.getLogger(__name__)
 
 
 def namegen_filename(obj, file_data=None):
@@ -255,8 +258,12 @@ def generate_thumbnail(input_filename):
         img = Image.open(input_filename)
         img.thumbnail(size)
         img.save(image_path)
+    except KeyError as e:
+        logger.error(u'%s' % e)
+    except IOError as e:
+        logger.error(u'%s' % e)
     except Exception as e:
-        print(e)
+        logger.exception('Unexpected error', e)
     else:
         return image_path
 
@@ -273,11 +280,13 @@ def create_image(image_path, filename, thumbnail=False, check_if_exists=True):
     """
 
     image_root = current_app.config['IMAGE_ROOT']
-
+    if not os.path.isdir(image_root):
+        os.makedirs(image_root)
     image_destiation_path = os.path.join(image_root, filename)
 
     if check_if_exists:
-        img = webapp.dbsql.session.query(models.Image).filter_by(name=filename).first()
+        img = webapp.dbsql.session.query(
+            models.Image).filter_by(name=filename).first()
         if img:
             return img
 
@@ -285,7 +294,7 @@ def create_image(image_path, filename, thumbnail=False, check_if_exists=True):
         shutil.copyfile(image_path, image_destiation_path)
     except IOError as e:
         # https://docs.python.org/3/library/exceptions.html#FileNotFoundError
-        print("ERROR: %s" % e)
+        logger.error(u'%s' % e)
 
     if thumbnail:
         generate_thumbnail(image_destiation_path)
@@ -315,6 +324,26 @@ def fix_page_content(filename, content):
     Insert the anchor based on filename
     """
     return JournalStaticPage(filename, content).body
+
+
+def fix_page(journal_pages_path, files):
+    """
+    Extract the header and the footer of the page
+    Insert the anchor based on filename
+    """
+    content = []
+    unavailable_message = None
+    for file in files:
+        file_path = os.path.join(journal_pages_path, file)
+        page = JournalStaticPageFile(file_path)
+        if page.unavailable_message:
+            content.append(page.anchor)
+            unavailable_message = page.unavailable_message
+        else:
+            content.append(page.body)
+    if unavailable_message is not None:
+        content.append(unavailable_message)
+    return '\n'.join(content)
 
 
 def extract_images(content):

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,3 +26,4 @@ beautifulsoup4==4.6.0
 Flask-WTF==0.14.2
 Flask-Caching==1.3.3
 redis==2.10.6
+lxml==4.2.4


### PR DESCRIPTION
 - uso de BeautifulSoup + lxml
 - remoção de âncoras desnecessárias
 - troca de ``<p class="subtitulo">`` por ``<b>`` pois dentro do site novo os "subtítulos" ficavam sem bold
 - ajustes na remoção de cabeçalhos (logo do periódico etc) e rodapés (links de navegação) das páginas originais
 - remoção da multiplicidade de textos "Conteúdo indisponível na versão do idioma da interface", mantendo apenas 1 vez. (Como a página informativa é formada pelo conteúdo de 3 páginas do site antigo, no site novo a mesma mensagem ficava repetida 3 vezes).
 - testes