### PR TITLE
Adiciona Link referencia cruzada entre os periódicos ativos e inativos

### DIFF
--- a/opac/webapp/controllers.py
+++ b/opac/webapp/controllers.py
@@ -227,9 +227,7 @@ def get_journal_json_data(journal, language='pt'):
         }
 
     if journal.next_title:
-        new_journal = get_journal_by_title(title=journal.next_title)
-        if new_journal:
-            j_data['url_new_journal'] = url_for('main.journal_detail', url_seg=new_journal.url_segment)
+        j_data['url_new_journal'] = journal.url_new_journal
 
     return j_data
 

--- a/opac/webapp/controllers.py
+++ b/opac/webapp/controllers.py
@@ -227,7 +227,7 @@ def get_journal_json_data(journal, language='pt'):
         }
 
     if journal.next_title:
-        j_data['url_new_journal'] = journal.url_new_journal
+        j_data['url_next_journal'] = journal.url_next_journal
 
     return j_data
 

--- a/opac/webapp/controllers.py
+++ b/opac/webapp/controllers.py
@@ -226,8 +226,8 @@ def get_journal_json_data(journal, language='pt'):
             'url_segment': '%s/%s' % ('toc', journal.url_last_issue)
         }
 
-    if journal.next_title:
-        j_data['url_next_journal'] = journal.url_next_journal
+    if journal.url_next_journal:
+        j_data['url_next_journal'] = url_for('main.journal_detail', url_seg=journal.url_next_journal)
 
     return j_data
 

--- a/opac/webapp/templates/collection/includes/tmpl_journal_list_row.html
+++ b/opac/webapp/templates/collection/includes/tmpl_journal_list_row.html
@@ -43,8 +43,8 @@
       (<%- journal.status_reason %>)
         <% if (journal.next_title) { %>
         <span class="journalPreviousTitle">{% trans %}Continua como {% endtrans %}
-            <% if (journal.url_new_journal) { %>
-              <a href="<%- journal.url_new_journal %>" class="NewCollectionLink">
+            <% if (journal.url_next_journal) { %>
+              <a href="<%- journal.url_next_journal %>" class="NewCollectionLink">
                   <%- journal.next_title %>
               </a>
             <% } else { %>

--- a/opac/webapp/templates/journal/includes/header.html
+++ b/opac/webapp/templates/journal/includes/header.html
@@ -73,7 +73,7 @@
             {% if journal.next_title %}
               <span class="otherTitle">
                 <span>{% trans %}Novo título:{% endtrans %}</span>
-                  <a href="{{ journal.url_new_journal }}" class="NewCollectionLink">
+                  <a href="{{ journal.url_next_journal }}" class="NewCollectionLink">
                       {{ journal.next_title }}
                   </a>
               </span>

--- a/opac/webapp/templates/journal/includes/header.html
+++ b/opac/webapp/templates/journal/includes/header.html
@@ -73,7 +73,7 @@
             {% if journal.next_title %}
               <span class="otherTitle">
                 <span>{% trans %}Novo título:{% endtrans %}</span>
-                  <a href="{{ journal.url_next_journal }}" class="NewCollectionLink">
+                  <a href="{{ url_for('.journal_detail', url_seg=journal.url_next_journal) }}" class="NewCollectionLink">
                       {{ journal.next_title }}
                   </a>
               </span>
@@ -84,7 +84,7 @@
             {% if journal.previous_journal_ref %}
               <span class="otherTitle">
                 <span>{% trans %}Título anterior:{% endtrans %}</span>
-                  <a href="{{ journal.url_previous_journal }}" class="NewCollectionLink">
+                  <a href="{{ url_for('.journal_detail', url_seg=journal.url_previous_journal) }}" class="NewCollectionLink">
                       {{ journal.previous_journal_ref }}
                   </a>
               </span>

--- a/opac/webapp/templates/journal/includes/header.html
+++ b/opac/webapp/templates/journal/includes/header.html
@@ -73,10 +73,23 @@
             {% if journal.next_title %}
               <span class="otherTitle">
                 <span>{% trans %}Novo título:{% endtrans %}</span>
-                {{ journal.next_title }}
+                  <a href="{{ journal.url_new_journal }}" class="NewCollectionLink">
+                      {{ journal.next_title }}
+                  </a>
               </span>
             {% endif %}
             <!-- Fim - Se houver um outro título-->
+
+            <!-- Ini - Se houver um outro título antigo -->
+            {% if journal.previous_journal_ref %}
+              <span class="otherTitle">
+                <span>{% trans %}Título anterior:{% endtrans %}</span>
+                  <a href="{{ journal.url_previous_journal }}" class="NewCollectionLink">
+                      {{ journal.previous_journal_ref }}
+                  </a>
+              </span>
+            {% endif %}
+             <!-- Fim - Se houver um outro título antigo-->
 
           </div>
         </div>

--- a/opac/webapp/translations/en/LC_MESSAGES/messages.po
+++ b/opac/webapp/translations/en/LC_MESSAGES/messages.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version:  OPAC\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-02-01 19:52+0000\n"
+"POT-Creation-Date: 2019-02-06 15:41+0000\n"
 "PO-Revision-Date: 2018-03-06 19:50+0000\n"
 "Last-Translator: jamil Atta <atta.jamil@gmail.com>\n"
 "Language: en\n"
@@ -230,135 +230,135 @@ msgstr "indexing interrupted by the committee"
 msgid "publicação finalizada"
 msgstr "publication finished"
 
-#: opac/webapp/controllers.py:346
+#: opac/webapp/controllers.py:341
 msgid "Lista Alfabética"
 msgstr "Alphabetic List"
 
-#: opac/webapp/controllers.py:350
+#: opac/webapp/controllers.py:345
 msgid "Lista Temática"
 msgstr "Thematic List"
 
-#: opac/webapp/controllers.py:354
+#: opac/webapp/controllers.py:349
 msgid "Lista Web of Science"
 msgstr "Web of Science List"
 
-#: opac/webapp/controllers.py:358
+#: opac/webapp/controllers.py:353
 msgid "Lista by Institution"
 msgstr "List by Institution"
 
-#: opac/webapp/controllers.py:417
+#: opac/webapp/controllers.py:412
 msgid "Obrigatório um jid."
 msgstr "A jid is required."
 
-#: opac/webapp/controllers.py:433
+#: opac/webapp/controllers.py:428
 msgid "Obrigatório um acronym."
 msgstr "An acronym is required."
 
-#: opac/webapp/controllers.py:449
+#: opac/webapp/controllers.py:444
 msgid "Obrigatório um url_seg."
 msgstr "A url_seg is required."
 
-#: opac/webapp/controllers.py:465
+#: opac/webapp/controllers.py:460
 msgid "Obrigatório um issn."
 msgstr "ISSN is required."
 
-#: opac/webapp/controllers.py:480
+#: opac/webapp/controllers.py:475
 msgid "Obrigatório um title."
 msgstr ""
 
-#: opac/webapp/controllers.py:518 opac/webapp/controllers.py:662
-#: opac/webapp/controllers.py:802
+#: opac/webapp/controllers.py:513 opac/webapp/controllers.py:657
+#: opac/webapp/controllers.py:797
 msgid "Obrigatório uma lista de ids."
 msgstr "A list of id's is required."
 
-#: opac/webapp/controllers.py:624 opac/webapp/controllers.py:823
+#: opac/webapp/controllers.py:619 opac/webapp/controllers.py:818
 msgid "Obrigatório um iid."
 msgstr "A iid is required."
 
-#: opac/webapp/controllers.py:681
+#: opac/webapp/controllers.py:676
 msgid "Obrigatório um jacron e issue_label."
 msgstr "A jacron and issue_label are required."
 
-#: opac/webapp/controllers.py:694
+#: opac/webapp/controllers.py:689
 msgid "Obrigatório um PID."
 msgstr "PID is required."
 
-#: opac/webapp/controllers.py:710
+#: opac/webapp/controllers.py:705
 msgid "Obrigatório um url_seg e url_seg_issue."
 msgstr "A url_seg and url_seg_issue are required."
 
-#: opac/webapp/controllers.py:717
+#: opac/webapp/controllers.py:712
 msgid "Obrigatório um assets_code."
 msgstr " assets_code is mandatory."
 
-#: opac/webapp/controllers.py:720
+#: opac/webapp/controllers.py:715
 msgid "Obrigatório um journal."
 msgstr "Journal is mandatory."
 
-#: opac/webapp/controllers.py:736
+#: opac/webapp/controllers.py:731
 msgid "Obrigatório um aid."
 msgstr "A aid is required."
 
-#: opac/webapp/controllers.py:750
+#: opac/webapp/controllers.py:745
 msgid "Obrigatório um url_seg_article."
 msgstr "A url_seg_article is required."
 
-#: opac/webapp/controllers.py:765
+#: opac/webapp/controllers.py:760
 msgid "Obrigatório um iid and url_seg_article."
 msgstr "A iid and url_seg_article are required."
 
-#: opac/webapp/controllers.py:861
+#: opac/webapp/controllers.py:856
 msgid "Obrigatório um pid."
 msgstr "pid is required."
 
-#: opac/webapp/controllers.py:874
+#: opac/webapp/controllers.py:869
 msgid "Obrigatório um aop_pid."
 msgstr "aop_pid is mandatory."
 
-#: opac/webapp/controllers.py:885
+#: opac/webapp/controllers.py:880
 msgid "Parámetro obrigatório: issue_iid."
 msgstr "issue_iid is mandatory."
 
-#: opac/webapp/controllers.py:933
+#: opac/webapp/controllers.py:928
 msgid "Parâmetro email deve ser uma string"
 msgstr "The parameter \"email\" must be a string."
 
-#: opac/webapp/controllers.py:944
+#: opac/webapp/controllers.py:939
 msgid "Parâmetro email deve ser uma inteiro"
 msgstr "The parameter \"email\" must be an integer."
 
-#: opac/webapp/controllers.py:956 opac/webapp/controllers.py:970
+#: opac/webapp/controllers.py:951 opac/webapp/controllers.py:965
 #, python-format
 msgid "Usuário deve ser do tipo %s"
 msgstr "User must be of type %s"
 
-#: opac/webapp/controllers.py:1026
+#: opac/webapp/controllers.py:1021
 msgid "Compartilhamento de link SciELO"
 msgstr "SciELO link sharing"
 
-#: opac/webapp/controllers.py:1027
+#: opac/webapp/controllers.py:1022
 #, python-format
 msgid "O usuário %s compartilha este link: %s, da SciELO"
 msgstr "The user %s share link: %s, of SciELO"
 
-#: opac/webapp/controllers.py:1035 opac/webapp/controllers.py:1071
-#: opac/webapp/controllers.py:1093
+#: opac/webapp/controllers.py:1030 opac/webapp/controllers.py:1066
+#: opac/webapp/controllers.py:1088
 msgid "Mensagem enviada!"
 msgstr "Message sent!"
 
-#: opac/webapp/controllers.py:1052
+#: opac/webapp/controllers.py:1047
 msgid "[Erro] Erro informado pelo usuário no site SciELO"
 msgstr "[Error] Error informed by the user in the SciELO site"
 
-#: opac/webapp/controllers.py:1055
+#: opac/webapp/controllers.py:1050
 msgid "aplicação"
 msgstr ""
 
-#: opac/webapp/controllers.py:1057
+#: opac/webapp/controllers.py:1052
 msgid "conteúdo"
 msgstr ""
 
-#: opac/webapp/controllers.py:1062
+#: opac/webapp/controllers.py:1057
 #, python-format
 msgid ""
 "O usuário <b>%s</b> com e-mail: <b>%s</b>, informa que existe um erro na "
@@ -369,16 +369,16 @@ msgstr ""
 " %s in the website SciELO.<br><br><b>Title of page:</b> "
 "%s<br><br><b>Link:</b> %s"
 
-#: opac/webapp/controllers.py:1083
+#: opac/webapp/controllers.py:1078
 msgid "Contato de usuário via site SciELO"
 msgstr "User contact by SciELO website"
 
-#: opac/webapp/controllers.py:1085
+#: opac/webapp/controllers.py:1080
 #, python-format
 msgid "O usuário %s, com e-mail: %s, entra em contato com a seguinte mensagem:"
 msgstr "User %s, e-mail: %s, contact us with the following message:"
 
-#: opac/webapp/controllers.py:1117
+#: opac/webapp/controllers.py:1112
 msgid "Obrigatório um slug_name."
 msgstr "An slug_name is required"
 
@@ -1172,7 +1172,7 @@ msgstr "Go to the home page of the collection:"
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:7
 #: opac/webapp/templates/issue/includes/alternative_header.html:121
 #: opac/webapp/templates/journal/includes/alternative_header.html:117
-#: opac/webapp/templates/journal/includes/header.html:92
+#: opac/webapp/templates/journal/includes/header.html:105
 msgid "Submissão de manuscritos"
 msgstr "Submission of manuscripts"
 
@@ -1180,7 +1180,7 @@ msgstr "Submission of manuscripts"
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:16
 #: opac/webapp/templates/issue/includes/alternative_header.html:127
 #: opac/webapp/templates/journal/includes/alternative_header.html:123
-#: opac/webapp/templates/journal/includes/header.html:98
+#: opac/webapp/templates/journal/includes/header.html:111
 msgid "Sobre o periódico"
 msgstr "About the journal"
 
@@ -1188,7 +1188,7 @@ msgstr "About the journal"
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:10
 #: opac/webapp/templates/issue/includes/alternative_header.html:132
 #: opac/webapp/templates/journal/includes/alternative_header.html:128
-#: opac/webapp/templates/journal/includes/header.html:103
+#: opac/webapp/templates/journal/includes/header.html:116
 msgid "Corpo Editorial"
 msgstr "Editorial Board"
 
@@ -1196,7 +1196,7 @@ msgstr "Editorial Board"
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:13
 #: opac/webapp/templates/issue/includes/alternative_header.html:137
 #: opac/webapp/templates/journal/includes/alternative_header.html:133
-#: opac/webapp/templates/journal/includes/header.html:108
+#: opac/webapp/templates/journal/includes/header.html:121
 msgid "Instruções aos autores"
 msgstr "Instructions to authors"
 
@@ -1204,7 +1204,7 @@ msgstr "Instructions to authors"
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:19
 #: opac/webapp/templates/issue/includes/alternative_header.html:142
 #: opac/webapp/templates/journal/includes/alternative_header.html:138
-#: opac/webapp/templates/journal/includes/header.html:114
+#: opac/webapp/templates/journal/includes/header.html:127
 msgid "Contato"
 msgstr "Contact"
 
@@ -1935,7 +1935,11 @@ msgstr "ISSN online version:"
 msgid "Novo título:"
 msgstr "New title:"
 
-#: opac/webapp/templates/journal/includes/header.html:122
+#: opac/webapp/templates/journal/includes/header.html:86
+msgid "Título anterior:"
+msgstr "Previous title"
+
+#: opac/webapp/templates/journal/includes/header.html:135
 msgid "Siga-nos"
 msgstr "Follow us"
 

--- a/opac/webapp/translations/es/LC_MESSAGES/messages.po
+++ b/opac/webapp/translations/es/LC_MESSAGES/messages.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version:  OPAC\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-02-01 19:52+0000\n"
+"POT-Creation-Date: 2019-02-06 15:41+0000\n"
 "PO-Revision-Date: 2018-03-07 00:47+0000\n"
 "Last-Translator: jamil Atta <atta.jamil@gmail.com>\n"
 "Language: es\n"
@@ -231,135 +231,135 @@ msgstr "indización interrumpida por el comité"
 msgid "publicação finalizada"
 msgstr "publicación finalizada"
 
-#: opac/webapp/controllers.py:346
+#: opac/webapp/controllers.py:341
 msgid "Lista Alfabética"
 msgstr "Lista Alfabética"
 
-#: opac/webapp/controllers.py:350
+#: opac/webapp/controllers.py:345
 msgid "Lista Temática"
 msgstr "Lista Temática"
 
-#: opac/webapp/controllers.py:354
+#: opac/webapp/controllers.py:349
 msgid "Lista Web of Science"
 msgstr "Lista Web of Science"
 
-#: opac/webapp/controllers.py:358
+#: opac/webapp/controllers.py:353
 msgid "Lista by Institution"
 msgstr "Lista por Institución"
 
-#: opac/webapp/controllers.py:417
+#: opac/webapp/controllers.py:412
 msgid "Obrigatório um jid."
 msgstr "Obligatorio un jid."
 
-#: opac/webapp/controllers.py:433
+#: opac/webapp/controllers.py:428
 msgid "Obrigatório um acronym."
 msgstr "Obligatorio un acronym."
 
-#: opac/webapp/controllers.py:449
+#: opac/webapp/controllers.py:444
 msgid "Obrigatório um url_seg."
 msgstr "Obligatorio un url_seg."
 
-#: opac/webapp/controllers.py:465
+#: opac/webapp/controllers.py:460
 msgid "Obrigatório um issn."
 msgstr "ISSN obligatorio."
 
-#: opac/webapp/controllers.py:480
+#: opac/webapp/controllers.py:475
 msgid "Obrigatório um title."
 msgstr ""
 
-#: opac/webapp/controllers.py:518 opac/webapp/controllers.py:662
-#: opac/webapp/controllers.py:802
+#: opac/webapp/controllers.py:513 opac/webapp/controllers.py:657
+#: opac/webapp/controllers.py:797
 msgid "Obrigatório uma lista de ids."
 msgstr "Obligatorio un listado de ids."
 
-#: opac/webapp/controllers.py:624 opac/webapp/controllers.py:823
+#: opac/webapp/controllers.py:619 opac/webapp/controllers.py:818
 msgid "Obrigatório um iid."
 msgstr "Obligatorio un iid."
 
-#: opac/webapp/controllers.py:681
+#: opac/webapp/controllers.py:676
 msgid "Obrigatório um jacron e issue_label."
 msgstr "Obligatorio un jacron e issue_label."
 
-#: opac/webapp/controllers.py:694
+#: opac/webapp/controllers.py:689
 msgid "Obrigatório um PID."
 msgstr "PID obligatorio."
 
-#: opac/webapp/controllers.py:710
+#: opac/webapp/controllers.py:705
 msgid "Obrigatório um url_seg e url_seg_issue."
 msgstr "Obligatorio un url_seg y url_seg_issue."
 
-#: opac/webapp/controllers.py:717
+#: opac/webapp/controllers.py:712
 msgid "Obrigatório um assets_code."
 msgstr "assets_code es obligatório."
 
-#: opac/webapp/controllers.py:720
+#: opac/webapp/controllers.py:715
 msgid "Obrigatório um journal."
 msgstr "journal es obligatorio."
 
-#: opac/webapp/controllers.py:736
+#: opac/webapp/controllers.py:731
 msgid "Obrigatório um aid."
 msgstr "Obligatorio un aid."
 
-#: opac/webapp/controllers.py:750
+#: opac/webapp/controllers.py:745
 msgid "Obrigatório um url_seg_article."
 msgstr "Obligatorio un url_seg_article."
 
-#: opac/webapp/controllers.py:765
+#: opac/webapp/controllers.py:760
 msgid "Obrigatório um iid and url_seg_article."
 msgstr "Obligatorio un iid and url_seg_article."
 
-#: opac/webapp/controllers.py:861
+#: opac/webapp/controllers.py:856
 msgid "Obrigatório um pid."
 msgstr "PID obligatorio."
 
-#: opac/webapp/controllers.py:874
+#: opac/webapp/controllers.py:869
 msgid "Obrigatório um aop_pid."
 msgstr "Obligatorio un aop_pid."
 
-#: opac/webapp/controllers.py:885
+#: opac/webapp/controllers.py:880
 msgid "Parámetro obrigatório: issue_iid."
 msgstr "Parámetro obligatorio: issue_iid."
 
-#: opac/webapp/controllers.py:933
+#: opac/webapp/controllers.py:928
 msgid "Parâmetro email deve ser uma string"
 msgstr "Parámetro email debe ser un string"
 
-#: opac/webapp/controllers.py:944
+#: opac/webapp/controllers.py:939
 msgid "Parâmetro email deve ser uma inteiro"
 msgstr "Parámetro email debe ser un entero"
 
-#: opac/webapp/controllers.py:956 opac/webapp/controllers.py:970
+#: opac/webapp/controllers.py:951 opac/webapp/controllers.py:965
 #, python-format
 msgid "Usuário deve ser do tipo %s"
 msgstr "Usuario debe ser del tipo %s"
 
-#: opac/webapp/controllers.py:1026
+#: opac/webapp/controllers.py:1021
 msgid "Compartilhamento de link SciELO"
 msgstr "Compartir enlace SciELO"
 
-#: opac/webapp/controllers.py:1027
+#: opac/webapp/controllers.py:1022
 #, python-format
 msgid "O usuário %s compartilha este link: %s, da SciELO"
 msgstr "El usuario %s comparte este enlace: %s, de SciELO"
 
-#: opac/webapp/controllers.py:1035 opac/webapp/controllers.py:1071
-#: opac/webapp/controllers.py:1093
+#: opac/webapp/controllers.py:1030 opac/webapp/controllers.py:1066
+#: opac/webapp/controllers.py:1088
 msgid "Mensagem enviada!"
 msgstr "Mensaje enviado!"
 
-#: opac/webapp/controllers.py:1052
+#: opac/webapp/controllers.py:1047
 msgid "[Erro] Erro informado pelo usuário no site SciELO"
 msgstr ""
 
-#: opac/webapp/controllers.py:1055
+#: opac/webapp/controllers.py:1050
 msgid "aplicação"
 msgstr ""
 
-#: opac/webapp/controllers.py:1057
+#: opac/webapp/controllers.py:1052
 msgid "conteúdo"
 msgstr ""
 
-#: opac/webapp/controllers.py:1062
+#: opac/webapp/controllers.py:1057
 #, python-format
 msgid ""
 "O usuário <b>%s</b> com e-mail: <b>%s</b>, informa que existe um erro na "
@@ -370,16 +370,16 @@ msgstr ""
 " en la% s en el sitio SciELO. <br> <br> <b> Título de la página: </ b>% s"
 " <br> <br> <b> Link: </ b% s"
 
-#: opac/webapp/controllers.py:1083
+#: opac/webapp/controllers.py:1078
 msgid "Contato de usuário via site SciELO"
 msgstr "Contacto de usuário por sitio SciELO"
 
-#: opac/webapp/controllers.py:1085
+#: opac/webapp/controllers.py:1080
 #, python-format
 msgid "O usuário %s, com e-mail: %s, entra em contato com a seguinte mensagem:"
 msgstr "El usuario %s, con e-mail: %s, entra en contacto com la siguiente mensaje:"
 
-#: opac/webapp/controllers.py:1117
+#: opac/webapp/controllers.py:1112
 msgid "Obrigatório um slug_name."
 msgstr ""
 
@@ -1176,7 +1176,7 @@ msgstr "Ir a la página de inicio de la colección:"
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:7
 #: opac/webapp/templates/issue/includes/alternative_header.html:121
 #: opac/webapp/templates/journal/includes/alternative_header.html:117
-#: opac/webapp/templates/journal/includes/header.html:92
+#: opac/webapp/templates/journal/includes/header.html:105
 msgid "Submissão de manuscritos"
 msgstr "Envío de manuscritos"
 
@@ -1184,7 +1184,7 @@ msgstr "Envío de manuscritos"
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:16
 #: opac/webapp/templates/issue/includes/alternative_header.html:127
 #: opac/webapp/templates/journal/includes/alternative_header.html:123
-#: opac/webapp/templates/journal/includes/header.html:98
+#: opac/webapp/templates/journal/includes/header.html:111
 msgid "Sobre o periódico"
 msgstr "Acerca de la revista"
 
@@ -1192,7 +1192,7 @@ msgstr "Acerca de la revista"
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:10
 #: opac/webapp/templates/issue/includes/alternative_header.html:132
 #: opac/webapp/templates/journal/includes/alternative_header.html:128
-#: opac/webapp/templates/journal/includes/header.html:103
+#: opac/webapp/templates/journal/includes/header.html:116
 msgid "Corpo Editorial"
 msgstr "Cuerpo Editorial"
 
@@ -1200,7 +1200,7 @@ msgstr "Cuerpo Editorial"
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:13
 #: opac/webapp/templates/issue/includes/alternative_header.html:137
 #: opac/webapp/templates/journal/includes/alternative_header.html:133
-#: opac/webapp/templates/journal/includes/header.html:108
+#: opac/webapp/templates/journal/includes/header.html:121
 msgid "Instruções aos autores"
 msgstr "Instrucciones a los autores"
 
@@ -1208,7 +1208,7 @@ msgstr "Instrucciones a los autores"
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:19
 #: opac/webapp/templates/issue/includes/alternative_header.html:142
 #: opac/webapp/templates/journal/includes/alternative_header.html:138
-#: opac/webapp/templates/journal/includes/header.html:114
+#: opac/webapp/templates/journal/includes/header.html:127
 msgid "Contato"
 msgstr "Contacto"
 
@@ -1937,7 +1937,11 @@ msgstr "Versión on-line ISSN:"
 msgid "Novo título:"
 msgstr "Nuevo titulo:"
 
-#: opac/webapp/templates/journal/includes/header.html:122
+#: opac/webapp/templates/journal/includes/header.html:86
+msgid "Título anterior:"
+msgstr "Titulo anterior"
+
+#: opac/webapp/templates/journal/includes/header.html:135
 msgid "Siga-nos"
 msgstr "Síganos"
 

--- a/opac/webapp/translations/es_ES/LC_MESSAGES/messages.po
+++ b/opac/webapp/translations/es_ES/LC_MESSAGES/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-02-01 19:52+0000\n"
+"POT-Creation-Date: 2019-02-06 15:41+0000\n"
 "PO-Revision-Date: 2016-02-09 09:39-0600\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es_ES\n"
@@ -226,135 +226,135 @@ msgstr ""
 msgid "publicação finalizada"
 msgstr ""
 
-#: opac/webapp/controllers.py:346
+#: opac/webapp/controllers.py:341
 msgid "Lista Alfabética"
 msgstr ""
 
-#: opac/webapp/controllers.py:350
+#: opac/webapp/controllers.py:345
 msgid "Lista Temática"
 msgstr ""
 
-#: opac/webapp/controllers.py:354
+#: opac/webapp/controllers.py:349
 msgid "Lista Web of Science"
 msgstr ""
 
-#: opac/webapp/controllers.py:358
+#: opac/webapp/controllers.py:353
 msgid "Lista by Institution"
 msgstr ""
 
-#: opac/webapp/controllers.py:417
+#: opac/webapp/controllers.py:412
 msgid "Obrigatório um jid."
 msgstr ""
 
-#: opac/webapp/controllers.py:433
+#: opac/webapp/controllers.py:428
 msgid "Obrigatório um acronym."
 msgstr ""
 
-#: opac/webapp/controllers.py:449
+#: opac/webapp/controllers.py:444
 msgid "Obrigatório um url_seg."
 msgstr ""
 
-#: opac/webapp/controllers.py:465
+#: opac/webapp/controllers.py:460
 msgid "Obrigatório um issn."
 msgstr ""
 
-#: opac/webapp/controllers.py:480
+#: opac/webapp/controllers.py:475
 msgid "Obrigatório um title."
 msgstr ""
 
-#: opac/webapp/controllers.py:518 opac/webapp/controllers.py:662
-#: opac/webapp/controllers.py:802
+#: opac/webapp/controllers.py:513 opac/webapp/controllers.py:657
+#: opac/webapp/controllers.py:797
 msgid "Obrigatório uma lista de ids."
 msgstr ""
 
-#: opac/webapp/controllers.py:624 opac/webapp/controllers.py:823
+#: opac/webapp/controllers.py:619 opac/webapp/controllers.py:818
 msgid "Obrigatório um iid."
 msgstr ""
 
-#: opac/webapp/controllers.py:681
+#: opac/webapp/controllers.py:676
 msgid "Obrigatório um jacron e issue_label."
 msgstr ""
 
-#: opac/webapp/controllers.py:694
+#: opac/webapp/controllers.py:689
 msgid "Obrigatório um PID."
 msgstr ""
 
-#: opac/webapp/controllers.py:710
+#: opac/webapp/controllers.py:705
 msgid "Obrigatório um url_seg e url_seg_issue."
 msgstr ""
 
-#: opac/webapp/controllers.py:717
+#: opac/webapp/controllers.py:712
 msgid "Obrigatório um assets_code."
 msgstr ""
 
-#: opac/webapp/controllers.py:720
+#: opac/webapp/controllers.py:715
 msgid "Obrigatório um journal."
 msgstr ""
 
-#: opac/webapp/controllers.py:736
+#: opac/webapp/controllers.py:731
 msgid "Obrigatório um aid."
 msgstr ""
 
-#: opac/webapp/controllers.py:750
+#: opac/webapp/controllers.py:745
 msgid "Obrigatório um url_seg_article."
 msgstr ""
 
-#: opac/webapp/controllers.py:765
+#: opac/webapp/controllers.py:760
 msgid "Obrigatório um iid and url_seg_article."
 msgstr ""
 
-#: opac/webapp/controllers.py:861
+#: opac/webapp/controllers.py:856
 msgid "Obrigatório um pid."
 msgstr ""
 
-#: opac/webapp/controllers.py:874
+#: opac/webapp/controllers.py:869
 msgid "Obrigatório um aop_pid."
 msgstr ""
 
-#: opac/webapp/controllers.py:885
+#: opac/webapp/controllers.py:880
 msgid "Parámetro obrigatório: issue_iid."
 msgstr ""
 
-#: opac/webapp/controllers.py:933
+#: opac/webapp/controllers.py:928
 msgid "Parâmetro email deve ser uma string"
 msgstr ""
 
-#: opac/webapp/controllers.py:944
+#: opac/webapp/controllers.py:939
 msgid "Parâmetro email deve ser uma inteiro"
 msgstr ""
 
-#: opac/webapp/controllers.py:956 opac/webapp/controllers.py:970
+#: opac/webapp/controllers.py:951 opac/webapp/controllers.py:965
 #, python-format
 msgid "Usuário deve ser do tipo %s"
 msgstr ""
 
-#: opac/webapp/controllers.py:1026
+#: opac/webapp/controllers.py:1021
 msgid "Compartilhamento de link SciELO"
 msgstr ""
 
-#: opac/webapp/controllers.py:1027
+#: opac/webapp/controllers.py:1022
 #, python-format
 msgid "O usuário %s compartilha este link: %s, da SciELO"
 msgstr ""
 
-#: opac/webapp/controllers.py:1035 opac/webapp/controllers.py:1071
-#: opac/webapp/controllers.py:1093
+#: opac/webapp/controllers.py:1030 opac/webapp/controllers.py:1066
+#: opac/webapp/controllers.py:1088
 msgid "Mensagem enviada!"
 msgstr ""
 
-#: opac/webapp/controllers.py:1052
+#: opac/webapp/controllers.py:1047
 msgid "[Erro] Erro informado pelo usuário no site SciELO"
 msgstr ""
 
-#: opac/webapp/controllers.py:1055
+#: opac/webapp/controllers.py:1050
 msgid "aplicação"
 msgstr ""
 
-#: opac/webapp/controllers.py:1057
+#: opac/webapp/controllers.py:1052
 msgid "conteúdo"
 msgstr ""
 
-#: opac/webapp/controllers.py:1062
+#: opac/webapp/controllers.py:1057
 #, python-format
 msgid ""
 "O usuário <b>%s</b> com e-mail: <b>%s</b>, informa que existe um erro na "
@@ -362,16 +362,16 @@ msgid ""
 " %s"
 msgstr ""
 
-#: opac/webapp/controllers.py:1083
+#: opac/webapp/controllers.py:1078
 msgid "Contato de usuário via site SciELO"
 msgstr ""
 
-#: opac/webapp/controllers.py:1085
+#: opac/webapp/controllers.py:1080
 #, python-format
 msgid "O usuário %s, com e-mail: %s, entra em contato com a seguinte mensagem:"
 msgstr ""
 
-#: opac/webapp/controllers.py:1117
+#: opac/webapp/controllers.py:1112
 msgid "Obrigatório um slug_name."
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:7
 #: opac/webapp/templates/issue/includes/alternative_header.html:121
 #: opac/webapp/templates/journal/includes/alternative_header.html:117
-#: opac/webapp/templates/journal/includes/header.html:92
+#: opac/webapp/templates/journal/includes/header.html:105
 msgid "Submissão de manuscritos"
 msgstr ""
 
@@ -1159,7 +1159,7 @@ msgstr ""
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:16
 #: opac/webapp/templates/issue/includes/alternative_header.html:127
 #: opac/webapp/templates/journal/includes/alternative_header.html:123
-#: opac/webapp/templates/journal/includes/header.html:98
+#: opac/webapp/templates/journal/includes/header.html:111
 msgid "Sobre o periódico"
 msgstr ""
 
@@ -1167,7 +1167,7 @@ msgstr ""
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:10
 #: opac/webapp/templates/issue/includes/alternative_header.html:132
 #: opac/webapp/templates/journal/includes/alternative_header.html:128
-#: opac/webapp/templates/journal/includes/header.html:103
+#: opac/webapp/templates/journal/includes/header.html:116
 msgid "Corpo Editorial"
 msgstr ""
 
@@ -1175,7 +1175,7 @@ msgstr ""
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:13
 #: opac/webapp/templates/issue/includes/alternative_header.html:137
 #: opac/webapp/templates/journal/includes/alternative_header.html:133
-#: opac/webapp/templates/journal/includes/header.html:108
+#: opac/webapp/templates/journal/includes/header.html:121
 msgid "Instruções aos autores"
 msgstr ""
 
@@ -1183,7 +1183,7 @@ msgstr ""
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:19
 #: opac/webapp/templates/issue/includes/alternative_header.html:142
 #: opac/webapp/templates/journal/includes/alternative_header.html:138
-#: opac/webapp/templates/journal/includes/header.html:114
+#: opac/webapp/templates/journal/includes/header.html:127
 msgid "Contato"
 msgstr ""
 
@@ -1908,7 +1908,11 @@ msgstr ""
 msgid "Novo título:"
 msgstr ""
 
-#: opac/webapp/templates/journal/includes/header.html:122
+#: opac/webapp/templates/journal/includes/header.html:86
+msgid "Título anterior:"
+msgstr ""
+
+#: opac/webapp/templates/journal/includes/header.html:135
 msgid "Siga-nos"
 msgstr ""
 

--- a/opac/webapp/translations/es_MX/LC_MESSAGES/messages.po
+++ b/opac/webapp/translations/es_MX/LC_MESSAGES/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-02-01 19:52+0000\n"
+"POT-Creation-Date: 2019-02-06 15:41+0000\n"
 "PO-Revision-Date: 2016-02-09 09:39-0600\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es_MX\n"
@@ -226,135 +226,135 @@ msgstr ""
 msgid "publicação finalizada"
 msgstr ""
 
-#: opac/webapp/controllers.py:346
+#: opac/webapp/controllers.py:341
 msgid "Lista Alfabética"
 msgstr ""
 
-#: opac/webapp/controllers.py:350
+#: opac/webapp/controllers.py:345
 msgid "Lista Temática"
 msgstr ""
 
-#: opac/webapp/controllers.py:354
+#: opac/webapp/controllers.py:349
 msgid "Lista Web of Science"
 msgstr ""
 
-#: opac/webapp/controllers.py:358
+#: opac/webapp/controllers.py:353
 msgid "Lista by Institution"
 msgstr ""
 
-#: opac/webapp/controllers.py:417
+#: opac/webapp/controllers.py:412
 msgid "Obrigatório um jid."
 msgstr ""
 
-#: opac/webapp/controllers.py:433
+#: opac/webapp/controllers.py:428
 msgid "Obrigatório um acronym."
 msgstr ""
 
-#: opac/webapp/controllers.py:449
+#: opac/webapp/controllers.py:444
 msgid "Obrigatório um url_seg."
 msgstr ""
 
-#: opac/webapp/controllers.py:465
+#: opac/webapp/controllers.py:460
 msgid "Obrigatório um issn."
 msgstr ""
 
-#: opac/webapp/controllers.py:480
+#: opac/webapp/controllers.py:475
 msgid "Obrigatório um title."
 msgstr ""
 
-#: opac/webapp/controllers.py:518 opac/webapp/controllers.py:662
-#: opac/webapp/controllers.py:802
+#: opac/webapp/controllers.py:513 opac/webapp/controllers.py:657
+#: opac/webapp/controllers.py:797
 msgid "Obrigatório uma lista de ids."
 msgstr ""
 
-#: opac/webapp/controllers.py:624 opac/webapp/controllers.py:823
+#: opac/webapp/controllers.py:619 opac/webapp/controllers.py:818
 msgid "Obrigatório um iid."
 msgstr ""
 
-#: opac/webapp/controllers.py:681
+#: opac/webapp/controllers.py:676
 msgid "Obrigatório um jacron e issue_label."
 msgstr ""
 
-#: opac/webapp/controllers.py:694
+#: opac/webapp/controllers.py:689
 msgid "Obrigatório um PID."
 msgstr ""
 
-#: opac/webapp/controllers.py:710
+#: opac/webapp/controllers.py:705
 msgid "Obrigatório um url_seg e url_seg_issue."
 msgstr ""
 
-#: opac/webapp/controllers.py:717
+#: opac/webapp/controllers.py:712
 msgid "Obrigatório um assets_code."
 msgstr ""
 
-#: opac/webapp/controllers.py:720
+#: opac/webapp/controllers.py:715
 msgid "Obrigatório um journal."
 msgstr ""
 
-#: opac/webapp/controllers.py:736
+#: opac/webapp/controllers.py:731
 msgid "Obrigatório um aid."
 msgstr ""
 
-#: opac/webapp/controllers.py:750
+#: opac/webapp/controllers.py:745
 msgid "Obrigatório um url_seg_article."
 msgstr ""
 
-#: opac/webapp/controllers.py:765
+#: opac/webapp/controllers.py:760
 msgid "Obrigatório um iid and url_seg_article."
 msgstr ""
 
-#: opac/webapp/controllers.py:861
+#: opac/webapp/controllers.py:856
 msgid "Obrigatório um pid."
 msgstr ""
 
-#: opac/webapp/controllers.py:874
+#: opac/webapp/controllers.py:869
 msgid "Obrigatório um aop_pid."
 msgstr ""
 
-#: opac/webapp/controllers.py:885
+#: opac/webapp/controllers.py:880
 msgid "Parámetro obrigatório: issue_iid."
 msgstr ""
 
-#: opac/webapp/controllers.py:933
+#: opac/webapp/controllers.py:928
 msgid "Parâmetro email deve ser uma string"
 msgstr ""
 
-#: opac/webapp/controllers.py:944
+#: opac/webapp/controllers.py:939
 msgid "Parâmetro email deve ser uma inteiro"
 msgstr ""
 
-#: opac/webapp/controllers.py:956 opac/webapp/controllers.py:970
+#: opac/webapp/controllers.py:951 opac/webapp/controllers.py:965
 #, python-format
 msgid "Usuário deve ser do tipo %s"
 msgstr ""
 
-#: opac/webapp/controllers.py:1026
+#: opac/webapp/controllers.py:1021
 msgid "Compartilhamento de link SciELO"
 msgstr ""
 
-#: opac/webapp/controllers.py:1027
+#: opac/webapp/controllers.py:1022
 #, python-format
 msgid "O usuário %s compartilha este link: %s, da SciELO"
 msgstr ""
 
-#: opac/webapp/controllers.py:1035 opac/webapp/controllers.py:1071
-#: opac/webapp/controllers.py:1093
+#: opac/webapp/controllers.py:1030 opac/webapp/controllers.py:1066
+#: opac/webapp/controllers.py:1088
 msgid "Mensagem enviada!"
 msgstr ""
 
-#: opac/webapp/controllers.py:1052
+#: opac/webapp/controllers.py:1047
 msgid "[Erro] Erro informado pelo usuário no site SciELO"
 msgstr ""
 
-#: opac/webapp/controllers.py:1055
+#: opac/webapp/controllers.py:1050
 msgid "aplicação"
 msgstr ""
 
-#: opac/webapp/controllers.py:1057
+#: opac/webapp/controllers.py:1052
 msgid "conteúdo"
 msgstr ""
 
-#: opac/webapp/controllers.py:1062
+#: opac/webapp/controllers.py:1057
 #, python-format
 msgid ""
 "O usuário <b>%s</b> com e-mail: <b>%s</b>, informa que existe um erro na "
@@ -362,16 +362,16 @@ msgid ""
 " %s"
 msgstr ""
 
-#: opac/webapp/controllers.py:1083
+#: opac/webapp/controllers.py:1078
 msgid "Contato de usuário via site SciELO"
 msgstr ""
 
-#: opac/webapp/controllers.py:1085
+#: opac/webapp/controllers.py:1080
 #, python-format
 msgid "O usuário %s, com e-mail: %s, entra em contato com a seguinte mensagem:"
 msgstr ""
 
-#: opac/webapp/controllers.py:1117
+#: opac/webapp/controllers.py:1112
 msgid "Obrigatório um slug_name."
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:7
 #: opac/webapp/templates/issue/includes/alternative_header.html:121
 #: opac/webapp/templates/journal/includes/alternative_header.html:117
-#: opac/webapp/templates/journal/includes/header.html:92
+#: opac/webapp/templates/journal/includes/header.html:105
 msgid "Submissão de manuscritos"
 msgstr ""
 
@@ -1159,7 +1159,7 @@ msgstr ""
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:16
 #: opac/webapp/templates/issue/includes/alternative_header.html:127
 #: opac/webapp/templates/journal/includes/alternative_header.html:123
-#: opac/webapp/templates/journal/includes/header.html:98
+#: opac/webapp/templates/journal/includes/header.html:111
 msgid "Sobre o periódico"
 msgstr ""
 
@@ -1167,7 +1167,7 @@ msgstr ""
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:10
 #: opac/webapp/templates/issue/includes/alternative_header.html:132
 #: opac/webapp/templates/journal/includes/alternative_header.html:128
-#: opac/webapp/templates/journal/includes/header.html:103
+#: opac/webapp/templates/journal/includes/header.html:116
 msgid "Corpo Editorial"
 msgstr ""
 
@@ -1175,7 +1175,7 @@ msgstr ""
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:13
 #: opac/webapp/templates/issue/includes/alternative_header.html:137
 #: opac/webapp/templates/journal/includes/alternative_header.html:133
-#: opac/webapp/templates/journal/includes/header.html:108
+#: opac/webapp/templates/journal/includes/header.html:121
 msgid "Instruções aos autores"
 msgstr ""
 
@@ -1183,7 +1183,7 @@ msgstr ""
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:19
 #: opac/webapp/templates/issue/includes/alternative_header.html:142
 #: opac/webapp/templates/journal/includes/alternative_header.html:138
-#: opac/webapp/templates/journal/includes/header.html:114
+#: opac/webapp/templates/journal/includes/header.html:127
 msgid "Contato"
 msgstr ""
 
@@ -1908,7 +1908,11 @@ msgstr ""
 msgid "Novo título:"
 msgstr ""
 
-#: opac/webapp/templates/journal/includes/header.html:122
+#: opac/webapp/templates/journal/includes/header.html:86
+msgid "Título anterior:"
+msgstr ""
+
+#: opac/webapp/templates/journal/includes/header.html:135
 msgid "Siga-nos"
 msgstr ""
 

--- a/opac/webapp/translations/messages.pot
+++ b/opac/webapp/translations/messages.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-02-01 19:52+0000\n"
+"POT-Creation-Date: 2019-02-06 15:41+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -224,135 +224,135 @@ msgstr ""
 msgid "publicação finalizada"
 msgstr ""
 
-#: opac/webapp/controllers.py:346
+#: opac/webapp/controllers.py:341
 msgid "Lista Alfabética"
 msgstr ""
 
-#: opac/webapp/controllers.py:350
+#: opac/webapp/controllers.py:345
 msgid "Lista Temática"
 msgstr ""
 
-#: opac/webapp/controllers.py:354
+#: opac/webapp/controllers.py:349
 msgid "Lista Web of Science"
 msgstr ""
 
-#: opac/webapp/controllers.py:358
+#: opac/webapp/controllers.py:353
 msgid "Lista by Institution"
 msgstr ""
 
-#: opac/webapp/controllers.py:417
+#: opac/webapp/controllers.py:412
 msgid "Obrigatório um jid."
 msgstr ""
 
-#: opac/webapp/controllers.py:433
+#: opac/webapp/controllers.py:428
 msgid "Obrigatório um acronym."
 msgstr ""
 
-#: opac/webapp/controllers.py:449
+#: opac/webapp/controllers.py:444
 msgid "Obrigatório um url_seg."
 msgstr ""
 
-#: opac/webapp/controllers.py:465
+#: opac/webapp/controllers.py:460
 msgid "Obrigatório um issn."
 msgstr ""
 
-#: opac/webapp/controllers.py:480
+#: opac/webapp/controllers.py:475
 msgid "Obrigatório um title."
 msgstr ""
 
-#: opac/webapp/controllers.py:518 opac/webapp/controllers.py:662
-#: opac/webapp/controllers.py:802
+#: opac/webapp/controllers.py:513 opac/webapp/controllers.py:657
+#: opac/webapp/controllers.py:797
 msgid "Obrigatório uma lista de ids."
 msgstr ""
 
-#: opac/webapp/controllers.py:624 opac/webapp/controllers.py:823
+#: opac/webapp/controllers.py:619 opac/webapp/controllers.py:818
 msgid "Obrigatório um iid."
 msgstr ""
 
-#: opac/webapp/controllers.py:681
+#: opac/webapp/controllers.py:676
 msgid "Obrigatório um jacron e issue_label."
 msgstr ""
 
-#: opac/webapp/controllers.py:694
+#: opac/webapp/controllers.py:689
 msgid "Obrigatório um PID."
 msgstr ""
 
-#: opac/webapp/controllers.py:710
+#: opac/webapp/controllers.py:705
 msgid "Obrigatório um url_seg e url_seg_issue."
 msgstr ""
 
-#: opac/webapp/controllers.py:717
+#: opac/webapp/controllers.py:712
 msgid "Obrigatório um assets_code."
 msgstr ""
 
-#: opac/webapp/controllers.py:720
+#: opac/webapp/controllers.py:715
 msgid "Obrigatório um journal."
 msgstr ""
 
-#: opac/webapp/controllers.py:736
+#: opac/webapp/controllers.py:731
 msgid "Obrigatório um aid."
 msgstr ""
 
-#: opac/webapp/controllers.py:750
+#: opac/webapp/controllers.py:745
 msgid "Obrigatório um url_seg_article."
 msgstr ""
 
-#: opac/webapp/controllers.py:765
+#: opac/webapp/controllers.py:760
 msgid "Obrigatório um iid and url_seg_article."
 msgstr ""
 
-#: opac/webapp/controllers.py:861
+#: opac/webapp/controllers.py:856
 msgid "Obrigatório um pid."
 msgstr ""
 
-#: opac/webapp/controllers.py:874
+#: opac/webapp/controllers.py:869
 msgid "Obrigatório um aop_pid."
 msgstr ""
 
-#: opac/webapp/controllers.py:885
+#: opac/webapp/controllers.py:880
 msgid "Parámetro obrigatório: issue_iid."
 msgstr ""
 
-#: opac/webapp/controllers.py:933
+#: opac/webapp/controllers.py:928
 msgid "Parâmetro email deve ser uma string"
 msgstr ""
 
-#: opac/webapp/controllers.py:944
+#: opac/webapp/controllers.py:939
 msgid "Parâmetro email deve ser uma inteiro"
 msgstr ""
 
-#: opac/webapp/controllers.py:956 opac/webapp/controllers.py:970
+#: opac/webapp/controllers.py:951 opac/webapp/controllers.py:965
 #, python-format
 msgid "Usuário deve ser do tipo %s"
 msgstr ""
 
-#: opac/webapp/controllers.py:1026
+#: opac/webapp/controllers.py:1021
 msgid "Compartilhamento de link SciELO"
 msgstr ""
 
-#: opac/webapp/controllers.py:1027
+#: opac/webapp/controllers.py:1022
 #, python-format
 msgid "O usuário %s compartilha este link: %s, da SciELO"
 msgstr ""
 
-#: opac/webapp/controllers.py:1035 opac/webapp/controllers.py:1071
-#: opac/webapp/controllers.py:1093
+#: opac/webapp/controllers.py:1030 opac/webapp/controllers.py:1066
+#: opac/webapp/controllers.py:1088
 msgid "Mensagem enviada!"
 msgstr ""
 
-#: opac/webapp/controllers.py:1052
+#: opac/webapp/controllers.py:1047
 msgid "[Erro] Erro informado pelo usuário no site SciELO"
 msgstr ""
 
-#: opac/webapp/controllers.py:1055
+#: opac/webapp/controllers.py:1050
 msgid "aplicação"
 msgstr ""
 
-#: opac/webapp/controllers.py:1057
+#: opac/webapp/controllers.py:1052
 msgid "conteúdo"
 msgstr ""
 
-#: opac/webapp/controllers.py:1062
+#: opac/webapp/controllers.py:1057
 #, python-format
 msgid ""
 "O usuário <b>%s</b> com e-mail: <b>%s</b>, informa que existe um erro na "
@@ -360,16 +360,16 @@ msgid ""
 " %s"
 msgstr ""
 
-#: opac/webapp/controllers.py:1083
+#: opac/webapp/controllers.py:1078
 msgid "Contato de usuário via site SciELO"
 msgstr ""
 
-#: opac/webapp/controllers.py:1085
+#: opac/webapp/controllers.py:1080
 #, python-format
 msgid "O usuário %s, com e-mail: %s, entra em contato com a seguinte mensagem:"
 msgstr ""
 
-#: opac/webapp/controllers.py:1117
+#: opac/webapp/controllers.py:1112
 msgid "Obrigatório um slug_name."
 msgstr ""
 
@@ -1149,7 +1149,7 @@ msgstr ""
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:7
 #: opac/webapp/templates/issue/includes/alternative_header.html:121
 #: opac/webapp/templates/journal/includes/alternative_header.html:117
-#: opac/webapp/templates/journal/includes/header.html:92
+#: opac/webapp/templates/journal/includes/header.html:105
 msgid "Submissão de manuscritos"
 msgstr ""
 
@@ -1157,7 +1157,7 @@ msgstr ""
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:16
 #: opac/webapp/templates/issue/includes/alternative_header.html:127
 #: opac/webapp/templates/journal/includes/alternative_header.html:123
-#: opac/webapp/templates/journal/includes/header.html:98
+#: opac/webapp/templates/journal/includes/header.html:111
 msgid "Sobre o periódico"
 msgstr ""
 
@@ -1165,7 +1165,7 @@ msgstr ""
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:10
 #: opac/webapp/templates/issue/includes/alternative_header.html:132
 #: opac/webapp/templates/journal/includes/alternative_header.html:128
-#: opac/webapp/templates/journal/includes/header.html:103
+#: opac/webapp/templates/journal/includes/header.html:116
 msgid "Corpo Editorial"
 msgstr ""
 
@@ -1173,7 +1173,7 @@ msgstr ""
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:13
 #: opac/webapp/templates/issue/includes/alternative_header.html:137
 #: opac/webapp/templates/journal/includes/alternative_header.html:133
-#: opac/webapp/templates/journal/includes/header.html:108
+#: opac/webapp/templates/journal/includes/header.html:121
 msgid "Instruções aos autores"
 msgstr ""
 
@@ -1181,7 +1181,7 @@ msgstr ""
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:19
 #: opac/webapp/templates/issue/includes/alternative_header.html:142
 #: opac/webapp/templates/journal/includes/alternative_header.html:138
-#: opac/webapp/templates/journal/includes/header.html:114
+#: opac/webapp/templates/journal/includes/header.html:127
 msgid "Contato"
 msgstr ""
 
@@ -1906,7 +1906,11 @@ msgstr ""
 msgid "Novo título:"
 msgstr ""
 
-#: opac/webapp/templates/journal/includes/header.html:122
+#: opac/webapp/templates/journal/includes/header.html:86
+msgid "Título anterior:"
+msgstr ""
+
+#: opac/webapp/templates/journal/includes/header.html:135
 msgid "Siga-nos"
 msgstr ""
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ Flask-Migrate==2.2.1
 unicodecsv==0.14.1
 feedparser==5.2.1
 legendarium==2.0.2
--e git+https://git@github.com/scieloorg/opac_schema@v2.49#egg=opac_schema
+-e git+https://git@github.com/scieloorg/opac_schema@v2.50#egg=opac_schema
 Flask-HTMLmin==1.4.0
 python-slugify==1.2.4
 requests>=2.20.0


### PR DESCRIPTION
#### O que esse PR faz?
* No cabeçalho do periódico do título antigo adiciona o link para o título novo:
* No cabeçalho do periódico do título novo adiciona o link para o título antigo:

#### Onde a revisão poderia começar?
Pelo 'controllers.py' e 'journal/includes/header.html'

#### Como este poderia ser testado manualmente?
na listagem de periódicos e na visualização do periódico inativos e do periódico ativo que o referencia  

### Screenshots (se aplicável)#

![captura de tela 2019-02-06 as 15 27 03](https://user-images.githubusercontent.com/1105583/52360725-d9559f80-2a23-11e9-9b56-78daa3fc26d1.png)

![captura de tela 2019-02-06 as 15 30 17](https://user-images.githubusercontent.com/1105583/52360888-28033980-2a24-11e9-9ef7-aadba9aeb286.png)

#### Quais são tickets relevantes?
https://github.com/scieloorg/opac/issues/1117