### PR TITLE
[tk891] Corrige o conteúdo da janela modal onde deveria apresentar links para Google e Google Scholar

### DIFF
--- a/opac/webapp/templates/article/includes/modal/related_article.html
+++ b/opac/webapp/templates/article/includes/modal/related_article.html
@@ -14,7 +14,7 @@
             {% for source, label, link in related_links  %}
               <li>
                 <a href="{{ link }}" target="_blank">
-                  {% trans %}{{ label }}{% endtrans %}<br/> {{ source }}
+                  {{ source }}
                 </a>
               </li>
             {% endfor %}


### PR DESCRIPTION
#### What's this PR do?
Corrige o conteúdo da janela modal onde deveria apresentar links para Google e Google Scholar, pois os links não estavam funcionando, aparentemente por haver mudado o link de busca.

#### Where should the reviewer start?
/opac/webapp/main/views.py, linha 862

#### How should this be manually tested?
Após o deploy, entre na página de um artigo, por exemplo: https://new.scielo.br/scielo.php?pid=S0100-879X2004000400003&script=sci_arttext, acesse o menu flutuante na lateral esquerda inferior, clicar no último ícone (Artigos relacionados ou artigos e similares). Testar os links que aparecem na janela modal.

#### Any background context you want to provide?
como a forma de criar os links para Google e Google Scholar podem mudar, decidi criar funções que geram os dados para apresentar o conteúdo do modal. Veja /opac/webapp/utils/related_articles_urls.py

#### What are the relevant tickets?
#891 

#### Screenshots (if appropriate)
Ver no issue #891 
