### PR TITLE
Atualizar widget PlumX

### DIFF
--- a/opac/webapp/config/default.py
+++ b/opac/webapp/config/default.py
@@ -400,7 +400,7 @@ PINGDOM_VISITOR_INSIGHTS_JS_SRC = os.environ.get('OPAC_PINGDOM_VISITOR_INSIGHTS_
 
 # Google Recaptcha
 GOOGLE_RECAPTCHA_SECRET_KEY = os.environ.get('OPAC_GOOGLE_RECAPTCHA_SECRET_KEY', "")
-GOOGLE_RECAPTCHA_URL = os.environ.get('OPAC_GOOGLE_RECAPTCHA_URL', "https://www.google.com/recaptcha/api.js")
+GOOGLE_RECAPTCHA_URL = os.environ.get('OPAC_GOOGLE_RECAPTCHA_URL', "//www.google.com/recaptcha/api.js")
 GOOGLE_VERIFY_RECAPTCHA_URL = os.environ.get('OPAC_GOOGLE_VERIFY_RECAPTCHA_URL', "https://www.google.com/recaptcha/api/siteverify")
 GOOGLE_VERIFY_RECAPTCHA_KEY = os.environ.get('OPAC_GOOGLE_VERIFY_RECAPTCHA_KEY', "")
 

--- a/opac/webapp/templates/article/base.html
+++ b/opac/webapp/templates/article/base.html
@@ -43,6 +43,6 @@
 
 {% block extra_js %}
   <script type="text/javascript" src="{{ url_for('static', filename='js/scielo-article-min.js') }}"></script>
-  <script type="text/javascript" src="https://badge.dimensions.ai/badge.js" charset="utf-8" async></script>
-  <script type="text/javascript" src="https://d39af2mgp1pqhg.cloudfront.net/widget-popup.js"></script>
+  <script type="text/javascript" src="//badge.dimensions.ai/badge.js" charset="utf-8" async></script>
+  <script type="text/javascript" src="//cdn.plu.mx/widget-popup.js"></script>
 {% endblock %}

--- a/opac/webapp/templates/base.html
+++ b/opac/webapp/templates/base.html
@@ -146,7 +146,7 @@
       <div class="bugherd">
         <div class="bugherd=container">
           <div class="btn-group" role="group" aria-label="...">
-            <a href="https://github.com/scieloorg/opac/issues/new" target="_blank" class="btn bugherd-btn-danger">Reportar erro</a>
+            <a href="//github.com/scieloorg/opac/issues/new" target="_blank" class="btn bugherd-btn-danger">Reportar erro</a>
           </div>
         </div>
       </div>


### PR DESCRIPTION
#### O que esse PR faz?
Atualiza o endereço para o javascript do **Plumx** e realiza algumas alteração de URL para uso de http e https.

#### Onde a revisão poderia começar?
Verificar manualmente o endereço do Plumx no arquivo: opac/webapp/templates/article/base.html

#### Como este poderia ser testado manualmente?
Acessando um página de artigo o modal de métricas, ver:

<img width="944" alt="screenshot 2019-02-05 15 12 43" src="https://user-images.githubusercontent.com/373745/52290985-7ea34180-2958-11e9-979d-9e560619fc63.png">

#### Quais são tickets relevantes?
#1136