### PR TITLE
add mathjax conf e js no template base dos artigos

### DIFF
--- a/opac/webapp/config/default.py
+++ b/opac/webapp/config/default.py
@@ -148,6 +148,9 @@ import os
         - OPAC_RQ_REDIS_PASSWORD: senha do servidor de Redis (pode ser o mesmo server do Cache)
         - OPAC_MAILING_CRON_STRING: valor de cron padrão para o envio de emails
         - OPAC_DEFAULT_SCHEDULER_TIMEOUT: timeout do screduler cron (dafault: 1000).
+
+      - MathJax:
+        - OPAC_MATHJAX_CDN_URL: string com a URL do mathjax padrão; ex: "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/latest.js?config=TeX-MML-AM_CHTML"
 """
 
 PROJECT_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
@@ -426,3 +429,6 @@ MAILING_CRON_STRING = os.environ.get(
     'OPAC_MAILING_CRON_STRING', '0 7 * * *')
 DEFAULT_SCHEDULER_TIMEOUT = int(
     os.environ.get('OPAC_DEFAULT_SCHEDULER_TIMEOUT', 1000))
+
+DEFAULT_MATHJAX_CDN_URL = "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/latest.js?config=TeX-MML-AM_CHTML"
+MATHJAX_CDN_URL = os.environ.get('OPAC_MATHJAX_CDN_URL', DEFAULT_MATHJAX_CDN_URL)

--- a/opac/webapp/templates/article/base.html
+++ b/opac/webapp/templates/article/base.html
@@ -10,6 +10,10 @@
 
 {% block extra_css %}
   <link rel="stylesheet" href="{{ url_for('static', filename='css/scielo-article.css') }}" type="text/css" async/>
+  {% if config.MATHJAX_CDN_URL %}
+    {# recomendação da doc do mathjax: "(It can also go in the <body> if necessary, but the head is to be preferred.)" #}
+    <script type="text/javascript" async src="{{ config.MATHJAX_CDN_URL }}"></script>
+  {% endif %}
 {% endblock %}
 
 {% block content %}


### PR DESCRIPTION
FIX: #1086 

#### O que resolve este PR?
O issue: 1086. as formulas matemáticas que não são renderizadas corretamente na página do artigo

#### Por onde começar a revisão:
no arquivo de configuração `default.py` que adiciona a variável de ambinte para configurar a URL da lib JS.

#### Como deveria ser testado manualmente?
Acessando um artigo com formula matematica, deve ser renderizada corretamente. No issue tem um exemplo.

#### Algum contexto adicional a considerar?
Não

#### Outros tickets relevantes?
N/A

#### Screenshots
N/A

#### Perguntas:
N/A