### PR TITLE
fix: url do js MATHML com config certo e add namespace na tag html

### DIFF
--- a/opac/webapp/config/default.py
+++ b/opac/webapp/config/default.py
@@ -150,7 +150,7 @@ import os
         - OPAC_DEFAULT_SCHEDULER_TIMEOUT: timeout do screduler cron (dafault: 1000).
 
       - MathJax:
-        - OPAC_MATHJAX_CDN_URL: string com a URL do mathjax padrão; ex: "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/latest.js?config=TeX-MML-AM_CHTML"
+        - OPAC_MATHJAX_CDN_URL: string com a URL do mathjax padrão; ex: "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/latest.js?config=TeX-AMS-MML_HTMLorMML"
 """
 
 PROJECT_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
@@ -430,5 +430,5 @@ MAILING_CRON_STRING = os.environ.get(
 DEFAULT_SCHEDULER_TIMEOUT = int(
     os.environ.get('OPAC_DEFAULT_SCHEDULER_TIMEOUT', 1000))
 
-DEFAULT_MATHJAX_CDN_URL = "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/latest.js?config=TeX-MML-AM_CHTML"
+DEFAULT_MATHJAX_CDN_URL = "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/latest.js?config=TeX-AMS-MML_HTMLorMML"
 MATHJAX_CDN_URL = os.environ.get('OPAC_MATHJAX_CDN_URL', DEFAULT_MATHJAX_CDN_URL)

--- a/opac/webapp/templates/article/base.html
+++ b/opac/webapp/templates/article/base.html
@@ -1,5 +1,10 @@
 {% extends "base.html" %}
 
+{% block ie7_extra_namespaces %}xmlns:mml="http://www.w3.org/1998/Math/MathML"{% endblock ie7_extra_namespaces %}
+{% block ie8_extra_namespaces %}xmlns:mml="http://www.w3.org/1998/Math/MathML"{% endblock ie8_extra_namespaces %}
+{% block ie9_extra_namespaces %}xmlns:mml="http://www.w3.org/1998/Math/MathML"{% endblock ie9_extra_namespaces %}
+{% block extra_namespaces %}xmlns:mml="http://www.w3.org/1998/Math/MathML"{% endblock extra_namespaces %}
+
 {% block body_class %}journal article{% endblock %}
 
 {% block title %}{{ super() }} - {{ article.title }}{% endblock %}

--- a/opac/webapp/templates/base.html
+++ b/opac/webapp/templates/base.html
@@ -2,10 +2,10 @@
 <!DOCTYPE html>
 
 {% with html_lang=session.get('lang', config.get('BABEL_DEFAULT_LOCALE')).replace('_', '-')  %}
-  <!--[if lt IE 7]>      <html class="no-js lt-ie9 lt-ie8 lt-ie7" lang="{{ html_lang }}"> <![endif]-->
-  <!--[if IE 7]>         <html class="no-js lt-ie9 lt-ie8" lang="{{ html_lang }}"> <![endif]-->
-  <!--[if IE 8]>         <html class="no-js lt-ie9" lang="{{ html_lang }}"> <![endif]-->
-  <!--[if gt IE 8]><!--> <html class="no-js" lang="{{ html_lang }}"> <!--<![endif]-->
+  <!--[if lt IE 7]>      <html class="no-js lt-ie9 lt-ie8 lt-ie7" lang="{{ html_lang }}" {% block ie7_extra_namespaces %}{% endblock %} > <![endif]-->
+  <!--[if IE 7]>         <html class="no-js lt-ie9 lt-ie8" lang="{{ html_lang }}"        {% block ie8_extra_namespaces %}{% endblock %}> <![endif]-->
+  <!--[if IE 8]>         <html class="no-js lt-ie9" lang="{{ html_lang }}"               {% block ie9_extra_namespaces %}{% endblock %}> <![endif]-->
+  <!--[if gt IE 8]><!--> <html class="no-js" lang="{{ html_lang }}" {% block extra_namespaces %}{% endblock %}> <!--<![endif]-->
 {% endwith %}
   <head>
     <meta charset="utf-8">


### PR DESCRIPTION
#### O que resolve este PR?
Correções de erros encontrados na revisão em homologação:
- fix: parametro config na URL do js.
- add: namespace do MathML na tag `<html...>` somente para os templates de artigos

#### Por onde começar a revisão:
no arquivo de configuração `default.py` que adiciona a variável de ambiente para configurar a URL da lib JS.

#### Como deveria ser testado manualmente?
Acessando um artigo com formula matemática. Em homologação temos: 
https://homolog.opac.scielo.br/scielo.php?pid=S0044-59672017000300175&script=sci_arttext
uma formula na seção: **Statistical analysis**.

#### Algum contexto adicional a considerar?
Anteriormente não foi adicionado o **namespace** pela recomendação da documentação. Mas conferindo que não funcionou, estamos tentando com o namespace.

Fragmento da [documentação](http://docs.mathjax.org/en/latest/start.html#mathml-input): 
```
Note that even on old browsers this will work in HTML files, not just XHTML files (MathJax works with both), and that the web page need not be served with any special MIME-type. However note that in HTML (as opposed to XHTML), you should not include a namespace prefix for your <math> tags; for example, you should not use <m:math> except in an XHTML file where you have tied the m namespace to the MathML DTD by adding the xmlns:m="http://www.w3.org/1998/Math/MathML" attribute to your file’s <html> tag.

Although it is not required, it is recommended that you include the xmlns="http://www.w3.org/1998/Math/MathML" attribute on all <math> tags in your document (and this is preferred to the use of a namespace prefix like m: above, since those are deprecated in HTML5) in order to make your MathML work in the widest range of situations.
```

#### Outros tickets relevantes?
-  #1086 

#### Screenshots
##### Com erro:
![screen shot 2018-11-08 at 15 26 58](https://user-images.githubusercontent.com/805749/48216064-dedf1300-e36a-11e8-8515-4aa937700e0d.png)

##### Sem erro:
![screen shot 2018-11-08 at 15 28 36](https://user-images.githubusercontent.com/805749/48216161-16e65600-e36b-11e8-8af1-bc114a477747.png)


#### Perguntas:
N/A