### PR TITLE
[tk828] Tradução do termo "Números <span>mais recentes</span>" para i…

### DIFF
--- a/opac/webapp/translations/en/LC_MESSAGES/messages.po
+++ b/opac/webapp/translations/en/LC_MESSAGES/messages.po
@@ -1407,7 +1407,7 @@ msgstr "Thematic"
 
 #: opac/webapp/templates/collection/index.html:93
 msgid "Números <span>mais recentes</span>"
-msgstr ""
+msgstr "<span>Latest</span> issues"
 
 #: opac/webapp/templates/collection/index.html:137
 msgid "em perspectiva"

--- a/opac/webapp/translations/es/LC_MESSAGES/messages.po
+++ b/opac/webapp/translations/es/LC_MESSAGES/messages.po
@@ -1724,7 +1724,7 @@ msgstr "Lea"
 
 #: opac/webapp/templates/includes/footer.html:38
 msgid "a Declaração de Acesso Aberto"
-msgstr "a Declaración de Acceso abierto"
+msgstr "la Declaración de Acceso abierto"
 
 #: opac/webapp/templates/issue/grid.html:4
 msgid "Fascículos"

--- a/opac/webapp/translations/es/LC_MESSAGES/messages.po
+++ b/opac/webapp/translations/es/LC_MESSAGES/messages.po
@@ -1410,7 +1410,7 @@ msgstr "Temática"
 
 #: opac/webapp/templates/collection/index.html:93
 msgid "Números <span>mais recentes</span>"
-msgstr ""
+msgstr "Números <span>más recientes</span>"
 
 #: opac/webapp/templates/collection/index.html:137
 msgid "em perspectiva"

--- a/opac/webapp/translations/es_ES/LC_MESSAGES/messages.po
+++ b/opac/webapp/translations/es_ES/LC_MESSAGES/messages.po
@@ -1385,7 +1385,7 @@ msgstr ""
 
 #: opac/webapp/templates/collection/index.html:93
 msgid "Números <span>mais recentes</span>"
-msgstr ""
+msgstr "Números <span>más recientes</span>"
 
 #: opac/webapp/templates/collection/index.html:137
 msgid "em perspectiva"

--- a/opac/webapp/translations/es_MX/LC_MESSAGES/messages.po
+++ b/opac/webapp/translations/es_MX/LC_MESSAGES/messages.po
@@ -1385,7 +1385,7 @@ msgstr ""
 
 #: opac/webapp/templates/collection/index.html:93
 msgid "Números <span>mais recentes</span>"
-msgstr ""
+msgstr "Números <span>más recientes</span>"
 
 #: opac/webapp/templates/collection/index.html:137
 msgid "em perspectiva"


### PR DESCRIPTION
…nglês e espanhol

#### What's this PR do?
Traduz o termo "Números ``<span>mais recentes</span>``" para inglês e espanhol
Também corrige o termo "a Declaración de Acceso abierto" (espanhol). O correto é "la Declaración de Acceso abierto"

#### Where should the reviewer start?
/opac/webapp/translations/en/LC_MESSAGES/messages.po

#### How should this be manually tested?
Acessar https://new.scielo.br/ em inglês e espanhol e procurar respectivamente por Latest issue e por Números más recientes
<img width="1138" alt="captura de tela 2019-01-11 as 16 54 03" src="https://user-images.githubusercontent.com/505143/51053710-8b36b300-15c1-11e9-95b9-1a8cdb71db06.png">

Acessar https://new.scielo.br/ em espanhol, ver no pé da página
<img width="311" alt="captura de tela 2019-01-11 as 17 03 40" src="https://user-images.githubusercontent.com/505143/51054214-427ff980-15c3-11e9-999c-8f0bf575b2c6.png">
O correto é "Lea la Declaración de Acceso abierto"

#### Any background context you want to provide?
N/A

#### What are the relevant tickets?
#828 e #1030

