### PR TITLE
[tk983] Apresentação do link Scimago na home do periódico

### DIFF
--- a/opac/tests/test_interface_journal_home.py
+++ b/opac/tests/test_interface_journal_home.py
@@ -276,8 +276,10 @@ class JournalHomeTestCase(BaseTestCase):
                             url_seg=journal.url_segment))
                 response_data = response.data.decode('utf-8')
                 # then
-                self.assertStatus(response, 200)
                 expected = 'https://www.scimagojr.com/journalsearch.php?tip=sid&clean=0&q=22596'
+                if '&amp;' in response_data:
+                    expected = expected.replace('&', '&amp;')
+                self.assertStatus(response, 200)
                 self.assertIn(expected, response_data)
 
                 expected = '<a target="_blank" href="{}">Scimago'.format(expected)

--- a/opac/tests/test_interface_journal_home.py
+++ b/opac/tests/test_interface_journal_home.py
@@ -340,9 +340,12 @@ class JournalHomeTestCase(BaseTestCase):
                     url_for('main.journal_detail',
                             url_seg=journal.url_segment))
                 response_data = response.data.decode('utf-8')
+                
+                expected = 'https://www.scimagojr.com/journalsearch.php?tip=sid&clean=0&q='
+                if '&amp;' in response_data:
+                    expected = expected.replace('&', '&amp;')
                 # then
                 self.assertStatus(response, 200)
-                expected = 'https://www.scimagojr.com/journalsearch.php?tip=sid&clean=0&q='
                 self.assertNotIn(expected, response_data)
 
                 expected = '<a target="_blank" href="{}">Scimago'.format(expected)

--- a/opac/webapp/config/default.py
+++ b/opac/webapp/config/default.py
@@ -382,3 +382,9 @@ GOOGLE_RECAPTCHA_SECRET_KEY = os.environ.get('OPAC_GOOGLE_RECAPTCHA_SECRET_KEY',
 GOOGLE_RECAPTCHA_URL = os.environ.get('OPAC_GOOGLE_RECAPTCHA_URL', "https://www.google.com/recaptcha/api.js")
 GOOGLE_VERIFY_RECAPTCHA_URL = os.environ.get('OPAC_GOOGLE_VERIFY_RECAPTCHA_URL', "https://www.google.com/recaptcha/api/siteverify")
 GOOGLE_VERIFY_RECAPTCHA_KEY = os.environ.get('OPAC_GOOGLE_VERIFY_RECAPTCHA_KEY', "")
+
+
+SCIMAGO_URL = os.environ.get(
+              'SCIMAGO_URL',
+              'https://www.scimagojr.com/journalsearch.php?tip=sid&clean=0&q=')
+SCIMAGO_ENABLED = os.environ.get('SCIMAGO_ENABLED', 'True') == 'True'

--- a/opac/webapp/templates/journal/detail.html
+++ b/opac/webapp/templates/journal/detail.html
@@ -43,6 +43,9 @@
             <span id="date" class="datetime"></span>
             <ul>
               <li><a target="_blank" href="{{ config.METRICS_URL }}/?journal={{ journal.scielo_issn or journal.eletronic_issn or journal.print_issn }}&collection={{ config.OPAC_COLLECTION }}">SciELO</a>
+              {% if config.SCIMAGO_ENABLED and journal.scimago_id %}
+              <li><a target="_blank" href="{{ config.SCIMAGO_URL }}{{ journal.scimago_id }}">Scimago</a>
+              {% endif %}
               <li><a href="">Google Metrics</a>
                 <div>
                   <small>

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ Flask-Migrate==2.2.1
 unicodecsv==0.14.1
 feedparser==5.2.1
 legendarium==2.0.2
--e git+https://git@github.com/scieloorg/opac_schema@v2.46#egg=opac_schema
+-e git+https://git@github.com/scieloorg/opac_schema@v2.47#egg=opac_schema
 Flask-HTMLmin==1.4.0
 python-slugify==1.2.4
 requests==2.19.1

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ install_requirements = [
 ]
 
 dependency_links = [
-    'http://github.com/scieloorg/opac_schema/tarball/v2.44#egg=opac_schema-v2.44'
+    'http://github.com/scieloorg/opac_schema/tarball/v2.47#egg=opac_schema-v2.47'
 ]
 
 setup(


### PR DESCRIPTION
- Uso de variáveis de ambiente:
    - SCIMAGO_URL (default: 'https://www.scimagojr.com/journalsearch.php?tip=sid&clean=0&q=')
    - SCIMAGO_ENABLED (default: True)
- Apresenta URL somente se periódico tem scimago_id e se SCIMAGO_ENABLED is True

Fixes #983