### PR TITLE
[tk1016] Incluir título para as âncoras (about, editors, instructions) 

### DIFF
--- a/opac/tests/test_utils_journal_static_page.py
+++ b/opac/tests/test_utils_journal_static_page.py
@@ -109,48 +109,70 @@ class JournalStaticPageTestCase(BaseTestCase):
         jspf = JournalStaticPageFile(self.html_file('icse_eaboutj'))
         self.assertEqual(
             jspf.anchor_title, '<h1>Acerca de la revista</h1>')
+        self.assertTrue(
+            '<h1>Acerca de la revista</h1>' in jspf.body)
 
     def test_title_eins_eedboar(self):
         jspf = JournalStaticPageFile(self.html_file('eins_eedboard'))
         self.assertEqual(jspf.anchor_title, '<h1>Cuerpo Editorial</h1>')
+        self.assertTrue(
+            '<h1>Cuerpo Editorial</h1>' in jspf.body)
 
     def test_title_abb_einstruc(self):
         jspf = JournalStaticPageFile(self.html_file('abb_einstruc'))
         self.assertEqual(
             jspf.anchor_title, '<h1>Instrucciones a los autores</h1>')
+        self.assertTrue(
+            '<h1>Instrucciones a los autores</h1>' in jspf.body)
 
     def test_title_bjgeo_einstr(self):
         jspf = JournalStaticPageFile(self.html_file('bjgeo_einstruct'))
         self.assertEqual(
             jspf.anchor_title, '<h1>Instrucciones a los autores</h1>')
+        self.assertTrue(
+            '<h1>Instrucciones a los autores</h1>' in jspf.body)
 
     def test_title_bjmbr_pabout(self):
         jspf = JournalStaticPageFile(self.html_file('bjmbr_paboutj'))
         self.assertEqual(jspf.anchor_title, '<h1>Sobre o periódico</h1>')
+        self.assertTrue(
+            '<h1>Sobre o periódico</h1>' in jspf.body)
 
     def test_title_eagri_pedboa(self):
         jspf = JournalStaticPageFile(self.html_file('eagri_pedboard'))
         self.assertEqual(jspf.anchor_title, '<h1>Corpo Editorial</h1>')
+        self.assertTrue(
+            '<h1>Corpo Editorial</h1>' in jspf.body)
 
     def test_title_abb_pinstruc(self):
         jspf = JournalStaticPageFile(self.html_file('abb_pinstruc'))
         self.assertEqual(jspf.anchor_title, '<h1>Instruções aos autores</h1>')
+        self.assertTrue(
+            '<h1>Instruções aos autores</h1>' in jspf.body)
 
     def test_title_bjgeo_pinstr(self):
         jspf = JournalStaticPageFile(self.html_file('bjgeo_pinstruct'))
         self.assertEqual(jspf.anchor_title, '<h1>Instruções aos autores</h1>')
+        self.assertTrue(
+            '<h1>Instruções aos autores</h1>' in jspf.body)
 
     def test_title_bjmbr_iabout(self):
         jspf = JournalStaticPageFile(self.html_file('bjmbr_iaboutj'))
         self.assertEqual(jspf.anchor_title, '<h1>About the journal</h1>')
+        self.assertTrue(
+            '<h1>About the journal</h1>' in jspf.body)
 
     def test_title_bjmbr_iedboa(self):
         jspf = JournalStaticPageFile(self.html_file('bjmbr_iedboard'))
         self.assertEqual(jspf.anchor_title, '<h1>Editorial Board</h1>')
+        self.assertTrue(
+            '<h1>Editorial Board</h1>' in jspf.body)
 
     def test_title_bjmbr_iinstr(self):
         jspf = JournalStaticPageFile(self.html_file('bjmbr_iinstruc'))
         self.assertEqual(jspf.anchor_title, '<h1>Instructions to authors</h1>')
+        self.assertTrue(
+            '<h1>Instructions to authors</h1>' in jspf.body)
 
     def test_insert_bold_to_p_subtitulo_aa_eedboard(self):
         jspf = JournalStaticPageFile(self.html_file('aa_eedboard'))

--- a/opac/tests/test_utils_journal_static_page.py
+++ b/opac/tests/test_utils_journal_static_page.py
@@ -105,6 +105,53 @@ class JournalStaticPageTestCase(BaseTestCase):
         if os.path.isfile(f):
             return f
 
+    def test_title_icse_eaboutj(self):
+        jspf = JournalStaticPageFile(self.html_file('icse_eaboutj'))
+        self.assertEqual(
+            jspf.anchor_title, '<h1>Acerca de la revista</h1>')
+
+    def test_title_eins_eedboar(self):
+        jspf = JournalStaticPageFile(self.html_file('eins_eedboard'))
+        self.assertEqual(jspf.anchor_title, '<h1>Cuerpo Editorial</h1>')
+
+    def test_title_abb_einstruc(self):
+        jspf = JournalStaticPageFile(self.html_file('abb_einstruc'))
+        self.assertEqual(
+            jspf.anchor_title, '<h1>Instrucciones a los autores</h1>')
+
+    def test_title_bjgeo_einstr(self):
+        jspf = JournalStaticPageFile(self.html_file('bjgeo_einstruct'))
+        self.assertEqual(
+            jspf.anchor_title, '<h1>Instrucciones a los autores</h1>')
+
+    def test_title_bjmbr_pabout(self):
+        jspf = JournalStaticPageFile(self.html_file('bjmbr_paboutj'))
+        self.assertEqual(jspf.anchor_title, '<h1>Sobre o periódico</h1>')
+
+    def test_title_eagri_pedboa(self):
+        jspf = JournalStaticPageFile(self.html_file('eagri_pedboard'))
+        self.assertEqual(jspf.anchor_title, '<h1>Corpo Editorial</h1>')
+
+    def test_title_abb_pinstruc(self):
+        jspf = JournalStaticPageFile(self.html_file('abb_pinstruc'))
+        self.assertEqual(jspf.anchor_title, '<h1>Instruções aos autores</h1>')
+
+    def test_title_bjgeo_pinstr(self):
+        jspf = JournalStaticPageFile(self.html_file('bjgeo_pinstruct'))
+        self.assertEqual(jspf.anchor_title, '<h1>Instruções aos autores</h1>')
+
+    def test_title_bjmbr_iabout(self):
+        jspf = JournalStaticPageFile(self.html_file('bjmbr_iaboutj'))
+        self.assertEqual(jspf.anchor_title, '<h1>About the journal</h1>')
+
+    def test_title_bjmbr_iedboa(self):
+        jspf = JournalStaticPageFile(self.html_file('bjmbr_iedboard'))
+        self.assertEqual(jspf.anchor_title, '<h1>Editorial Board</h1>')
+
+    def test_title_bjmbr_iinstr(self):
+        jspf = JournalStaticPageFile(self.html_file('bjmbr_iinstruc'))
+        self.assertEqual(jspf.anchor_title, '<h1>Instructions to authors</h1>')
+
     def test_insert_bold_to_p_subtitulo_aa_eedboard(self):
         jspf = JournalStaticPageFile(self.html_file('aa_eedboard'))
 

--- a/opac/webapp/utils/journal_static_page.py
+++ b/opac/webapp/utils/journal_static_page.py
@@ -69,13 +69,6 @@ class JournalStaticPageFile(object):
     def __init__(self, filename):
         self.filename = filename
         self.name = os.path.basename(filename)
-        title = self.h1.get(self.name)
-        if title is None:
-            alt = [v for k, v in self.h1.items()
-                   if self.name.startswith(k[:5])]
-            if len(alt) == 1:
-                title = alt[0]
-        self.anchor_title = '<h1>{}</h1>'.format(title or '')
         self.version = self.versions[self.name[0]]
         self.file_content = self._read()
         self.get_tree()
@@ -95,6 +88,16 @@ class JournalStaticPageFile(object):
                 self._info('Not found: begin. FAILED {}'.format(parser))
             else:
                 break
+
+    @property
+    def anchor_title(self):
+        title = self.h1.get(self.name)
+        if title is None:
+            alt = [v for k, v in self.h1.items()
+                   if self.name[:5] == k[:5]]
+            if len(alt) == 1:
+                title = alt[0]
+        return '<h1>{}</h1>'.format(title or '')
 
     @property
     def _body_tree(self):

--- a/opac/webapp/utils/journal_static_page.py
+++ b/opac/webapp/utils/journal_static_page.py
@@ -49,6 +49,18 @@ class JournalStaticPageFile(object):
         'instructions': 'instruc',
     }
     versions = {'p': 'português', 'e': 'español', 'i': 'English'}
+    h1 = {
+        'paboutj.htm': 'Sobre o periódico',
+        'pedboard.htm': 'Corpo Editorial',
+        'pinstruc.htm': 'Instruções aos autores',
+        'eaboutj.htm': 'Acerca de la revista',
+        'eedboard.htm': 'Cuerpo Editorial',
+        'einstruc.htm': 'Instrucciones a los autores',
+        'iaboutj.htm': 'About the journal',
+        'iedboard.htm': 'Editorial Board',
+        'iinstruc.htm': 'Instructions to authors',
+    }
+
     PT_UNAVAILABLE_MSG = 'Informação não disponível em português. ' + \
                          'Consultar outra versão. '
     ES_UNAVAILABLE_MSG = 'Información no disponible en español. ' + \
@@ -57,6 +69,13 @@ class JournalStaticPageFile(object):
     def __init__(self, filename):
         self.filename = filename
         self.name = os.path.basename(filename)
+        title = self.h1.get(self.name)
+        if title is None:
+            alt = [v for k, v in self.h1.items()
+                   if self.name.startswith(k[:5])]
+            if len(alt) == 1:
+                title = alt[0]
+        self.anchor_title = '<h1>{}</h1>'.format(title or '')
         self.version = self.versions[self.name[0]]
         self.file_content = self._read()
         self.get_tree()
@@ -390,7 +409,8 @@ class JournalStaticPageFile(object):
     @property
     def body(self):
         return '<!-- inicio {} -->'.format(self.filename) + \
-               self.anchor + self.middle + '<hr noshade="" size="1"/>' + \
+               self.anchor + self.anchor_title + \
+               self.middle + '<hr noshade="" size="1"/>' + \
                '<!-- fim {} -->'.format(self.filename)
 
 


### PR DESCRIPTION
- Geração e inclusão de título para as âncoras no conteúdo da página

- Testes para:
  - atributo jspf.anchor_title
  - verificar se o título da âncora está presente no conteúdo da página

Fixes #1016