### PR TITLE
get_recent_articles_of_issue deve retornar somente documentos do tipo "citável":

### DIFF
--- a/opac/tests/test_controller.py
+++ b/opac/tests/test_controller.py
@@ -812,6 +812,73 @@ class ArticleControllerTestCase(BaseTestCase):
         """
         self.assertRaises(ValueError, controllers.get_articles_by_iid, [])
 
+    def test_get_recent_articles_of_issue(self):
+        self._make_one(attrib={
+            '_id': '012ijs9y24',
+            'issue': '90210j83',
+            'journal': 'oak,ajimn1'
+        })
+
+        self._make_one(attrib={
+            '_id': '2183ikos90',
+            'issue': '90210j83',
+            'type': 'article-commentary',
+            'journal': 'oak,ajimn1'
+        })
+
+        self._make_one(attrib={
+            '_id': '012ijs9y14',
+            'issue': '90210j83',
+            'type': 'brief-report',
+            'journal': 'oak,ajimn1'
+        })
+
+        self._make_one(attrib={
+            '_id': '2183ikoD90',
+            'issue': '90210j83',
+            'type': 'case-report',
+            'journal': 'oak,ajimn1'
+        })
+
+        self._make_one(attrib={
+            '_id': '2183ikos9B',
+            'issue': '90210j83',
+            'type': 'rapid-communication',
+            'journal': 'oak,ajimn1'
+        })
+
+        self._make_one(attrib={
+            '_id': '012ijs9y1B',
+            'issue': '90210j83',
+            'type': 'research-article',
+            'journal': 'oak,ajimn1'
+        })
+
+        self._make_one(attrib={
+            '_id': '2183ikoD9F',
+            'issue': '90210j83',
+            'type': 'review-article',
+            'journal': 'oak,ajimn1'
+        })
+
+        self._make_one(attrib={
+            '_id': '9298wjXX89',
+            'issue': '90210j83',
+            'journal': 'oak,ajimn1'
+        })
+        self._make_one(attrib={
+            '_id': '9298wjXZ89',
+            'issue': '90210j83',
+            'journal': 'oak,ajimn1'
+        })
+        result = controllers.get_recent_articles_of_issue(
+            issue_iid='90210j83', is_public=True)
+        self.assertEqual(len(result), 6)
+        result = [article._id for article in result]
+        expected = ['2183ikos90', '2183ikoD90', '2183ikos9B', '012ijs9y1B',
+                    '2183ikoD9F', '012ijs9y14']
+        self.assertEqual(set(result), set(expected))
+
 
 class UserControllerTestCase(BaseTestCase):
 

--- a/opac/webapp/controllers.py
+++ b/opac/webapp/controllers.py
@@ -38,6 +38,15 @@ from mongoengine import Q
 from mongoengine.errors import InvalidQueryError
 
 
+HIGHLIGHTED_TYPES = (
+    u'article-commentary',
+    u'brief-report',
+    u'case-report',
+    u'rapid-communication',
+    u'research-article',
+    u'review-article'
+)
+
 # -------- COLLECTION --------
 
 def get_current_collection():
@@ -825,7 +834,11 @@ def get_recent_articles_of_issue(issue_iid, is_public=True):
     if not issue_iid:
         raise ValueError(__('Parámetro obrigatório: issue_iid.'))
 
-    return Article.objects.filter(issue=issue_iid, is_public=is_public).order_by('-order')
+    articles = Article.objects.filter(
+        issue=issue_iid, is_public=is_public).order_by('-order')
+    return [article
+            for article in articles
+            if article.type in HIGHLIGHTED_TYPES]
 
 # -------- NEWS --------
 

--- a/opac/webapp/controllers.py
+++ b/opac/webapp/controllers.py
@@ -834,11 +834,9 @@ def get_recent_articles_of_issue(issue_iid, is_public=True):
     if not issue_iid:
         raise ValueError(__('Parámetro obrigatório: issue_iid.'))
 
-    articles = Article.objects.filter(
-        issue=issue_iid, is_public=is_public).order_by('-order')
-    return [article
-            for article in articles
-            if article.type in HIGHLIGHTED_TYPES]
+    return Article.objects.filter(
+        issue=issue_iid, is_public=is_public,
+        type__in=HIGHLIGHTED_TYPES).order_by('-order')
 
 # -------- NEWS --------
 


### PR DESCRIPTION
#### What's this PR do?
Retornar apenas documentos dos tipos:
    - article-commentary
    - brief-report
    - case-report
    - rapid-communication
    - research-article
    - review-article
Com o objetivo de dar destaques a documentos mais relevantes na página principal do periódico na seção "Artigos mais recentes" 

#### Where should the reviewer start?
opac/webapp/controllers.py
linha 837

#### What are the relevant tickets?
issue #885 

#### Screenshots (if appropriate)
![captura de tela 2018-12-03 as 16 09 21](https://user-images.githubusercontent.com/505143/49392516-d2ee3300-f715-11e8-8754-7c673f872197.png)


tk885