### PR TITLE
Corrige a alteração do conteúdo das Páginas Secundárias no Admin

### DIFF
--- a/opac/tests/test_utils.py
+++ b/opac/tests/test_utils.py
@@ -264,7 +264,7 @@ class UtilsTestCase(BaseTestCase):
         new_content = wutils.migrate_page_content(
             content, acron='rbep', page_name=None, language='pt')
         self.assertEqual(
-            '<html><body><img src="/media/rbep_abc.jpg"/>'
-            '<a href="/media/rbep_avaliacao_en.htm"></a></body></html>',
+            '<img src="/media/rbep_abc.jpg"/>'
+            '<a href="/media/rbep_avaliacao_en.htm"></a>',
             new_content
         )

--- a/opac/tests/test_utils_page_migration.py
+++ b/opac/tests/test_utils_page_migration.py
@@ -206,7 +206,7 @@ class UtilsMigratedPageTestCase(BaseTestCase):
 
     def test_content(self):
         self.page.content = '<html><body>x</body></html>'
-        self.assertEqual(self.page.content, '<html><body>x</body></html>')
+        self.assertEqual(self.page.content, 'x')
 
     def test_find_original_website_reference(self):
         self.page.content = '''<img src="www.scielo.br"/>

--- a/opac/webapp/utils/page_migration.py
+++ b/opac/webapp/utils/page_migration.py
@@ -313,7 +313,7 @@ class MigratedPage(object):
 
     @property
     def content(self):
-        return str(self.tree)
+        return ''.join([str(content) for content in self.tree.body.contents])
 
     @content.setter
     def content(self, value):


### PR DESCRIPTION
#### O que esse PR faz?
Corrige o conteúdo das páginas secundárias que, ao ser alterado, estava gerando um erro por conta do _parser_ de HTML utilizado para o conteúdo.

#### Onde a revisão poderia começar?
Property `MigratedPage.content` em `webapp/utils/page_migration.py`

#### Como este poderia ser testado manualmente?
- Altere uma página secundária existente e tente visualizá-la.
- Crie uma página secundária nova e tente visualizá-la.

#### Algum cenário de contexto que queira dar?
A aplicação utiliza o Flask-HTMLmin que mimifica os responses do Flask de mime type `text/html`. Ele utiliza o htmlmin e seu parser valida se há outras tags além da tag `html` que fecha todo o conteúdo. Como o conteúdo das páginas secundárias está sendo parseado na aplicação com o BeautifulSoup, utilizando o parser `lxml`, o objeto retornado é criado com as tags `html` e `body`, que conflitam com as tags da página da aplicação. 

#### Quais são tickets relevantes?
#1145

#### Screenshots (se aplicável)
N/A

#### Perguntas:
N/A
