### PR TITLE
[tk1081] Páginas about acessíveis com slug_name e language

### DIFF
--- a/opac/tests/test_controller.py
+++ b/opac/tests/test_controller.py
@@ -1046,16 +1046,29 @@ class PageControllerTestCase(BaseTestCase):
         para retornar um objeto: ``Pages``.
         """
         page = self._make_one({'name': 'Critérios', 'language': 'pt_BR', 'content': 'texto em port.'})
-        page = self._make_one({'name': 'Critérios', 'language': 'es_ES', 'content': 'texto en esp.'})
+        page = self._make_one({'name': 'Criterios', 'language': 'es_ES', 'content': 'texto en esp.'})
         slug_name = page.slug_name
 
-        _page = controllers.get_page_by_slug_name('es_ES', slug_name)
-        self.assertEqual('Critérios', _page.name)
+        _page = controllers.get_page_by_slug_name(slug_name, 'es_ES')
+        self.assertEqual('Criterios', _page.name)
         self.assertEqual('texto en esp.', _page.content)
         self.assertEqual('es_ES', _page.language)
 
-        _page = controllers.get_page_by_slug_name('pt_BR', slug_name)
+        _page = controllers.get_page_by_slug_name(slug_name, 'pt_BR')
         self.assertEqual('Critérios', _page.name)
         self.assertEqual('pt_BR', _page.language)
         self.assertEqual('texto em port.', _page.content)
+
+        _page = controllers.get_page_by_slug_name(slug_name, 'en_US')
+        self.assertIsNone(_page)
+
+        _page = controllers.get_page_by_slug_name('Bla')
+        self.assertIsNone(_page)
+
+        _page = controllers.get_page_by_slug_name(slug_name)
+        self.assertEqual(len(_page), 2)
+        self.assertEqual(
+            {item.name for item in _page},
+            {'Critérios', 'Criterios'}
+            )
 

--- a/opac/tests/test_controller.py
+++ b/opac/tests/test_controller.py
@@ -1063,7 +1063,7 @@ class PageControllerTestCase(BaseTestCase):
         self.assertIsNone(_page)
 
         _page = controllers.get_page_by_slug_name('Bla')
-        self.assertIsNone(_page)
+        self.assertEqual(len(_page), 0)
 
         _page = controllers.get_page_by_slug_name(slug_name)
         self.assertEqual(len(_page), 2)

--- a/opac/tests/test_main_views.py
+++ b/opac/tests/test_main_views.py
@@ -1145,8 +1145,10 @@ class PageTestCase(BaseTestCase):
                                'language': 'es_ES'}),
             utils.makeOnePage({'name': 'Critérios SciELO',
                                'language': 'pt_BR'}),
-            utils.makeOnePage({'name': 'FAQ SciELO'}),
-            utils.makeOnePage({'name': 'Equipe SciELO'})
+            utils.makeOnePage({'name': 'FAQ SciELO',
+                               'language': 'pt_BR'}),
+            utils.makeOnePage({'name': 'Equipe SciELO',
+                               'language': 'pt_BR'})
         ]
 
         response = self.client.get(url_for('main.about_collection'))
@@ -1155,8 +1157,10 @@ class PageTestCase(BaseTestCase):
         self.assertTemplateUsed('collection/about.html')
 
         for page in pages:
-            self.assertIn('/about/%s' % page.slug_name,
-                          response.data.decode('utf-8'))
+            if page.language == 'pt_BR':
+                self.assertIn(
+                    '/about/%s/%s' % (page.slug_name, page.language),
+                    response.data.decode('utf-8'))
 
         self.assertListEqual(
             sorted([page.slug_name for page in pages[1:]]),
@@ -1172,9 +1176,11 @@ class PageTestCase(BaseTestCase):
         with current_app.app_context():
             utils.makeOneCollection()
 
-            page = utils.makeOnePage({'name': 'Critérios SciELO'})
+            page = utils.makeOnePage({'name': 'Critérios SciELO',
+                                      'language': 'es_ES'})
             response = self.client.get(url_for('main.about_collection',
-                                               slug_name=page.slug_name))
+                                               slug_name=page.slug_name,
+                                               lang=page.language))
 
             self.assertEqual(200, response.status_code)
             self.assertTemplateUsed('collection/about.html')
@@ -1193,7 +1199,6 @@ class PageTestCase(BaseTestCase):
             utils.makeOneCollection()
             unknown_page_name = 'xxjfsfadfa0k2qhs8slwnui8'
             response = self.client.get(url_for('main.about_collection',
-                                       slug_name=unknown_page_name))
+                                       slug_name=unknown_page_name,
+                                       lang='ab_cd'))
             self.assertStatus(response, 404)
-            self.assertIn('Página não encontrada',
-                          response.data.decode('utf-8'))

--- a/opac/webapp/admin/views.py
+++ b/opac/webapp/admin/views.py
@@ -670,7 +670,7 @@ class PagesAdminView(OpacBaseAdminView):
     column_searchable_list = ('name', 'description')
 
     column_exclude_list = [
-        '_id', 'content', 'slug_name',
+        '_id', 'content',
     ]
 
     column_labels = dict(
@@ -706,7 +706,7 @@ class PagesAdminView(OpacBaseAdminView):
                      [(journal.acronym, journal.title) for journal in controllers.get_journals()]),
     )
 
-    form_excluded_columns = ('created_at', 'updated_at', 'slug_name')
+    form_excluded_columns = ('created_at', 'updated_at')
 
     def _content_formatter(self, context, model, name):
         return Markup(model.content)

--- a/opac/webapp/controllers.py
+++ b/opac/webapp/controllers.py
@@ -1043,9 +1043,9 @@ def get_pages():
     return Pages.objects()
 
 
-def get_page_by_slug_name(lang, slug_name):
-    if not lang:
-        raise ValueError(__('Obrigatório um lang.'))
+def get_page_by_slug_name(slug_name, lang=None):
     if not slug_name:
         raise ValueError(__('Obrigatório um slug_name.'))
+    if not lang:
+        return Pages.objects(slug_name=slug_name)
     return Pages.objects(language=lang, slug_name=slug_name).first()

--- a/opac/webapp/main/views.py
+++ b/opac/webapp/main/views.py
@@ -186,16 +186,16 @@ def collection_list_feed():
 
 
 @main.route("/about/", methods=['GET'])
-@main.route('/about/<string:slug_name>', methods=['GET'])
+@main.route('/about/<string:slug_name>/<string:lang>', methods=['GET'])
 @cache.cached(key_prefix=cache_key_with_lang_with_qs)
-def about_collection(slug_name=None):
-    language = session.get('lang', get_locale())
+def about_collection(slug_name=None, lang=None):
+    language = lang or session.get('lang', get_locale())
 
     context = {}
-
+    page = None
     if slug_name:
         # caso seja uma página
-        page = controllers.get_page_by_slug_name(language, slug_name)
+        page = controllers.get_page_by_slug_name(slug_name, language)
         if not page:
             abort(404, _('Página não encontrada'))
         context['page'] = page

--- a/opac/webapp/templates/collection/about.html
+++ b/opac/webapp/templates/collection/about.html
@@ -18,7 +18,7 @@
                 <ul class="networkList">
 
                     {% for page in pages %}
-                        <a href="/about/{{ page.slug_name }}">
+                        <a href="/about/{{ page.slug_name }}/{{ page.language }}">
                             <li>
                                 {% trans %} {{ page }} {% endtrans %}
                             </li>


### PR DESCRIPTION
Como alguns slug_name podem ficar identicos, usar o language para distinguir.

Fixes #1081