### PR TITLE
Alteração do cabeçalho da página

### DIFF
--- a/opac/webapp/templates/base.html
+++ b/opac/webapp/templates/base.html
@@ -14,7 +14,7 @@
 
     {% block extra_meta %}{% endblock %}
 
-    <title>{% block title %}{{ coll_macro.get_collection_name() }}{% endblock %}</title>
+    <title>SciELO - {% block title %}{{ coll_macro.get_collection_name() }}{% endblock %}</title>
 
     <link rel="icon" href="{{ url_for('static', filename='img/favicon.ico') }}" />
     <link rel="stylesheet" href="{{ url_for('static', filename='css/scielo-bundle.css') }}?v={{ config.VCS_REF }}">


### PR DESCRIPTION
Alteração do cabeçalho para SciELO - <nome da coleção>.

Assim, aparecerá:
- spa: SciELO - Saúde Pública
- scl: SciELO - Brasil

OBS: será necessário alterar o cadastro para retirar "SciELO" e ficar somente "Brasil"
