### PR TITLE
Corrige ordenação de artigos AOPs e de publicação contínua

### DIFF
--- a/opac/webapp/controllers.py
+++ b/opac/webapp/controllers.py
@@ -799,8 +799,7 @@ def get_articles_by_iid(iid, **kwargs):
 
     articles = Article.objects(issue=iid, **kwargs).order_by('order')
     if is_aop_issue(iid) or is_open_publication(articles):
-        ordered = sorted([(article.publication_date, article) for article in articles], reverse=True)
-        return [article for pubdate, article in ordered]
+        return articles.order_by('-publication_date')
     return articles
 
 


### PR DESCRIPTION
#### O que esse PR faz?
Corrige a implementação feita no PR #1159, onde `controllers. get_articles_by_iid()` deve retornar sempre um QuerySet e não uma lista.

#### Como este poderia ser testado manualmente?
Ao acessar o TOC de um periódico de publicação contínua ou de um Ahead of Print, não deve ocorrer erro.

#### Algum cenário de contexto que queira dar?
Detalhes no PR #1159.

#### Quais são tickets relevantes?
#987 