### PR TITLE
[tk1067] Acesso às páginas About da coleção por slug_name e não mais …

### DIFF
--- a/opac/tests/test_controller.py
+++ b/opac/tests/test_controller.py
@@ -1015,3 +1015,39 @@ class FunctionsInControllerTestCase(BaseTestCase):
             ValueError,
             controllers.count_elements_by_type_and_visibility,
             'ksjkadjkajsdkja')
+
+
+class PageControllerTestCase(BaseTestCase):
+
+    def _make_one(self, attrib=None):
+        """
+        Retorna um objeto ``Pages`` com os atributos obrigatórios:
+        ``_id``, o param ``attrib`` atualiza os atributos do objeto.
+        """
+        return utils.makeOnePage(attrib=attrib)
+
+    def test_get_page_by_lang(self):
+        """
+        Teste da função controllers.get_pages_by_lang() para retornar um objeto:
+        ``Pages``.
+        """
+        page = self._make_one()
+        self.assertEqual(
+            [page.language for page in controllers.get_pages()], 
+            [page['language']])
+        self.assertEqual(
+            [page.language for page in controllers.get_pages_by_lang(
+                lang='pt_BR')],
+            ['pt_BR'])
+
+    def test_get_page_by_slug_name(self):
+        """
+        Teste da função controllers.get_page_by_slug_name()
+        para retornar um objeto: ``Pages``.
+        """
+        page = self._make_one({'name': 'Critérios'})
+        slug_name = page.slug_name
+        self.assertEqual(
+            'Critérios',
+            controllers.get_page_by_slug_name(slug_name).name)
+

--- a/opac/tests/test_interface_menu.py
+++ b/opac/tests/test_interface_menu.py
@@ -62,7 +62,7 @@ class MenuTestCase(BaseTestCase):
                 self.assertIn(expected_anchor6, response_data)
                 expected_anchor7 = """<a href="%s" class="onlineSubmission">\n      <span class="glyphBtn infoMenu"></span>\n      %s %s\n    </a>""" % (url_for('.about_collection'), __('Sobre o SciELO'), collection.name)
                 self.assertIn(expected_anchor7, response_data)
-                expected_anchor8 = """<li>\n            <a href="/collection/about/">\n              %s\n            </a>\n          </li>""" % __('Contatos')
+                expected_anchor8 = """<li>\n            <a href="/about/">\n              %s\n            </a>\n          </li>""" % __('Contatos')
                 self.assertIn(expected_anchor8, response_data)
                 expected_anchor9 = """<a href="#">\n        <strong>SciELO.org - %s</strong>\n      </a>""" % __('Rede SciELO')
                 self.assertIn(expected_anchor9, response_data)

--- a/opac/tests/utils.py
+++ b/opac/tests/utils.py
@@ -1,7 +1,9 @@
 # coding: utf-8
 import datetime
+import random
 from uuid import uuid4
 from flask import current_app
+from slugify import slugify
 from opac_schema.v1 import models
 
 
@@ -125,6 +127,57 @@ def makeAnyJournal(items=3, attrib=None):  # noqa
         journals.append(journal)
 
     return journals
+
+
+def makeOnePage(attrib=None):  # noqa
+    """
+    Retorna um objeto ``Page`` com os atributos obrigatórios:
+    ``_id``, ``jid``, ``is_public``.
+    Atualiza o objeto de retorno com os valores do param ``attrib``.
+    """
+    attrib = attrib or {}
+    default_id = attrib.get('_id', str(uuid4().hex))
+    default_name = "page-%s" % default_id
+    texts = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.' + \
+            ' Ut cursus porttitor suscipit. ' + \
+            'Suspendisse ut dolor volutpat, ' + \
+            'tempor eros nec, tincidunt dui. Integer id ornare lectus, ' + \
+            'sit amet consectetur leo. Mauris massa massa, ' + \
+            'ut, euismod aliquet erat. Cras id blandit magna, et porttitor' + \
+            ' purus. Vestibulum rhoncus euismod purus at ultrices. '
+    texts = texts.split()
+    times = random.choice(range(10, len(texts)))
+
+    page = {
+        '_id': default_id,
+        'name': attrib.get('name', default_name),
+        'slug_name': slugify(attrib.get('name', default_name)),
+        'journal': attrib.get('journal', ''),
+        'content': ' '.join([random.choice(texts) for n in range(0, times)]),
+        'description': 'Description {}'.format(default_name),
+        'language': attrib.get('language', 'pt_BR'),
+        'created_at': attrib.get('created', datetime.datetime.now()),
+        'updated_at': attrib.get('updated', datetime.datetime.now()),
+    }
+    page.update(attrib)
+    return models.Pages(**page).save()
+
+
+def makeAnyPage(items=3, attrib=None):  # noqa
+    """
+    Retorna uma lista de objetos ``Pages`` com atributos ``jid``,
+    ``is_public`` e ``acronym`` limitando a quantidade pelo param ``items``.
+    Param attrib para adicionar atributo aos objecto do tipo Pages
+    """
+    pages = []
+
+    for _ in range(items):
+
+        page = makeOnePage(attrib)
+
+        pages.append(page)
+
+    return pages
 
 
 def makeOneIssue(attrib=None):  # noqa
@@ -276,7 +329,7 @@ def makeAnyArticle(issue=None, items=3, attrib=None):  # noqa
     """
     Retorna uma lista de objetos ``Article`` com atributos ``aid``,
     ``issue`` limitando a quantidade pelo param ``items`` e o param issue
-    permiti definir um objeto ``Issue`` para o artcile ou será criado
+    permiti definir um objeto ``Issue`` para o artcile ou será c riado
     automáticamente.
     """
     articles = []

--- a/opac/webapp/admin/views.py
+++ b/opac/webapp/admin/views.py
@@ -670,7 +670,7 @@ class PagesAdminView(OpacBaseAdminView):
     column_searchable_list = ('name', 'description')
 
     column_exclude_list = [
-        '_id', 'content',
+        '_id', 'content', 'slug_name',
     ]
 
     column_labels = dict(

--- a/opac/webapp/controllers.py
+++ b/opac/webapp/controllers.py
@@ -35,6 +35,7 @@ from .utils import utils
 from uuid import uuid4
 
 from mongoengine import Q
+from mongoengine.errors import InvalidQueryError
 
 
 # -------- COLLECTION --------
@@ -1036,3 +1037,13 @@ def get_page_by_id(id):
 
 def get_pages_by_lang(lang, journal=''):
     return Pages.objects(language=lang, journal=journal)
+
+
+def get_pages():
+    return Pages.objects()
+
+
+def get_page_by_slug_name(slug_name):
+    if not slug_name:
+        raise ValueError(__('Obrigatório um slug_name.'))
+    return Pages.objects(Q(slug_name=slug_name)).first()

--- a/opac/webapp/main/views.py
+++ b/opac/webapp/main/views.py
@@ -185,18 +185,19 @@ def collection_list_feed():
     return feed.get_response()
 
 
-@main.route("/collection/about/", methods=['GET'])
+@main.route("/about/", methods=['GET'])
+@main.route('/about/<string:slug_name>', methods=['GET'])
 @cache.cached(key_prefix=cache_key_with_lang_with_qs)
-def about_collection():
+def about_collection(slug_name=None):
     language = session.get('lang', get_locale())
 
     context = {}
 
-    page_id = request.args.get('page_id')
-
-    if page_id:
+    if slug_name:
         # caso seja uma página
-        page = controllers.get_page_by_id(page_id)
+        page = controllers.get_page_by_slug_name(slug_name)
+        if not page:
+            abort(404, _('Página não encontrada'))
         context['page'] = page
     else:
         # caso não seja uma página é uma lista
@@ -204,6 +205,7 @@ def about_collection():
         context['pages'] = pages
 
     return render_template("collection/about.html", **context)
+
 
 # ###################################Journal#####################################
 
@@ -227,7 +229,7 @@ def router_legacy():
             journal = controllers.get_journal_by_issn(pid)
 
             if not journal:
-                abort(404, _('Periódico não encontrada'))
+                abort(404, _('Periódico não encontrado'))
 
             if not journal.is_public:
                 abort(404, JOURNAL_UNPUBLISH + _(journal.unpublish_reason))

--- a/opac/webapp/templates/collection/about.html
+++ b/opac/webapp/templates/collection/about.html
@@ -18,7 +18,7 @@
                 <ul class="networkList">
 
                     {% for page in pages %}
-                        <a href="?page_id={{ page.id}}">
+                        <a href="/about/{{ page.slug_name }}">
                             <li>
                                 {% trans %} {{ page }} {% endtrans %}
                             </li>

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ Flask-Migrate==2.2.1
 unicodecsv==0.14.1
 feedparser==5.2.1
 legendarium==2.0.2
--e git+https://git@github.com/scieloorg/opac_schema@v2.47#egg=opac_schema
+-e git+https://git@github.com/scieloorg/opac_schema@v2.48#egg=opac_schema
 Flask-HTMLmin==1.4.0
 python-slugify==1.2.4
 requests==2.19.1


### PR DESCRIPTION
…por page_id

No lugar de:
https://new.scielo.br/collection/about/

Gerar
``https://new.scielo.br/about/``

No lugar de:
``https://new.scielo.br/collection/about/?page_id=<page_id>``

Gerar
``https://new.scielo.br/about/<page_name>``

depende de opac_schema v2.48

Fixes #1067