### PR TITLE
Corrigi atributo para a url do formulário de contato

### DIFF
--- a/opac/webapp/templates/journal/base.html
+++ b/opac/webapp/templates/journal/base.html
@@ -13,8 +13,8 @@
   <esi:remove>
     {% include "journal/includes/contact_form.html" %}
   </esi:remove>
-  <esi:include src="{{ url_for('main.form_contact', url_seg=journal.url_seg ) }}"/>
 
+  <esi:include src="{{ url_for('main.form_contact', url_seg=journal.url_segment ) }}"/>
 
 {% endblock %}
 


### PR DESCRIPTION
O consultor do Varnish sinalizou o seguinte problema: 

> Guillaume Quintard (Varnish Software)Oct 20, 08:15 CESTHi,
> 
> I've been poking around, and the first issue (error message in the footer) is fairly straightforward: we get a 404 because the location is "/form_contact//", which looks like a problem with a missing/empty variable. Does this ring a bell?
> 

Esse PR corrigi a o caminho para o form de contato.

