### PR TITLE
[TK #1130] Páginas about devem ter vínculos entre os idiomas

### DIFF
--- a/opac/tests/test_main_views.py
+++ b/opac/tests/test_main_views.py
@@ -1258,7 +1258,7 @@ class PageTestCase(BaseTestCase):
         for page in pages:
             if page.language == 'pt_BR':
                 self.assertIn(
-                    '/about/%s/%s' % (page.slug_name, page.language),
+                    '/about/%s' % (page.slug_name),
                     response.data.decode('utf-8'))
 
         self.assertListEqual(
@@ -1276,10 +1276,9 @@ class PageTestCase(BaseTestCase):
             utils.makeOneCollection()
 
             page = utils.makeOnePage({'name': 'Critérios SciELO',
-                                      'language': 'es_ES'})
+                                      'language': 'pt_BR'})
             response = self.client.get(url_for('main.about_collection',
-                                               slug_name=page.slug_name,
-                                               lang=page.language))
+                                               slug_name=page.slug_name))
 
             self.assertEqual(200, response.status_code)
             self.assertTemplateUsed('collection/about.html')
@@ -1298,6 +1297,5 @@ class PageTestCase(BaseTestCase):
             utils.makeOneCollection()
             unknown_page_name = 'xxjfsfadfa0k2qhs8slwnui8'
             response = self.client.get(url_for('main.about_collection',
-                                       slug_name=unknown_page_name,
-                                       lang='ab_cd'))
-            self.assertStatus(response, 404)
+                                       slug_name=unknown_page_name))
+            self.assertStatus(response, 302)

--- a/opac/tests/test_main_views.py
+++ b/opac/tests/test_main_views.py
@@ -1298,4 +1298,4 @@ class PageTestCase(BaseTestCase):
             unknown_page_name = 'xxjfsfadfa0k2qhs8slwnui8'
             response = self.client.get(url_for('main.about_collection',
                                        slug_name=unknown_page_name))
-            self.assertStatus(response, 302)
+            self.assertStatus(response, 404)

--- a/opac/webapp/main/views.py
+++ b/opac/webapp/main/views.py
@@ -204,7 +204,7 @@ def about_collection(slug_name=None):
         # caso seja uma página
         page = controllers.get_page_by_slug_name(slug_name, language)
         if not page:
-            return redirect(url_for('main.about_collection'))
+            abort(404, _('Página não encontrada'))
         context['page'] = page
     else:
         # caso não seja uma página é uma lista

--- a/opac/webapp/main/views.py
+++ b/opac/webapp/main/views.py
@@ -193,10 +193,10 @@ def collection_list_feed():
 
 
 @main.route("/about/", methods=['GET'])
-@main.route('/about/<string:slug_name>/<string:lang>', methods=['GET'])
+@main.route('/about/<string:slug_name>', methods=['GET'])
 @cache.cached(key_prefix=cache_key_with_lang_with_qs)
-def about_collection(slug_name=None, lang=None):
-    language = lang or session.get('lang', get_locale())
+def about_collection(slug_name=None):
+    language = session.get('lang', get_locale())
 
     context = {}
     page = None
@@ -204,7 +204,7 @@ def about_collection(slug_name=None, lang=None):
         # caso seja uma página
         page = controllers.get_page_by_slug_name(slug_name, language)
         if not page:
-            abort(404, _('Página não encontrada'))
+            return redirect(url_for('main.about_collection'))
         context['page'] = page
     else:
         # caso não seja uma página é uma lista

--- a/opac/webapp/templates/collection/about.html
+++ b/opac/webapp/templates/collection/about.html
@@ -18,7 +18,7 @@
                 <ul class="networkList">
 
                     {% for page in pages %}
-                        <a href="/about/{{ page.slug_name }}/{{ page.language }}">
+                        <a href="/about/{{ page.slug_name }}">
                             <li>
                                 {% trans %} {{ page }} {% endtrans %}
                             </li>

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ Flask-Migrate==2.2.1
 unicodecsv==0.14.1
 feedparser==5.2.1
 legendarium==2.0.2
--e git+https://git@github.com/scieloorg/opac_schema@v2.50#egg=opac_schema
+-e git+https://git@github.com/scieloorg/opac_schema@v2.51#egg=opac_schema
 Flask-HTMLmin==1.4.0
 python-slugify==1.2.4
 requests>=2.20.0


### PR DESCRIPTION
#### O que esse PR faz?
Foi removido o `lang` da URL assim a solução dada foi que os `slug_name` das paginas do sobre deve ser iguais, nos 3 idiomas, assim é possível o vínculos das paginas. E caso a aplicação não encontre uma slug_name, no idioma atual da sessão o usuario sera redirecionado a listagem das paginas do sobre

#### Onde a revisão poderia começar?
Pelo `main/views.py`

#### Como este poderia ser testado manualmente?
Apos atualizar o ambiente, e criar as 3 paginas com a mesma `slug_name`, mas languages diferentes acesse o ambiente opac, e alterne os idiomas

#### Algum cenário de contexto que queira dar?
Apos a atualização do ambiente sera necessário alterar os `slug_name` das paginas manualmente, e sempre manter esse padrão para as novas paginas que forem criadas na aplicação

#### Quais são tickets relevantes?
#1130 
