### PR TITLE
Adicionado razão da descontinuidade do periódico na listagem

### DIFF
--- a/opac/webapp/choices.py
+++ b/opac/webapp/choices.py
@@ -32,3 +32,11 @@ ISO3166_ALPHA2 = {
     'ar': __('Árabe'),
     'zh': __('Chinês'),
 }
+
+JOURNAL_STATUS = {
+    "current": __("corrente"),
+    "deceased": __("terminado"),
+    "suspended": __("indexação interrompida"),
+    "interrupted": __("indexação interrompida pelo Comitê"),
+    "finished": __("publicação finalizada"),
+}

--- a/opac/webapp/controllers.py
+++ b/opac/webapp/controllers.py
@@ -30,7 +30,7 @@ from flask_babelex import lazy_gettext as __
 from flask_mongoengine import Pagination
 from webapp import dbsql
 from .models import User
-from .choices import INDEX_NAME
+from .choices import INDEX_NAME, JOURNAL_STATUS
 from .utils import utils
 from uuid import uuid4
 
@@ -206,6 +206,7 @@ def get_journal_json_data(journal, language='pt'):
         'is_active': journal.current_status == 'current',
         'issues_count': journal.issue_count,
         'next_title': journal.next_title,
+        'status_reason' : str(JOURNAL_STATUS.get(journal.current_status, journal.current_status))
     }
 
     if journal.last_issue:

--- a/opac/webapp/templates/collection/includes/tmpl_journal_list_row.html
+++ b/opac/webapp/templates/collection/includes/tmpl_journal_list_row.html
@@ -40,7 +40,7 @@
     <% } %>
 
     <% if (!journal.is_active) { %>
-      ({% trans %}descontinuado{% endtrans %})
+      (<%- journal.status_reason %>)
         <% if (journal.next_title) { %>
         <span class="journalPreviousTitle">{% trans %}Continua como {% endtrans %}
             <% if (journal.url_new_journal) { %>

--- a/opac/webapp/translations/en/LC_MESSAGES/messages.po
+++ b/opac/webapp/translations/en/LC_MESSAGES/messages.po
@@ -216,7 +216,7 @@ msgstr "current"
 
 #: opac/webapp/choices.py:38
 msgid "terminado"
-msgstr "ceased"
+msgstr "deceased"
 
 #: opac/webapp/choices.py:39
 msgid "indexação interrompida"

--- a/opac/webapp/translations/en/LC_MESSAGES/messages.po
+++ b/opac/webapp/translations/en/LC_MESSAGES/messages.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version:  OPAC\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-01-31 15:58+0000\n"
+"POT-Creation-Date: 2019-02-01 19:52+0000\n"
 "PO-Revision-Date: 2018-03-06 19:50+0000\n"
 "Last-Translator: jamil Atta <atta.jamil@gmail.com>\n"
 "Language: en\n"
@@ -121,7 +121,7 @@ msgstr "Collection"
 
 #: opac/webapp/__init__.py:120 opac/webapp/admin/views.py:537
 #: opac/webapp/admin/views.py:609 opac/webapp/templates/issue/grid.html:41
-#: opac/webapp/templates/news/includes/issue_last_row.html:10
+#: opac/webapp/templates/news/includes/issue_last_row.html:11
 msgid "Número"
 msgstr "Number"
 
@@ -210,135 +210,155 @@ msgstr "Russian"
 msgid "Árabe"
 msgstr "Arabic"
 
-#: opac/webapp/controllers.py:342
+#: opac/webapp/choices.py:37
+msgid "corrente"
+msgstr "current"
+
+#: opac/webapp/choices.py:38
+msgid "terminado"
+msgstr "ceased"
+
+#: opac/webapp/choices.py:39
+msgid "indexação interrompida"
+msgstr "indexing interrupted"
+
+#: opac/webapp/choices.py:40
+msgid "indexação interrompida pelo Comitê"
+msgstr "indexing interrupted by the committee"
+
+#: opac/webapp/choices.py:41
+msgid "publicação finalizada"
+msgstr "publication finished"
+
+#: opac/webapp/controllers.py:346
 msgid "Lista Alfabética"
 msgstr "Alphabetic List"
 
-#: opac/webapp/controllers.py:346
+#: opac/webapp/controllers.py:350
 msgid "Lista Temática"
 msgstr "Thematic List"
 
-#: opac/webapp/controllers.py:350
+#: opac/webapp/controllers.py:354
 msgid "Lista Web of Science"
 msgstr "Web of Science List"
 
-#: opac/webapp/controllers.py:354
+#: opac/webapp/controllers.py:358
 msgid "Lista by Institution"
 msgstr "List by Institution"
 
-#: opac/webapp/controllers.py:413
+#: opac/webapp/controllers.py:417
 msgid "Obrigatório um jid."
 msgstr "A jid is required."
 
-#: opac/webapp/controllers.py:429
+#: opac/webapp/controllers.py:433
 msgid "Obrigatório um acronym."
 msgstr "An acronym is required."
 
-#: opac/webapp/controllers.py:445
+#: opac/webapp/controllers.py:449
 msgid "Obrigatório um url_seg."
 msgstr "A url_seg is required."
 
-#: opac/webapp/controllers.py:461
+#: opac/webapp/controllers.py:465
 msgid "Obrigatório um issn."
 msgstr "ISSN is required."
 
-#: opac/webapp/controllers.py:476
+#: opac/webapp/controllers.py:480
 msgid "Obrigatório um title."
 msgstr ""
 
-#: opac/webapp/controllers.py:514 opac/webapp/controllers.py:658
-#: opac/webapp/controllers.py:798
+#: opac/webapp/controllers.py:518 opac/webapp/controllers.py:662
+#: opac/webapp/controllers.py:802
 msgid "Obrigatório uma lista de ids."
 msgstr "A list of id's is required."
 
-#: opac/webapp/controllers.py:620 opac/webapp/controllers.py:819
+#: opac/webapp/controllers.py:624 opac/webapp/controllers.py:823
 msgid "Obrigatório um iid."
 msgstr "A iid is required."
 
-#: opac/webapp/controllers.py:677
+#: opac/webapp/controllers.py:681
 msgid "Obrigatório um jacron e issue_label."
 msgstr "A jacron and issue_label are required."
 
-#: opac/webapp/controllers.py:690
+#: opac/webapp/controllers.py:694
 msgid "Obrigatório um PID."
 msgstr "PID is required."
 
-#: opac/webapp/controllers.py:706
+#: opac/webapp/controllers.py:710
 msgid "Obrigatório um url_seg e url_seg_issue."
 msgstr "A url_seg and url_seg_issue are required."
 
-#: opac/webapp/controllers.py:713
+#: opac/webapp/controllers.py:717
 msgid "Obrigatório um assets_code."
 msgstr " assets_code is mandatory."
 
-#: opac/webapp/controllers.py:716
+#: opac/webapp/controllers.py:720
 msgid "Obrigatório um journal."
 msgstr "Journal is mandatory."
 
-#: opac/webapp/controllers.py:732
+#: opac/webapp/controllers.py:736
 msgid "Obrigatório um aid."
 msgstr "A aid is required."
 
-#: opac/webapp/controllers.py:746
+#: opac/webapp/controllers.py:750
 msgid "Obrigatório um url_seg_article."
 msgstr "A url_seg_article is required."
 
-#: opac/webapp/controllers.py:761
+#: opac/webapp/controllers.py:765
 msgid "Obrigatório um iid and url_seg_article."
 msgstr "A iid and url_seg_article are required."
 
-#: opac/webapp/controllers.py:857
+#: opac/webapp/controllers.py:861
 msgid "Obrigatório um pid."
 msgstr "pid is required."
 
-#: opac/webapp/controllers.py:870
+#: opac/webapp/controllers.py:874
 msgid "Obrigatório um aop_pid."
 msgstr "aop_pid is mandatory."
 
-#: opac/webapp/controllers.py:881
+#: opac/webapp/controllers.py:885
 msgid "Parámetro obrigatório: issue_iid."
 msgstr "issue_iid is mandatory."
 
-#: opac/webapp/controllers.py:929
+#: opac/webapp/controllers.py:933
 msgid "Parâmetro email deve ser uma string"
 msgstr "The parameter \"email\" must be a string."
 
-#: opac/webapp/controllers.py:940
+#: opac/webapp/controllers.py:944
 msgid "Parâmetro email deve ser uma inteiro"
 msgstr "The parameter \"email\" must be an integer."
 
-#: opac/webapp/controllers.py:952 opac/webapp/controllers.py:966
+#: opac/webapp/controllers.py:956 opac/webapp/controllers.py:970
 #, python-format
 msgid "Usuário deve ser do tipo %s"
 msgstr "User must be of type %s"
 
-#: opac/webapp/controllers.py:1022
+#: opac/webapp/controllers.py:1026
 msgid "Compartilhamento de link SciELO"
 msgstr "SciELO link sharing"
 
-#: opac/webapp/controllers.py:1023
+#: opac/webapp/controllers.py:1027
 #, python-format
 msgid "O usuário %s compartilha este link: %s, da SciELO"
 msgstr "The user %s share link: %s, of SciELO"
 
-#: opac/webapp/controllers.py:1031 opac/webapp/controllers.py:1067
-#: opac/webapp/controllers.py:1089
+#: opac/webapp/controllers.py:1035 opac/webapp/controllers.py:1071
+#: opac/webapp/controllers.py:1093
 msgid "Mensagem enviada!"
 msgstr "Message sent!"
 
-#: opac/webapp/controllers.py:1048
+#: opac/webapp/controllers.py:1052
 msgid "[Erro] Erro informado pelo usuário no site SciELO"
 msgstr "[Error] Error informed by the user in the SciELO site"
 
-#: opac/webapp/controllers.py:1051
+#: opac/webapp/controllers.py:1055
 msgid "aplicação"
 msgstr ""
 
-#: opac/webapp/controllers.py:1053
+#: opac/webapp/controllers.py:1057
 msgid "conteúdo"
 msgstr ""
 
-#: opac/webapp/controllers.py:1058
+#: opac/webapp/controllers.py:1062
 #, python-format
 msgid ""
 "O usuário <b>%s</b> com e-mail: <b>%s</b>, informa que existe um erro na "
@@ -349,16 +369,16 @@ msgstr ""
 " %s in the website SciELO.<br><br><b>Title of page:</b> "
 "%s<br><br><b>Link:</b> %s"
 
-#: opac/webapp/controllers.py:1079
+#: opac/webapp/controllers.py:1083
 msgid "Contato de usuário via site SciELO"
 msgstr "User contact by SciELO website"
 
-#: opac/webapp/controllers.py:1081
+#: opac/webapp/controllers.py:1085
 #, python-format
 msgid "O usuário %s, com e-mail: %s, entra em contato com a seguinte mensagem:"
 msgstr "User %s, e-mail: %s, contact us with the following message:"
 
-#: opac/webapp/controllers.py:1113
+#: opac/webapp/controllers.py:1117
 msgid "Obrigatório um slug_name."
 msgstr "An slug_name is required"
 
@@ -734,7 +754,7 @@ msgstr "Cover's URL"
 #: opac/webapp/admin/views.py:536
 #: opac/webapp/templates/collection/list_feed_content.html:3
 #: opac/webapp/templates/issue/grid.html:40
-#: opac/webapp/templates/news/includes/issue_last_row.html:6
+#: opac/webapp/templates/news/includes/issue_last_row.html:7
 msgid "Volume"
 msgstr "Volume"
 
@@ -762,7 +782,7 @@ msgstr "End month"
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:25
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:68
 #: opac/webapp/templates/issue/grid.html:39
-#: opac/webapp/templates/news/includes/issue_last_row.html:4
+#: opac/webapp/templates/news/includes/issue_last_row.html:5
 msgid "Ano"
 msgstr "Year"
 
@@ -1424,7 +1444,6 @@ msgstr "Last issue"
 msgid "Nº"
 msgstr "Nº"
 
-#: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:43
 #: opac/webapp/templates/collection/list_feed_content.html:6
 msgid "descontinuado"
 msgstr "non-current"
@@ -1965,11 +1984,11 @@ msgstr " special issue "
 msgid "número especial"
 msgstr "special issue"
 
-#: opac/webapp/templates/news/includes/issue_last_row.html:14
+#: opac/webapp/templates/news/includes/issue_last_row.html:15
 msgid "Suplemento"
 msgstr ""
 
-#: opac/webapp/templates/news/includes/issue_last_row.html:19
+#: opac/webapp/templates/news/includes/issue_last_row.html:20
 msgid "Ver"
 msgstr "Open"
 

--- a/opac/webapp/translations/es/LC_MESSAGES/messages.po
+++ b/opac/webapp/translations/es/LC_MESSAGES/messages.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version:  OPAC\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-01-31 15:58+0000\n"
+"POT-Creation-Date: 2019-02-01 19:52+0000\n"
 "PO-Revision-Date: 2018-03-07 00:47+0000\n"
 "Last-Translator: jamil Atta <atta.jamil@gmail.com>\n"
 "Language: es\n"
@@ -122,7 +122,7 @@ msgstr "Colección"
 
 #: opac/webapp/__init__.py:120 opac/webapp/admin/views.py:537
 #: opac/webapp/admin/views.py:609 opac/webapp/templates/issue/grid.html:41
-#: opac/webapp/templates/news/includes/issue_last_row.html:10
+#: opac/webapp/templates/news/includes/issue_last_row.html:11
 msgid "Número"
 msgstr "Número"
 
@@ -211,135 +211,155 @@ msgstr "Ruso"
 msgid "Árabe"
 msgstr "Árabe"
 
-#: opac/webapp/controllers.py:342
+#: opac/webapp/choices.py:37
+msgid "corrente"
+msgstr "vigente"
+
+#: opac/webapp/choices.py:38
+msgid "terminado"
+msgstr "terminado"
+
+#: opac/webapp/choices.py:39
+msgid "indexação interrompida"
+msgstr "indización interrumpida"
+
+#: opac/webapp/choices.py:40
+msgid "indexação interrompida pelo Comitê"
+msgstr "indización interrumpida por el comité"
+
+#: opac/webapp/choices.py:41
+msgid "publicação finalizada"
+msgstr "publicación finalizada"
+
+#: opac/webapp/controllers.py:346
 msgid "Lista Alfabética"
 msgstr "Lista Alfabética"
 
-#: opac/webapp/controllers.py:346
+#: opac/webapp/controllers.py:350
 msgid "Lista Temática"
 msgstr "Lista Temática"
 
-#: opac/webapp/controllers.py:350
+#: opac/webapp/controllers.py:354
 msgid "Lista Web of Science"
 msgstr "Lista Web of Science"
 
-#: opac/webapp/controllers.py:354
+#: opac/webapp/controllers.py:358
 msgid "Lista by Institution"
 msgstr "Lista por Institución"
 
-#: opac/webapp/controllers.py:413
+#: opac/webapp/controllers.py:417
 msgid "Obrigatório um jid."
 msgstr "Obligatorio un jid."
 
-#: opac/webapp/controllers.py:429
+#: opac/webapp/controllers.py:433
 msgid "Obrigatório um acronym."
 msgstr "Obligatorio un acronym."
 
-#: opac/webapp/controllers.py:445
+#: opac/webapp/controllers.py:449
 msgid "Obrigatório um url_seg."
 msgstr "Obligatorio un url_seg."
 
-#: opac/webapp/controllers.py:461
+#: opac/webapp/controllers.py:465
 msgid "Obrigatório um issn."
 msgstr "ISSN obligatorio."
 
-#: opac/webapp/controllers.py:476
+#: opac/webapp/controllers.py:480
 msgid "Obrigatório um title."
 msgstr ""
 
-#: opac/webapp/controllers.py:514 opac/webapp/controllers.py:658
-#: opac/webapp/controllers.py:798
+#: opac/webapp/controllers.py:518 opac/webapp/controllers.py:662
+#: opac/webapp/controllers.py:802
 msgid "Obrigatório uma lista de ids."
 msgstr "Obligatorio un listado de ids."
 
-#: opac/webapp/controllers.py:620 opac/webapp/controllers.py:819
+#: opac/webapp/controllers.py:624 opac/webapp/controllers.py:823
 msgid "Obrigatório um iid."
 msgstr "Obligatorio un iid."
 
-#: opac/webapp/controllers.py:677
+#: opac/webapp/controllers.py:681
 msgid "Obrigatório um jacron e issue_label."
 msgstr "Obligatorio un jacron e issue_label."
 
-#: opac/webapp/controllers.py:690
+#: opac/webapp/controllers.py:694
 msgid "Obrigatório um PID."
 msgstr "PID obligatorio."
 
-#: opac/webapp/controllers.py:706
+#: opac/webapp/controllers.py:710
 msgid "Obrigatório um url_seg e url_seg_issue."
 msgstr "Obligatorio un url_seg y url_seg_issue."
 
-#: opac/webapp/controllers.py:713
+#: opac/webapp/controllers.py:717
 msgid "Obrigatório um assets_code."
 msgstr "assets_code es obligatório."
 
-#: opac/webapp/controllers.py:716
+#: opac/webapp/controllers.py:720
 msgid "Obrigatório um journal."
 msgstr "journal es obligatorio."
 
-#: opac/webapp/controllers.py:732
+#: opac/webapp/controllers.py:736
 msgid "Obrigatório um aid."
 msgstr "Obligatorio un aid."
 
-#: opac/webapp/controllers.py:746
+#: opac/webapp/controllers.py:750
 msgid "Obrigatório um url_seg_article."
 msgstr "Obligatorio un url_seg_article."
 
-#: opac/webapp/controllers.py:761
+#: opac/webapp/controllers.py:765
 msgid "Obrigatório um iid and url_seg_article."
 msgstr "Obligatorio un iid and url_seg_article."
 
-#: opac/webapp/controllers.py:857
+#: opac/webapp/controllers.py:861
 msgid "Obrigatório um pid."
 msgstr "PID obligatorio."
 
-#: opac/webapp/controllers.py:870
+#: opac/webapp/controllers.py:874
 msgid "Obrigatório um aop_pid."
 msgstr "Obligatorio un aop_pid."
 
-#: opac/webapp/controllers.py:881
+#: opac/webapp/controllers.py:885
 msgid "Parámetro obrigatório: issue_iid."
 msgstr "Parámetro obligatorio: issue_iid."
 
-#: opac/webapp/controllers.py:929
+#: opac/webapp/controllers.py:933
 msgid "Parâmetro email deve ser uma string"
 msgstr "Parámetro email debe ser un string"
 
-#: opac/webapp/controllers.py:940
+#: opac/webapp/controllers.py:944
 msgid "Parâmetro email deve ser uma inteiro"
 msgstr "Parámetro email debe ser un entero"
 
-#: opac/webapp/controllers.py:952 opac/webapp/controllers.py:966
+#: opac/webapp/controllers.py:956 opac/webapp/controllers.py:970
 #, python-format
 msgid "Usuário deve ser do tipo %s"
 msgstr "Usuario debe ser del tipo %s"
 
-#: opac/webapp/controllers.py:1022
+#: opac/webapp/controllers.py:1026
 msgid "Compartilhamento de link SciELO"
 msgstr "Compartir enlace SciELO"
 
-#: opac/webapp/controllers.py:1023
+#: opac/webapp/controllers.py:1027
 #, python-format
 msgid "O usuário %s compartilha este link: %s, da SciELO"
 msgstr "El usuario %s comparte este enlace: %s, de SciELO"
 
-#: opac/webapp/controllers.py:1031 opac/webapp/controllers.py:1067
-#: opac/webapp/controllers.py:1089
+#: opac/webapp/controllers.py:1035 opac/webapp/controllers.py:1071
+#: opac/webapp/controllers.py:1093
 msgid "Mensagem enviada!"
 msgstr "Mensaje enviado!"
 
-#: opac/webapp/controllers.py:1048
+#: opac/webapp/controllers.py:1052
 msgid "[Erro] Erro informado pelo usuário no site SciELO"
 msgstr ""
 
-#: opac/webapp/controllers.py:1051
+#: opac/webapp/controllers.py:1055
 msgid "aplicação"
 msgstr ""
 
-#: opac/webapp/controllers.py:1053
+#: opac/webapp/controllers.py:1057
 msgid "conteúdo"
 msgstr ""
 
-#: opac/webapp/controllers.py:1058
+#: opac/webapp/controllers.py:1062
 #, python-format
 msgid ""
 "O usuário <b>%s</b> com e-mail: <b>%s</b>, informa que existe um erro na "
@@ -350,16 +370,16 @@ msgstr ""
 " en la% s en el sitio SciELO. <br> <br> <b> Título de la página: </ b>% s"
 " <br> <br> <b> Link: </ b% s"
 
-#: opac/webapp/controllers.py:1079
+#: opac/webapp/controllers.py:1083
 msgid "Contato de usuário via site SciELO"
 msgstr "Contacto de usuário por sitio SciELO"
 
-#: opac/webapp/controllers.py:1081
+#: opac/webapp/controllers.py:1085
 #, python-format
 msgid "O usuário %s, com e-mail: %s, entra em contato com a seguinte mensagem:"
 msgstr "El usuario %s, con e-mail: %s, entra en contacto com la siguiente mensaje:"
 
-#: opac/webapp/controllers.py:1113
+#: opac/webapp/controllers.py:1117
 msgid "Obrigatório um slug_name."
 msgstr ""
 
@@ -737,7 +757,7 @@ msgstr "URL de la capa"
 #: opac/webapp/admin/views.py:536
 #: opac/webapp/templates/collection/list_feed_content.html:3
 #: opac/webapp/templates/issue/grid.html:40
-#: opac/webapp/templates/news/includes/issue_last_row.html:6
+#: opac/webapp/templates/news/includes/issue_last_row.html:7
 msgid "Volume"
 msgstr "Volumen"
 
@@ -765,7 +785,7 @@ msgstr "Mes final"
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:25
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:68
 #: opac/webapp/templates/issue/grid.html:39
-#: opac/webapp/templates/news/includes/issue_last_row.html:4
+#: opac/webapp/templates/news/includes/issue_last_row.html:5
 msgid "Ano"
 msgstr "Año"
 
@@ -1428,7 +1448,6 @@ msgstr "último número"
 msgid "Nº"
 msgstr "Nº"
 
-#: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:43
 #: opac/webapp/templates/collection/list_feed_content.html:6
 msgid "descontinuado"
 msgstr "discontinuado"
@@ -1967,11 +1986,11 @@ msgstr ""
 msgid "número especial"
 msgstr ""
 
-#: opac/webapp/templates/news/includes/issue_last_row.html:14
+#: opac/webapp/templates/news/includes/issue_last_row.html:15
 msgid "Suplemento"
 msgstr ""
 
-#: opac/webapp/templates/news/includes/issue_last_row.html:19
+#: opac/webapp/templates/news/includes/issue_last_row.html:20
 msgid "Ver"
 msgstr "Ver"
 

--- a/opac/webapp/translations/es_ES/LC_MESSAGES/messages.po
+++ b/opac/webapp/translations/es_ES/LC_MESSAGES/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-01-31 15:58+0000\n"
+"POT-Creation-Date: 2019-02-01 19:52+0000\n"
 "PO-Revision-Date: 2016-02-09 09:39-0600\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es_ES\n"
@@ -117,7 +117,7 @@ msgstr ""
 
 #: opac/webapp/__init__.py:120 opac/webapp/admin/views.py:537
 #: opac/webapp/admin/views.py:609 opac/webapp/templates/issue/grid.html:41
-#: opac/webapp/templates/news/includes/issue_last_row.html:10
+#: opac/webapp/templates/news/includes/issue_last_row.html:11
 msgid "Número"
 msgstr ""
 
@@ -206,135 +206,155 @@ msgstr ""
 msgid "Árabe"
 msgstr ""
 
-#: opac/webapp/controllers.py:342
-msgid "Lista Alfabética"
+#: opac/webapp/choices.py:37
+msgid "corrente"
+msgstr ""
+
+#: opac/webapp/choices.py:38
+msgid "terminado"
+msgstr ""
+
+#: opac/webapp/choices.py:39
+msgid "indexação interrompida"
+msgstr ""
+
+#: opac/webapp/choices.py:40
+msgid "indexação interrompida pelo Comitê"
+msgstr ""
+
+#: opac/webapp/choices.py:41
+msgid "publicação finalizada"
 msgstr ""
 
 #: opac/webapp/controllers.py:346
-msgid "Lista Temática"
+msgid "Lista Alfabética"
 msgstr ""
 
 #: opac/webapp/controllers.py:350
-msgid "Lista Web of Science"
+msgid "Lista Temática"
 msgstr ""
 
 #: opac/webapp/controllers.py:354
+msgid "Lista Web of Science"
+msgstr ""
+
+#: opac/webapp/controllers.py:358
 msgid "Lista by Institution"
 msgstr ""
 
-#: opac/webapp/controllers.py:413
+#: opac/webapp/controllers.py:417
 msgid "Obrigatório um jid."
 msgstr ""
 
-#: opac/webapp/controllers.py:429
+#: opac/webapp/controllers.py:433
 msgid "Obrigatório um acronym."
 msgstr ""
 
-#: opac/webapp/controllers.py:445
+#: opac/webapp/controllers.py:449
 msgid "Obrigatório um url_seg."
 msgstr ""
 
-#: opac/webapp/controllers.py:461
+#: opac/webapp/controllers.py:465
 msgid "Obrigatório um issn."
 msgstr ""
 
-#: opac/webapp/controllers.py:476
+#: opac/webapp/controllers.py:480
 msgid "Obrigatório um title."
 msgstr ""
 
-#: opac/webapp/controllers.py:514 opac/webapp/controllers.py:658
-#: opac/webapp/controllers.py:798
+#: opac/webapp/controllers.py:518 opac/webapp/controllers.py:662
+#: opac/webapp/controllers.py:802
 msgid "Obrigatório uma lista de ids."
 msgstr ""
 
-#: opac/webapp/controllers.py:620 opac/webapp/controllers.py:819
+#: opac/webapp/controllers.py:624 opac/webapp/controllers.py:823
 msgid "Obrigatório um iid."
 msgstr ""
 
-#: opac/webapp/controllers.py:677
+#: opac/webapp/controllers.py:681
 msgid "Obrigatório um jacron e issue_label."
 msgstr ""
 
-#: opac/webapp/controllers.py:690
+#: opac/webapp/controllers.py:694
 msgid "Obrigatório um PID."
 msgstr ""
 
-#: opac/webapp/controllers.py:706
+#: opac/webapp/controllers.py:710
 msgid "Obrigatório um url_seg e url_seg_issue."
 msgstr ""
 
-#: opac/webapp/controllers.py:713
+#: opac/webapp/controllers.py:717
 msgid "Obrigatório um assets_code."
 msgstr ""
 
-#: opac/webapp/controllers.py:716
+#: opac/webapp/controllers.py:720
 msgid "Obrigatório um journal."
 msgstr ""
 
-#: opac/webapp/controllers.py:732
+#: opac/webapp/controllers.py:736
 msgid "Obrigatório um aid."
 msgstr ""
 
-#: opac/webapp/controllers.py:746
+#: opac/webapp/controllers.py:750
 msgid "Obrigatório um url_seg_article."
 msgstr ""
 
-#: opac/webapp/controllers.py:761
+#: opac/webapp/controllers.py:765
 msgid "Obrigatório um iid and url_seg_article."
 msgstr ""
 
-#: opac/webapp/controllers.py:857
+#: opac/webapp/controllers.py:861
 msgid "Obrigatório um pid."
 msgstr ""
 
-#: opac/webapp/controllers.py:870
+#: opac/webapp/controllers.py:874
 msgid "Obrigatório um aop_pid."
 msgstr ""
 
-#: opac/webapp/controllers.py:881
+#: opac/webapp/controllers.py:885
 msgid "Parámetro obrigatório: issue_iid."
 msgstr ""
 
-#: opac/webapp/controllers.py:929
+#: opac/webapp/controllers.py:933
 msgid "Parâmetro email deve ser uma string"
 msgstr ""
 
-#: opac/webapp/controllers.py:940
+#: opac/webapp/controllers.py:944
 msgid "Parâmetro email deve ser uma inteiro"
 msgstr ""
 
-#: opac/webapp/controllers.py:952 opac/webapp/controllers.py:966
+#: opac/webapp/controllers.py:956 opac/webapp/controllers.py:970
 #, python-format
 msgid "Usuário deve ser do tipo %s"
 msgstr ""
 
-#: opac/webapp/controllers.py:1022
+#: opac/webapp/controllers.py:1026
 msgid "Compartilhamento de link SciELO"
 msgstr ""
 
-#: opac/webapp/controllers.py:1023
+#: opac/webapp/controllers.py:1027
 #, python-format
 msgid "O usuário %s compartilha este link: %s, da SciELO"
 msgstr ""
 
-#: opac/webapp/controllers.py:1031 opac/webapp/controllers.py:1067
-#: opac/webapp/controllers.py:1089
+#: opac/webapp/controllers.py:1035 opac/webapp/controllers.py:1071
+#: opac/webapp/controllers.py:1093
 msgid "Mensagem enviada!"
 msgstr ""
 
-#: opac/webapp/controllers.py:1048
+#: opac/webapp/controllers.py:1052
 msgid "[Erro] Erro informado pelo usuário no site SciELO"
 msgstr ""
 
-#: opac/webapp/controllers.py:1051
+#: opac/webapp/controllers.py:1055
 msgid "aplicação"
 msgstr ""
 
-#: opac/webapp/controllers.py:1053
+#: opac/webapp/controllers.py:1057
 msgid "conteúdo"
 msgstr ""
 
-#: opac/webapp/controllers.py:1058
+#: opac/webapp/controllers.py:1062
 #, python-format
 msgid ""
 "O usuário <b>%s</b> com e-mail: <b>%s</b>, informa que existe um erro na "
@@ -342,16 +362,16 @@ msgid ""
 " %s"
 msgstr ""
 
-#: opac/webapp/controllers.py:1079
+#: opac/webapp/controllers.py:1083
 msgid "Contato de usuário via site SciELO"
 msgstr ""
 
-#: opac/webapp/controllers.py:1081
+#: opac/webapp/controllers.py:1085
 #, python-format
 msgid "O usuário %s, com e-mail: %s, entra em contato com a seguinte mensagem:"
 msgstr ""
 
-#: opac/webapp/controllers.py:1113
+#: opac/webapp/controllers.py:1117
 msgid "Obrigatório um slug_name."
 msgstr ""
 
@@ -723,7 +743,7 @@ msgstr ""
 #: opac/webapp/admin/views.py:536
 #: opac/webapp/templates/collection/list_feed_content.html:3
 #: opac/webapp/templates/issue/grid.html:40
-#: opac/webapp/templates/news/includes/issue_last_row.html:6
+#: opac/webapp/templates/news/includes/issue_last_row.html:7
 msgid "Volume"
 msgstr ""
 
@@ -751,7 +771,7 @@ msgstr ""
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:25
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:68
 #: opac/webapp/templates/issue/grid.html:39
-#: opac/webapp/templates/news/includes/issue_last_row.html:4
+#: opac/webapp/templates/news/includes/issue_last_row.html:5
 msgid "Ano"
 msgstr ""
 
@@ -1403,7 +1423,6 @@ msgstr ""
 msgid "Nº"
 msgstr ""
 
-#: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:43
 #: opac/webapp/templates/collection/list_feed_content.html:6
 msgid "descontinuado"
 msgstr ""
@@ -1938,11 +1957,11 @@ msgstr ""
 msgid "número especial"
 msgstr ""
 
-#: opac/webapp/templates/news/includes/issue_last_row.html:14
+#: opac/webapp/templates/news/includes/issue_last_row.html:15
 msgid "Suplemento"
 msgstr ""
 
-#: opac/webapp/templates/news/includes/issue_last_row.html:19
+#: opac/webapp/templates/news/includes/issue_last_row.html:20
 msgid "Ver"
 msgstr ""
 

--- a/opac/webapp/translations/es_MX/LC_MESSAGES/messages.po
+++ b/opac/webapp/translations/es_MX/LC_MESSAGES/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-01-31 15:58+0000\n"
+"POT-Creation-Date: 2019-02-01 19:52+0000\n"
 "PO-Revision-Date: 2016-02-09 09:39-0600\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es_MX\n"
@@ -117,7 +117,7 @@ msgstr ""
 
 #: opac/webapp/__init__.py:120 opac/webapp/admin/views.py:537
 #: opac/webapp/admin/views.py:609 opac/webapp/templates/issue/grid.html:41
-#: opac/webapp/templates/news/includes/issue_last_row.html:10
+#: opac/webapp/templates/news/includes/issue_last_row.html:11
 msgid "Número"
 msgstr ""
 
@@ -206,135 +206,155 @@ msgstr ""
 msgid "Árabe"
 msgstr ""
 
-#: opac/webapp/controllers.py:342
-msgid "Lista Alfabética"
+#: opac/webapp/choices.py:37
+msgid "corrente"
+msgstr ""
+
+#: opac/webapp/choices.py:38
+msgid "terminado"
+msgstr ""
+
+#: opac/webapp/choices.py:39
+msgid "indexação interrompida"
+msgstr ""
+
+#: opac/webapp/choices.py:40
+msgid "indexação interrompida pelo Comitê"
+msgstr ""
+
+#: opac/webapp/choices.py:41
+msgid "publicação finalizada"
 msgstr ""
 
 #: opac/webapp/controllers.py:346
-msgid "Lista Temática"
+msgid "Lista Alfabética"
 msgstr ""
 
 #: opac/webapp/controllers.py:350
-msgid "Lista Web of Science"
+msgid "Lista Temática"
 msgstr ""
 
 #: opac/webapp/controllers.py:354
+msgid "Lista Web of Science"
+msgstr ""
+
+#: opac/webapp/controllers.py:358
 msgid "Lista by Institution"
 msgstr ""
 
-#: opac/webapp/controllers.py:413
+#: opac/webapp/controllers.py:417
 msgid "Obrigatório um jid."
 msgstr ""
 
-#: opac/webapp/controllers.py:429
+#: opac/webapp/controllers.py:433
 msgid "Obrigatório um acronym."
 msgstr ""
 
-#: opac/webapp/controllers.py:445
+#: opac/webapp/controllers.py:449
 msgid "Obrigatório um url_seg."
 msgstr ""
 
-#: opac/webapp/controllers.py:461
+#: opac/webapp/controllers.py:465
 msgid "Obrigatório um issn."
 msgstr ""
 
-#: opac/webapp/controllers.py:476
+#: opac/webapp/controllers.py:480
 msgid "Obrigatório um title."
 msgstr ""
 
-#: opac/webapp/controllers.py:514 opac/webapp/controllers.py:658
-#: opac/webapp/controllers.py:798
+#: opac/webapp/controllers.py:518 opac/webapp/controllers.py:662
+#: opac/webapp/controllers.py:802
 msgid "Obrigatório uma lista de ids."
 msgstr ""
 
-#: opac/webapp/controllers.py:620 opac/webapp/controllers.py:819
+#: opac/webapp/controllers.py:624 opac/webapp/controllers.py:823
 msgid "Obrigatório um iid."
 msgstr ""
 
-#: opac/webapp/controllers.py:677
+#: opac/webapp/controllers.py:681
 msgid "Obrigatório um jacron e issue_label."
 msgstr ""
 
-#: opac/webapp/controllers.py:690
+#: opac/webapp/controllers.py:694
 msgid "Obrigatório um PID."
 msgstr ""
 
-#: opac/webapp/controllers.py:706
+#: opac/webapp/controllers.py:710
 msgid "Obrigatório um url_seg e url_seg_issue."
 msgstr ""
 
-#: opac/webapp/controllers.py:713
+#: opac/webapp/controllers.py:717
 msgid "Obrigatório um assets_code."
 msgstr ""
 
-#: opac/webapp/controllers.py:716
+#: opac/webapp/controllers.py:720
 msgid "Obrigatório um journal."
 msgstr ""
 
-#: opac/webapp/controllers.py:732
+#: opac/webapp/controllers.py:736
 msgid "Obrigatório um aid."
 msgstr ""
 
-#: opac/webapp/controllers.py:746
+#: opac/webapp/controllers.py:750
 msgid "Obrigatório um url_seg_article."
 msgstr ""
 
-#: opac/webapp/controllers.py:761
+#: opac/webapp/controllers.py:765
 msgid "Obrigatório um iid and url_seg_article."
 msgstr ""
 
-#: opac/webapp/controllers.py:857
+#: opac/webapp/controllers.py:861
 msgid "Obrigatório um pid."
 msgstr ""
 
-#: opac/webapp/controllers.py:870
+#: opac/webapp/controllers.py:874
 msgid "Obrigatório um aop_pid."
 msgstr ""
 
-#: opac/webapp/controllers.py:881
+#: opac/webapp/controllers.py:885
 msgid "Parámetro obrigatório: issue_iid."
 msgstr ""
 
-#: opac/webapp/controllers.py:929
+#: opac/webapp/controllers.py:933
 msgid "Parâmetro email deve ser uma string"
 msgstr ""
 
-#: opac/webapp/controllers.py:940
+#: opac/webapp/controllers.py:944
 msgid "Parâmetro email deve ser uma inteiro"
 msgstr ""
 
-#: opac/webapp/controllers.py:952 opac/webapp/controllers.py:966
+#: opac/webapp/controllers.py:956 opac/webapp/controllers.py:970
 #, python-format
 msgid "Usuário deve ser do tipo %s"
 msgstr ""
 
-#: opac/webapp/controllers.py:1022
+#: opac/webapp/controllers.py:1026
 msgid "Compartilhamento de link SciELO"
 msgstr ""
 
-#: opac/webapp/controllers.py:1023
+#: opac/webapp/controllers.py:1027
 #, python-format
 msgid "O usuário %s compartilha este link: %s, da SciELO"
 msgstr ""
 
-#: opac/webapp/controllers.py:1031 opac/webapp/controllers.py:1067
-#: opac/webapp/controllers.py:1089
+#: opac/webapp/controllers.py:1035 opac/webapp/controllers.py:1071
+#: opac/webapp/controllers.py:1093
 msgid "Mensagem enviada!"
 msgstr ""
 
-#: opac/webapp/controllers.py:1048
+#: opac/webapp/controllers.py:1052
 msgid "[Erro] Erro informado pelo usuário no site SciELO"
 msgstr ""
 
-#: opac/webapp/controllers.py:1051
+#: opac/webapp/controllers.py:1055
 msgid "aplicação"
 msgstr ""
 
-#: opac/webapp/controllers.py:1053
+#: opac/webapp/controllers.py:1057
 msgid "conteúdo"
 msgstr ""
 
-#: opac/webapp/controllers.py:1058
+#: opac/webapp/controllers.py:1062
 #, python-format
 msgid ""
 "O usuário <b>%s</b> com e-mail: <b>%s</b>, informa que existe um erro na "
@@ -342,16 +362,16 @@ msgid ""
 " %s"
 msgstr ""
 
-#: opac/webapp/controllers.py:1079
+#: opac/webapp/controllers.py:1083
 msgid "Contato de usuário via site SciELO"
 msgstr ""
 
-#: opac/webapp/controllers.py:1081
+#: opac/webapp/controllers.py:1085
 #, python-format
 msgid "O usuário %s, com e-mail: %s, entra em contato com a seguinte mensagem:"
 msgstr ""
 
-#: opac/webapp/controllers.py:1113
+#: opac/webapp/controllers.py:1117
 msgid "Obrigatório um slug_name."
 msgstr ""
 
@@ -723,7 +743,7 @@ msgstr ""
 #: opac/webapp/admin/views.py:536
 #: opac/webapp/templates/collection/list_feed_content.html:3
 #: opac/webapp/templates/issue/grid.html:40
-#: opac/webapp/templates/news/includes/issue_last_row.html:6
+#: opac/webapp/templates/news/includes/issue_last_row.html:7
 msgid "Volume"
 msgstr ""
 
@@ -751,7 +771,7 @@ msgstr ""
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:25
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:68
 #: opac/webapp/templates/issue/grid.html:39
-#: opac/webapp/templates/news/includes/issue_last_row.html:4
+#: opac/webapp/templates/news/includes/issue_last_row.html:5
 msgid "Ano"
 msgstr ""
 
@@ -1403,7 +1423,6 @@ msgstr ""
 msgid "Nº"
 msgstr ""
 
-#: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:43
 #: opac/webapp/templates/collection/list_feed_content.html:6
 msgid "descontinuado"
 msgstr ""
@@ -1938,11 +1957,11 @@ msgstr ""
 msgid "número especial"
 msgstr ""
 
-#: opac/webapp/templates/news/includes/issue_last_row.html:14
+#: opac/webapp/templates/news/includes/issue_last_row.html:15
 msgid "Suplemento"
 msgstr ""
 
-#: opac/webapp/templates/news/includes/issue_last_row.html:19
+#: opac/webapp/templates/news/includes/issue_last_row.html:20
 msgid "Ver"
 msgstr ""
 

--- a/opac/webapp/translations/messages.pot
+++ b/opac/webapp/translations/messages.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-01-31 15:58+0000\n"
+"POT-Creation-Date: 2019-02-01 19:52+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -115,7 +115,7 @@ msgstr ""
 
 #: opac/webapp/__init__.py:120 opac/webapp/admin/views.py:537
 #: opac/webapp/admin/views.py:609 opac/webapp/templates/issue/grid.html:41
-#: opac/webapp/templates/news/includes/issue_last_row.html:10
+#: opac/webapp/templates/news/includes/issue_last_row.html:11
 msgid "Número"
 msgstr ""
 
@@ -204,135 +204,155 @@ msgstr ""
 msgid "Árabe"
 msgstr ""
 
-#: opac/webapp/controllers.py:342
-msgid "Lista Alfabética"
+#: opac/webapp/choices.py:37
+msgid "corrente"
+msgstr ""
+
+#: opac/webapp/choices.py:38
+msgid "terminado"
+msgstr ""
+
+#: opac/webapp/choices.py:39
+msgid "indexação interrompida"
+msgstr ""
+
+#: opac/webapp/choices.py:40
+msgid "indexação interrompida pelo Comitê"
+msgstr ""
+
+#: opac/webapp/choices.py:41
+msgid "publicação finalizada"
 msgstr ""
 
 #: opac/webapp/controllers.py:346
-msgid "Lista Temática"
+msgid "Lista Alfabética"
 msgstr ""
 
 #: opac/webapp/controllers.py:350
-msgid "Lista Web of Science"
+msgid "Lista Temática"
 msgstr ""
 
 #: opac/webapp/controllers.py:354
+msgid "Lista Web of Science"
+msgstr ""
+
+#: opac/webapp/controllers.py:358
 msgid "Lista by Institution"
 msgstr ""
 
-#: opac/webapp/controllers.py:413
+#: opac/webapp/controllers.py:417
 msgid "Obrigatório um jid."
 msgstr ""
 
-#: opac/webapp/controllers.py:429
+#: opac/webapp/controllers.py:433
 msgid "Obrigatório um acronym."
 msgstr ""
 
-#: opac/webapp/controllers.py:445
+#: opac/webapp/controllers.py:449
 msgid "Obrigatório um url_seg."
 msgstr ""
 
-#: opac/webapp/controllers.py:461
+#: opac/webapp/controllers.py:465
 msgid "Obrigatório um issn."
 msgstr ""
 
-#: opac/webapp/controllers.py:476
+#: opac/webapp/controllers.py:480
 msgid "Obrigatório um title."
 msgstr ""
 
-#: opac/webapp/controllers.py:514 opac/webapp/controllers.py:658
-#: opac/webapp/controllers.py:798
+#: opac/webapp/controllers.py:518 opac/webapp/controllers.py:662
+#: opac/webapp/controllers.py:802
 msgid "Obrigatório uma lista de ids."
 msgstr ""
 
-#: opac/webapp/controllers.py:620 opac/webapp/controllers.py:819
+#: opac/webapp/controllers.py:624 opac/webapp/controllers.py:823
 msgid "Obrigatório um iid."
 msgstr ""
 
-#: opac/webapp/controllers.py:677
+#: opac/webapp/controllers.py:681
 msgid "Obrigatório um jacron e issue_label."
 msgstr ""
 
-#: opac/webapp/controllers.py:690
+#: opac/webapp/controllers.py:694
 msgid "Obrigatório um PID."
 msgstr ""
 
-#: opac/webapp/controllers.py:706
+#: opac/webapp/controllers.py:710
 msgid "Obrigatório um url_seg e url_seg_issue."
 msgstr ""
 
-#: opac/webapp/controllers.py:713
+#: opac/webapp/controllers.py:717
 msgid "Obrigatório um assets_code."
 msgstr ""
 
-#: opac/webapp/controllers.py:716
+#: opac/webapp/controllers.py:720
 msgid "Obrigatório um journal."
 msgstr ""
 
-#: opac/webapp/controllers.py:732
+#: opac/webapp/controllers.py:736
 msgid "Obrigatório um aid."
 msgstr ""
 
-#: opac/webapp/controllers.py:746
+#: opac/webapp/controllers.py:750
 msgid "Obrigatório um url_seg_article."
 msgstr ""
 
-#: opac/webapp/controllers.py:761
+#: opac/webapp/controllers.py:765
 msgid "Obrigatório um iid and url_seg_article."
 msgstr ""
 
-#: opac/webapp/controllers.py:857
+#: opac/webapp/controllers.py:861
 msgid "Obrigatório um pid."
 msgstr ""
 
-#: opac/webapp/controllers.py:870
+#: opac/webapp/controllers.py:874
 msgid "Obrigatório um aop_pid."
 msgstr ""
 
-#: opac/webapp/controllers.py:881
+#: opac/webapp/controllers.py:885
 msgid "Parámetro obrigatório: issue_iid."
 msgstr ""
 
-#: opac/webapp/controllers.py:929
+#: opac/webapp/controllers.py:933
 msgid "Parâmetro email deve ser uma string"
 msgstr ""
 
-#: opac/webapp/controllers.py:940
+#: opac/webapp/controllers.py:944
 msgid "Parâmetro email deve ser uma inteiro"
 msgstr ""
 
-#: opac/webapp/controllers.py:952 opac/webapp/controllers.py:966
+#: opac/webapp/controllers.py:956 opac/webapp/controllers.py:970
 #, python-format
 msgid "Usuário deve ser do tipo %s"
 msgstr ""
 
-#: opac/webapp/controllers.py:1022
+#: opac/webapp/controllers.py:1026
 msgid "Compartilhamento de link SciELO"
 msgstr ""
 
-#: opac/webapp/controllers.py:1023
+#: opac/webapp/controllers.py:1027
 #, python-format
 msgid "O usuário %s compartilha este link: %s, da SciELO"
 msgstr ""
 
-#: opac/webapp/controllers.py:1031 opac/webapp/controllers.py:1067
-#: opac/webapp/controllers.py:1089
+#: opac/webapp/controllers.py:1035 opac/webapp/controllers.py:1071
+#: opac/webapp/controllers.py:1093
 msgid "Mensagem enviada!"
 msgstr ""
 
-#: opac/webapp/controllers.py:1048
+#: opac/webapp/controllers.py:1052
 msgid "[Erro] Erro informado pelo usuário no site SciELO"
 msgstr ""
 
-#: opac/webapp/controllers.py:1051
+#: opac/webapp/controllers.py:1055
 msgid "aplicação"
 msgstr ""
 
-#: opac/webapp/controllers.py:1053
+#: opac/webapp/controllers.py:1057
 msgid "conteúdo"
 msgstr ""
 
-#: opac/webapp/controllers.py:1058
+#: opac/webapp/controllers.py:1062
 #, python-format
 msgid ""
 "O usuário <b>%s</b> com e-mail: <b>%s</b>, informa que existe um erro na "
@@ -340,16 +360,16 @@ msgid ""
 " %s"
 msgstr ""
 
-#: opac/webapp/controllers.py:1079
+#: opac/webapp/controllers.py:1083
 msgid "Contato de usuário via site SciELO"
 msgstr ""
 
-#: opac/webapp/controllers.py:1081
+#: opac/webapp/controllers.py:1085
 #, python-format
 msgid "O usuário %s, com e-mail: %s, entra em contato com a seguinte mensagem:"
 msgstr ""
 
-#: opac/webapp/controllers.py:1113
+#: opac/webapp/controllers.py:1117
 msgid "Obrigatório um slug_name."
 msgstr ""
 
@@ -721,7 +741,7 @@ msgstr ""
 #: opac/webapp/admin/views.py:536
 #: opac/webapp/templates/collection/list_feed_content.html:3
 #: opac/webapp/templates/issue/grid.html:40
-#: opac/webapp/templates/news/includes/issue_last_row.html:6
+#: opac/webapp/templates/news/includes/issue_last_row.html:7
 msgid "Volume"
 msgstr ""
 
@@ -749,7 +769,7 @@ msgstr ""
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:25
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:68
 #: opac/webapp/templates/issue/grid.html:39
-#: opac/webapp/templates/news/includes/issue_last_row.html:4
+#: opac/webapp/templates/news/includes/issue_last_row.html:5
 msgid "Ano"
 msgstr ""
 
@@ -1401,7 +1421,6 @@ msgstr ""
 msgid "Nº"
 msgstr ""
 
-#: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:43
 #: opac/webapp/templates/collection/list_feed_content.html:6
 msgid "descontinuado"
 msgstr ""
@@ -1936,11 +1955,11 @@ msgstr ""
 msgid "número especial"
 msgstr ""
 
-#: opac/webapp/templates/news/includes/issue_last_row.html:14
+#: opac/webapp/templates/news/includes/issue_last_row.html:15
 msgid "Suplemento"
 msgstr ""
 
-#: opac/webapp/templates/news/includes/issue_last_row.html:19
+#: opac/webapp/templates/news/includes/issue_last_row.html:20
 msgid "Ver"
 msgstr ""
 


### PR DESCRIPTION
#### O que esse PR faz?
Adicionado razão da descontinuidade do periódico na listagem de periódicos descontinuados do OPAC, 

#### Onde a revisão poderia começar?
verificar o `controler.py` a adição de uma nova chave ao dicionário com a razão da descontinuidade do periódico

#### Como este poderia ser testado manualmente?
Na lista de periódicos descontinuados agora deve aparecer entre parênteses o motivo pela descontinuidade do periódico, igual acontece no site atual

#### Quais são tickets relevantes?
https://github.com/scieloorg/opac/issues/1117