### PR TITLE
Inclui URL na mensagem de erro e adiciona os títulos corretos nas páginas

### DIFF
--- a/opac/webapp/controllers.py
+++ b/opac/webapp/controllers.py
@@ -985,7 +985,8 @@ def send_email_share(from_email, recipents, share_url, subject, comment):
     return (True, __('Mensagem enviada!'))
 
 
-def send_email_error(user_name, from_email, recipents, url, error_type, comment, subject=None):
+def send_email_error(user_name, from_email, recipents, url, error_type,
+                     comment, page_title, subject=None):
     """
     Envia uma mensagem de erro de página e retorna uma mensagem de
     confirmação
@@ -996,14 +997,21 @@ def send_email_error(user_name, from_email, recipents, url, error_type, comment,
     - ``url``       : URL da página com erro
     - ``subject``   : Assunto
     - ``comment``   : Comentário
+    - ``page_title``: Título da página
     """
     subject = subject or __('[Erro] Erro informado pelo usuário no site SciELO')
-    if error_type == 'application':
-        url = __('O usuário <b>%s</b> com e-mail: <b>%s</b>, informa que existe um erro na aplicação no site SciELO.</br></br>Link: %s' % (user_name, from_email, url))
-    elif error_type == 'content':
-        url = __('O usuário <b>%s</b> com e-mail: <b>%s</b>, informa que existe um erro de conteúdo no site SicELO.</br></br>Link: %s' % (user_name, from_email, url))
 
-    comment = '%s<br/><br/><b>Mensagem do usuário:</b> %s' % (url, comment)
+    msg = ('O usuário <b>%s</b> com e-mail: <b>%s</b>,'
+           ' informa que existe um erro na %s no site SciELO.'
+           '<br><br><b>Título da página:</b> %s'
+           '<br><br><b>Link:</b> %s')
+
+    if error_type == 'application':
+        url = __(msg % (user_name, from_email, 'aplicação', page_title, url))
+    elif error_type == 'content':
+        url = __(msg % (user_name, from_email, 'conteúdo', page_title, url))
+
+    comment = '%s<br><br><b>Mensagem do usuário:</b> %s' % (url, comment)
 
     sent, message = utils.send_email(recipents, subject, comment)
 

--- a/opac/webapp/forms.py
+++ b/opac/webapp/forms.py
@@ -40,4 +40,5 @@ class ErrorForm(FlaskForm):
     your_email = StringField('your_email', validators=[DataRequired(), Email()])
     error_type = StringField('error_type', validators=[DataRequired()])
     url = HiddenField('share_url', validators=[URL(), DataRequired()])
+    page_title = HiddenField('page_title', validators=[DataRequired()])
     message = TextAreaField('message', validators=[DataRequired()])

--- a/opac/webapp/main/views.py
+++ b/opac/webapp/main/views.py
@@ -1113,7 +1113,8 @@ def email_error_ajax():
                                                      recipients,
                                                      form.data['url'],
                                                      form.data['error_type'],
-                                                     form.data['message'])
+                                                     form.data['message'],
+                                                     form.data['page_title'])
 
         return jsonify({'sent': sent, 'message': str(message),
                         'fields': [key for key in form.data.keys()]})

--- a/opac/webapp/templates/article/base.html
+++ b/opac/webapp/templates/article/base.html
@@ -1,5 +1,7 @@
 {% extends "base.html" %}
 
+{% block title %}{{ article.title }}{% endblock %}
+
 {% block ie7_extra_namespaces %}xmlns:mml="http://www.w3.org/1998/Math/MathML"{% endblock ie7_extra_namespaces %}
 {% block ie8_extra_namespaces %}xmlns:mml="http://www.w3.org/1998/Math/MathML"{% endblock ie8_extra_namespaces %}
 {% block ie9_extra_namespaces %}xmlns:mml="http://www.w3.org/1998/Math/MathML"{% endblock ie9_extra_namespaces %}

--- a/opac/webapp/templates/collection/list_journal.html
+++ b/opac/webapp/templates/collection/list_journal.html
@@ -1,5 +1,7 @@
 {% extends "collection/base.html" %}
 
+{% block title %}{% trans %}Lista de periódicos{% endtrans %}{% endblock %}
+
 {% block level_menu %}
   {% include "collection/includes/levelMenu.html" %}
 {% endblock %}

--- a/opac/webapp/templates/includes/error_form.html
+++ b/opac/webapp/templates/includes/error_form.html
@@ -1,67 +1,73 @@
 <div class="modal-dialog">
-	<div class="modal-content">
-		<div class="modal-header">
-			<button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">&times;</span><span class="sr-only">Fechar</span></button>
-			<h4 class="modal-title">{% trans %} Reportar erro {% endtrans %}</h4>
-		</div>
-		<form action="" method="POST" id="error_form_id">
+    <div class="modal-content">
+        <div class="modal-header">
+            <button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">&times;</span><span class="sr-only">Fechar</span></button>
+            <h4 class="modal-title">{% trans %} Reportar erro {% endtrans %}</h4>
+        </div>
 
-			{{ g.error.csrf_token() }}
+        <form action="" method="POST" id="error_form_id">
 
-			{{ g.error.url(value=url) }}
+            {{ g.error.csrf_token() }}
 
-			<div class="modal-body">
+            {{ g.error.url(value=url) }}
 
-				<div class="form-group">
-					<label class="control-label">{% trans %}Seu Nome{% endtrans %}*</label>
-					{{ g.error.name(class="form-control valid", placeholder=_("Digite seu Nome")) }}
-					<label class="control-label" id="{{g.error.name.name}}_error"></label>
-				</div>
+            {{ g.error.page_title(value="") }}
 
-	            <div class="form-group">
-	              <label class="control-label">{% trans %}Seu e-mail{% endtrans %}*</label>
-	                {{ g.error.your_email(class="form-control valid", placeholder="Digite seu e-mail") }}
-	                <label class="control-label" id="{{g.error.your_email.name}}_error"></label>
-	            </div>
 
-				<div class="form-group">
-					<label class="control-label">{% trans %}Erro referente{% endtrans %}:</label>
+            <div class="modal-body">
 
-					<div class="radio" style="margin-top:0;">
-						<label><input type="radio" name="error_type" value="content" checked>{% trans %}ao conteúdo{% endtrans %}</label>
-					</div>
+                <div class="form-group">
+                    <label class="control-label">{% trans %}Seu Nome{% endtrans %}*</label>
+                    {{ g.error.name(class="form-control valid", placeholder=_("Digite seu Nome")) }}
+                    <label class="control-label" id="{{g.error.name.name}}_error"></label>
+                </div>
 
-					<div class="radio">
-						<label><input type="radio" name="error_type" value="application">{% trans %}à aplicação{% endtrans %}</label>
-					</div>
+                <div class="form-group">
+                  <label class="control-label">{% trans %}Seu e-mail{% endtrans %}*</label>
+                    {{ g.error.your_email(class="form-control valid", placeholder="Digite seu e-mail") }}
+                    <label class="control-label" id="{{g.error.your_email.name}}_error"></label>
+                </div>
 
-					<label class="control-label" id="{{g.error.error_type.name}}_error"></label>
-				</div>
+                <div class="form-group">
+                    <label class="control-label">{% trans %}Erro referente{% endtrans %}:</label>
 
-				<div class="form-group">
-					<label class="control-label">{% trans %}Descrição do erro{% endtrans %} :</label>
-					{{ g.error.message(class="form-control valid", placeholder=_("Digite sua mensagem"), rows="10") }}
-					<label class="control-label" id="{{g.error.message.name}}_error"></label>
-					<span class="info-form">{% trans %}Obs.: Link e título da página são enviados automaticamente{% endtrans %}.</span>
-				</div>
+                    <div class="radio" style="margin-top:0;">
+                        <label><input type="radio" name="error_type" value="content" checked>{% trans %}ao conteúdo{% endtrans %}</label>
+                    </div>
 
-				<div class="form-group">
- 			<div id="error_captcha_id"></div>
-			</div>
+                    <div class="radio">
+                        <label><input type="radio" name="error_type" value="application">{% trans %}à aplicação{% endtrans %}</label>
+                    </div>
 
-			</div>
+                    <label class="control-label" id="{{g.error.error_type.name}}_error"></label>
+                </div>
 
-			<div class="modal-footer">
-				<div class="btn-block">
-					<input type="submit" name="s" value="{% trans %}Enviar{% endtrans %} " class="btn" id="error_submit_btn_id">
-				</div>
-			</div>
+                <div class="form-group">
+                    <label class="control-label">{% trans %}Descrição do erro{% endtrans %} :</label>
+                    {{ g.error.message(class="form-control valid", placeholder=_("Digite sua mensagem"), rows="10") }}
+                    <label class="control-label" id="{{g.error.message.name}}_error"></label>
+                    <span class="info-form">{% trans %}Obs.: Link e título da página são enviados automaticamente{% endtrans %}.</span>
+                </div>
 
-		</form>
-	</div>
+                <div class="form-group">
+            <div id="error_captcha_id"></div>
+            </div>
+
+            </div>
+
+            <div class="modal-footer">
+                <div class="btn-block">
+                    <input type="submit" name="s" value="{% trans %}Enviar{% endtrans %} " class="btn" id="error_submit_btn_id">
+                </div>
+            </div>
+
+        </form>
+    </div>
 </div>
 
 <script>
+
+  $('#page_title').val(document.title);
 
   var error_form = Object.create(ModalForms);
 

--- a/opac/webapp/templates/issue/grid.html
+++ b/opac/webapp/templates/issue/grid.html
@@ -1,6 +1,8 @@
 {% extends "issue/base.html" %}
 {% import "macros/issue.html" as issue_macros %}
 
+{% block title %}{% trans %}Fascículos: {% endtrans %}{{ journal.title }}{% endblock %}
+
 {% block main_content %}
 
   <section class="journalContent">

--- a/opac/webapp/templates/issue/toc.html
+++ b/opac/webapp/templates/issue/toc.html
@@ -1,5 +1,7 @@
 {% extends "issue/base.html" %}
 
+{% block title %}{{ issue_legend|default('--', True) }}{% endblock %}
+
 {% block main_content %}
 
   <section class="journalContent">

--- a/opac/webapp/templates/journal/base.html
+++ b/opac/webapp/templates/journal/base.html
@@ -1,4 +1,7 @@
 {% extends "base.html" %}
+
+{% block title %}{{ journal.title }}{% endblock %}
+
 {% block body_class %}journal{% endblock %}
 {% block content %}
   {% include "journal/includes/header.html" %}


### PR DESCRIPTION

FIX: #1129

O que resolve este PR?
Adiciona o título das páginas na mensagem de erro.

Por onde começar a revisão:
No controllers.py linha: https://github.com/scieloorg/opac/blob/master/opac/webapp/controllers.py#L1000

Verificar os template: 
```
webapp/templates/article/base.html
webapp/templates/collection/list_journal.html
webapp/templates/includes/error_form.html
webapp/templates/issue/grid.html
webapp/templates/issue/toc.html
webapp/templates/journal/base.html
```
Mensagem ficará disponível no MailHog:

![captura de tela 2018-12-17 20 48 59](https://user-images.githubusercontent.com/373745/50121235-3eb8bb80-023f-11e9-9ba1-40d59b850309.png)


Algum contexto adicional a considerar?
Não

Outros tickets relevantes?
N/A

Perguntas:
N/A