### PR TITLE
Corrige mudança de idioma na lista temática de periódicos

### DIFF
--- a/opac/webapp/main/views.py
+++ b/opac/webapp/main/views.py
@@ -73,10 +73,14 @@ def set_locale(lang_code):
     if lang_code not in list(langs.keys()):
         abort(400, _('Código de idioma inválido'))
 
+    referrer = request.referrer
+    hash = request.args.get('hash')
+    if hash:
+        referrer += "#" + hash
+
     # salvar o lang code na sessão
     session['lang'] = lang_code
-
-    return redirect(request.referrer)
+    return redirect(referrer)
 
 
 def get_lang_from_session():

--- a/opac/webapp/templates/collection/list_journal.html
+++ b/opac/webapp/templates/collection/list_journal.html
@@ -386,10 +386,17 @@
             default:
                 listAlpha()
         }
+        window.location.hash = target;
 
       });
       $('.home-tab').click(function(){
         window.location.href = "{{ url_for('main.index') }}";
+      });
+
+      $("a[lang][class^='lang']").click(function (e) {
+  		  e.preventDefault();
+          var hash = window.location.hash;
+          window.location = $(this).attr("href") + '?hash=' + hash;
       });
 
     });


### PR DESCRIPTION
#### O que esse PR faz?
Hoje, ao acessar a lista temática de periódicos e alterar o idioma, ao invés de manter-se na aba temática, muda para a aba alfabética.

#### Onde a revisão poderia começar?
Pela view `set_locale` em `main/view.py`

#### Como este poderia ser testado manualmente?
- Acesse a lista de periódicos em ordem alfabética. Altere para a aba por área temática e mude o idioma. A lista por área temática deve continuar sendo exibida com o idioma alterado.
- Acesse outras páginas (página principal, home do periódico, , artigo etc) e altere o idioma, para garantir que a alteração não afetou a mudança de idioma em outras partes.

#### Algum cenário de contexto que queira dar?
N/A

#### Quais são tickets relevantes?
#835 

#### Screenshots (se aplicável)
N/A

#### Perguntas:
N/A
