### PR TITLE
Atualiza versão do RQ para corrigir exceção

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,7 @@ beautifulsoup4==4.6.3
 Flask-WTF==0.14.2
 Flask-Caching==1.4.0
 redis==2.10.6
-rq==0.9.1
+rq==0.9.2
 rq-dashboard==0.3.10
 rq-scheduler==0.8.2
 rq-scheduler-dashboard==0.0.2


### PR DESCRIPTION
Ao atualizar o ambiente, a seguinte exceção ocorreu:

```
Traceback (most recent call last):
  File "/usr/local/bin/rq", line 11, in <module>
    sys.exit(main())
  File "/usr/local/lib/python3.5/site-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python3.5/site-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python3.5/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python3.5/site-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python3.5/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/usr/local/lib/python3.5/site-packages/rq/cli/cli.py", line 73, in wrapper
    return ctx.invoke(func, cli_config, *args[1:], **kwargs)
  File "/usr/local/lib/python3.5/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/usr/local/lib/python3.5/site-packages/rq/cli/cli.py", line 202, in worker
    cleanup_ghosts(cli_config.connection)
  File "/usr/local/lib/python3.5/site-packages/rq/contrib/legacy.py", line 25, in cleanup_ghosts
    for worker in Worker.all(connection=conn):
  File "/usr/local/lib/python3.5/site-packages/rq/worker.py", line 109, in all
    for key in reported_working]
  File "/usr/local/lib/python3.5/site-packages/rq/worker.py", line 109, in <listcomp>
    for key in reported_working]
  File "/usr/local/lib/python3.5/site-packages/rq/worker.py", line 136, in find_by_key
    worker.refresh()
  File "/usr/local/lib/python3.5/site-packages/rq/worker.py", line 547, in refresh
    self.birth_date = utcparse(as_text(birth))
  File "/usr/local/lib/python3.5/site-packages/rq/utils.py", line 169, in utcparse
    return datetime.datetime.strptime(string, _TIMESTAMP_FORMAT)
TypeError: strptime() argument 1 must be str, not None
```
O problema foi corrigido na versão 0.9.2, conforme changelog:
https://pyup.io/changelogs/rq/#0.9.2

Erro reportado:
https://github.com/rq/rq/issues/905
