### PR TITLE
[tk1116] Traduzir as áreas temáticas da home do periódico

### DIFF
--- a/opac/tests/test_interface_journal_home.py
+++ b/opac/tests/test_interface_journal_home.py
@@ -1,6 +1,5 @@
 # coding: utf-8
 
-import os
 import flask
 from flask import url_for, current_app
 
@@ -10,6 +9,117 @@ from . import utils
 
 
 class JournalHomeTestCase(BaseTestCase):
+
+    def test_journal_detail_subject_areas_with_pt_language(self):
+        """
+        Teste para verificar se na interface inicial da revista esta retornando
+        o texto no idioma Português.
+        """
+        areas = [
+            "Applied Social Sciences",
+            "Agricultural Sciences",
+            "Biological Sciences",
+            "Engineering",
+            "Exact and Earth Sciences",
+            "Health Sciences",
+            "Human Sciences",
+            "Linguistics, Letters and Arts",
+        ]
+        journal = utils.makeOneJournal({'study_areas': areas})
+
+        with self.client as c:
+            # Criando uma coleção para termos o objeto ``g`` na interface
+            utils.makeOneCollection()
+
+            header = {'Referer': url_for('main.journal_detail',
+                                         url_seg=journal.url_segment)}
+
+            response = c.get(url_for('main.set_locale',
+                                      lang_code='pt_BR'),
+                             headers=header,
+                             follow_redirects=True)
+
+            self.assertEqual(200, response.status_code)
+
+            self.assertEqual(flask.session['lang'], 'pt_BR')
+            content = response.data.decode('utf-8')
+            expected = "Ciências Sociais Aplicadas, Ciências Agrárias, Ciências"
+            self.assertIn(expected, content)
+
+    def test_journal_detail_subject_areas_with_es_language(self):
+        """
+        Teste para verificar se na interface inicial da revista esta retornando o texto no
+        idioma Espanhol.
+        """
+        areas = [
+            "Applied Social Sciences",
+            "Agricultural Sciences",
+            "Biological Sciences",
+            "Engineering",
+            "Exact and Earth Sciences",
+            "Health Sciences",
+            "Human Sciences",
+            "Linguistics, Letters and Arts",
+        ]
+        journal = utils.makeOneJournal({'study_areas': areas})
+
+        with self.client as c:
+            # Criando uma coleção para termos o objeto ``g`` na interface
+            utils.makeOneCollection()
+
+            header = {'Referer': url_for('main.journal_detail',
+                                         url_seg=journal.url_segment)}
+
+            response = c.get(url_for('main.set_locale',
+                                     lang_code='es'),
+                             headers=header,
+                             follow_redirects=True)
+
+            self.assertEqual(200, response.status_code)
+
+            self.assertEqual(flask.session['lang'], 'es')
+
+            content = response.data.decode('utf-8')
+            expected = "Ciencias Sociales Aplicadas, Ciencias Agrícolas,"
+            self.assertIn(expected, content)
+
+    def test_journal_detail_subject_areas_with_en_language(self):
+        """
+        Teste para verificar se na interface inicial da revista esta retornando
+        o texto no idioma Inglês.
+        """
+        areas = [
+            "Applied Social Sciences",
+            "Agricultural Sciences",
+            "Biological Sciences",
+            "Engineering",
+            "Exact and Earth Sciences",
+            "Health Sciences",
+            "Human Sciences",
+            "Linguistics, Letters and Arts",
+        ]
+        journal = utils.makeOneJournal({'study_areas': areas})
+
+        with self.client as c:
+            # Criando uma coleção para termos o objeto ``g`` na interface
+            utils.makeOneCollection()
+
+            header = {'Referer': url_for('main.journal_detail',
+                                         url_seg=journal.url_segment)}
+
+            response = c.get(
+                url_for('main.set_locale', lang_code='en'),
+                headers=header,
+                follow_redirects=True)
+
+            self.assertEqual(200, response.status_code)
+
+            self.assertEqual(flask.session['lang'], 'en')
+
+            content = response.data.decode('utf-8')
+            expected = "Applied Social Sciences, Agricultural Sciences,"
+
+            self.assertIn(expected, content)
 
     # Mission
     def test_journal_detail_mission_with_pt_language(self):

--- a/opac/webapp/choices.py
+++ b/opac/webapp/choices.py
@@ -40,3 +40,15 @@ JOURNAL_STATUS = {
     "interrupted": __("indexação interrompida pelo Comitê"),
     "finished": __("publicação finalizada"),
 }
+
+STUDY_AREAS = {
+    "AGRICULTURAL SCIENCES": __("Ciências Agrárias"),
+    "APPLIED SOCIAL SCIENCES": __("Ciências Sociais Aplicadas"),
+    "BIOLOGICAL SCIENCES": __("Ciências Biológicas"),
+    "ENGINEERING": __("Engenharias"),
+    "EXACT AND EARTH SCIENCES": __("Ciências Exatas e da Terra"),
+    "HEALTH SCIENCES": __("Ciências da Saúde"),
+    "HUMAN SCIENCES": __("Ciências Humanas"),
+    "LINGUISTICS, LETTERS AND ARTS": __("Lingüística, Letras e Artes"),
+    "LINGUISTICS, LITERATURE AND ARTS": __("Lingüística, Letras e Artes"),
+}

--- a/opac/webapp/main/views.py
+++ b/opac/webapp/main/views.py
@@ -16,6 +16,7 @@ from . import main
 from webapp import babel
 from webapp import cache
 from webapp import controllers
+from webapp.choices import STUDY_AREAS
 from webapp.utils import utils
 from webapp.utils import related_articles_urls
 from webapp.utils.caching import cache_key_with_lang, cache_key_with_lang_with_qs
@@ -379,6 +380,9 @@ def journal_detail(url_seg):
         'journal': journal,
         'press_releases': press_releases,
         'recent_articles': recent_articles,
+        'journal_study_areas': [
+            STUDY_AREAS.get(study_area.upper()) for study_area in journal.study_areas
+        ],
         # o primiero item da lista é o último número.
         # condicional para verificar se issues contém itens
         'last_issue': latest_issue,

--- a/opac/webapp/templates/journal/includes/header.html
+++ b/opac/webapp/templates/journal/includes/header.html
@@ -46,11 +46,8 @@
               <span class="area">
                 {% trans %}Área:{% endtrans %}
               </span>
-              {% if journal.subject_categories %}
-                {{ journal.subject_categories|join(', ')|title|truncate(60) }}
-              {% endif %}
-              {% if journal.study_areas %}
-                {{ journal.study_areas|join(', ')|title|truncate(60) }}
+              {% if journal_study_areas %}
+                {{ journal_study_areas|join(', ')|title|truncate(60) }}
               {% endif %}
             </span>
             <span class="issn">

--- a/opac/webapp/translations/en/LC_MESSAGES/messages.po
+++ b/opac/webapp/translations/en/LC_MESSAGES/messages.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version:  OPAC\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-02-08 14:16-0200\n"
+"POT-Creation-Date: 2019-02-15 17:24-0200\n"
 "PO-Revision-Date: 2018-03-06 19:50+0000\n"
 "Last-Translator: jamil Atta <atta.jamil@gmail.com>\n"
 "Language: en\n"
@@ -229,6 +229,38 @@ msgstr "indexing interrupted by the committee"
 #: opac/webapp/choices.py:41
 msgid "publicação finalizada"
 msgstr "publication finished"
+
+#: opac/webapp/choices.py:45
+msgid "Ciências Agrárias"
+msgstr "Agricultural Sciences"
+
+#: opac/webapp/choices.py:46
+msgid "Ciências Sociais Aplicadas"
+msgstr "Applied Social Sciences"
+
+#: opac/webapp/choices.py:47
+msgid "Ciências Biológicas"
+msgstr "Biological Sciences"
+
+#: opac/webapp/choices.py:48
+msgid "Engenharias"
+msgstr "Engineering"
+
+#: opac/webapp/choices.py:49
+msgid "Ciências Exatas e da Terra"
+msgstr "Exact and Earth Sciences"
+
+#: opac/webapp/choices.py:50
+msgid "Ciências da Saúde"
+msgstr "Health Sciences"
+
+#: opac/webapp/choices.py:51
+msgid "Ciências Humanas"
+msgstr "Human Sciences"
+
+#: opac/webapp/choices.py:52 opac/webapp/choices.py:53
+msgid "Lingüística, Letras e Artes"
+msgstr "Linguistics, Literature and Arts"
 
 #: opac/webapp/controllers.py:341
 msgid "Lista Alfabética"
@@ -903,68 +935,68 @@ msgstr "Audited Id"
 msgid "Dados dos campos"
 msgstr "Field data"
 
-#: opac/webapp/main/views.py:28
+#: opac/webapp/main/views.py:29
 msgid "O periódico está indisponível por motivo de: "
 msgstr "The journal is unavailable because:"
 
-#: opac/webapp/main/views.py:29
+#: opac/webapp/main/views.py:30
 msgid "O número está indisponível por motivo de: "
 msgstr "The Issue is unavailable because of:"
 
-#: opac/webapp/main/views.py:30
+#: opac/webapp/main/views.py:31
 msgid "O artigo está indisponível por motivo de: "
 msgstr "The article is unavailable because:"
 
-#: opac/webapp/main/views.py:77
+#: opac/webapp/main/views.py:78
 msgid "Código de idioma inválido"
 msgstr "Invalid language code"
 
-#: opac/webapp/main/views.py:147
+#: opac/webapp/main/views.py:148
 msgid "Últimos periódicos inseridos na coleção"
 msgstr "Latest journals added to the collection"
 
-#: opac/webapp/main/views.py:148
+#: opac/webapp/main/views.py:149
 #, python-format
 msgid "10 últimos periódicos inseridos na coleção %s"
 msgstr "10 latest journals added to the collection %s"
 
-#: opac/webapp/main/views.py:207
+#: opac/webapp/main/views.py:208
 msgid "Página não encontrada"
 msgstr ""
 
-#: opac/webapp/main/views.py:231 opac/webapp/main/views.py:321
+#: opac/webapp/main/views.py:232 opac/webapp/main/views.py:322
 #, python-format
 msgid "Requsição inválida ao tentar acessar o artigo com pid: %s"
 msgstr ""
 
-#: opac/webapp/main/views.py:239 opac/webapp/main/views.py:289
-#: opac/webapp/main/views.py:333 opac/webapp/main/views.py:399
-#: opac/webapp/main/views.py:446 opac/webapp/main/views.py:584
-#: opac/webapp/main/views.py:601 opac/webapp/main/views.py:1028
+#: opac/webapp/main/views.py:240 opac/webapp/main/views.py:290
+#: opac/webapp/main/views.py:334 opac/webapp/main/views.py:403
+#: opac/webapp/main/views.py:450 opac/webapp/main/views.py:588
+#: opac/webapp/main/views.py:605 opac/webapp/main/views.py:1032
 msgid "Periódico não encontrado"
 msgstr "Journal not found"
 
-#: opac/webapp/main/views.py:251 opac/webapp/main/views.py:651
-#: opac/webapp/main/views.py:707 opac/webapp/main/views.py:1037
+#: opac/webapp/main/views.py:252 opac/webapp/main/views.py:655
+#: opac/webapp/main/views.py:711 opac/webapp/main/views.py:1041
 msgid "Número não encontrado"
 msgstr "Issue not found"
 
-#: opac/webapp/main/views.py:269 opac/webapp/main/views.py:304
-#: opac/webapp/main/views.py:755 opac/webapp/main/views.py:782
-#: opac/webapp/main/views.py:854 opac/webapp/main/views.py:857
-#: opac/webapp/main/views.py:961
+#: opac/webapp/main/views.py:270 opac/webapp/main/views.py:305
+#: opac/webapp/main/views.py:759 opac/webapp/main/views.py:786
+#: opac/webapp/main/views.py:858 opac/webapp/main/views.py:861
+#: opac/webapp/main/views.py:965
 msgid "Artigo não encontrado"
 msgstr "Article not found"
 
-#: opac/webapp/main/views.py:423
+#: opac/webapp/main/views.py:427
 msgid "Artigo sem título"
 msgstr "Article not found"
 
-#: opac/webapp/main/views.py:485 opac/webapp/main/views.py:502
+#: opac/webapp/main/views.py:489 opac/webapp/main/views.py:506
 msgid "Requisição inválida. Deve ser por ajax"
 msgstr "Invalid request. Must be made via ajax"
 
-#: opac/webapp/main/views.py:518
+#: opac/webapp/main/views.py:522
 msgid ""
 "Parámetro \"filter\" é inválido, deve ser \"areas\", \"wos\" ou "
 "\"publisher\"."
@@ -972,11 +1004,11 @@ msgstr ""
 "Invalid parameter \"filter\". Should be \"areas\", \"wos\" or "
 "\"publisher\"."
 
-#: opac/webapp/main/views.py:527
+#: opac/webapp/main/views.py:531
 msgid "Parámetro \"extension\" é inválido, deve ser \"csv\" ou \"xls\"."
 msgstr "Invalid parameter \"extension\". Should be \"csv\" or \"xls\"."
 
-#: opac/webapp/main/views.py:529
+#: opac/webapp/main/views.py:533
 msgid ""
 "Parámetro \"list_type\" é inválido, deve ser: \"alpha\", \"areas\", "
 "\"wos\" ou \"publisher\"."
@@ -984,57 +1016,57 @@ msgstr ""
 "Invalid parameter \"list_type\". Should be: \"alpha\", \"areas\", \"wos\""
 " or \"publisher\"."
 
-#: opac/webapp/main/views.py:550
+#: opac/webapp/main/views.py:554
 msgid "Requisição inválida, deve ser ajax."
 msgstr ""
 
-#: opac/webapp/main/views.py:559
+#: opac/webapp/main/views.py:563
 msgid "Periódico não permite envio de email."
 msgstr ""
 
-#: opac/webapp/main/views.py:577
+#: opac/webapp/main/views.py:581
 msgid "Requisição inválida, captcha inválido."
 msgstr ""
 
-#: opac/webapp/main/views.py:777 opac/webapp/main/views.py:956
+#: opac/webapp/main/views.py:781 opac/webapp/main/views.py:960
 msgid "Issue não encontrado"
 msgstr "Issue not found"
 
-#: opac/webapp/main/views.py:814 opac/webapp/main/views.py:820
-#: opac/webapp/main/views.py:993 opac/webapp/main/views.py:1001
-#: opac/webapp/main/views.py:1003
+#: opac/webapp/main/views.py:818 opac/webapp/main/views.py:824
+#: opac/webapp/main/views.py:997 opac/webapp/main/views.py:1005
+#: opac/webapp/main/views.py:1007
 msgid "PDF do Artigo não encontrado"
 msgstr "Article's PDF not found"
 
-#: opac/webapp/main/views.py:830
+#: opac/webapp/main/views.py:834
 msgid "HTML do Artigo não encontrado"
 msgstr "HTML of the Article not found"
 
-#: opac/webapp/main/views.py:844
+#: opac/webapp/main/views.py:848
 msgid "HTML do Artigo não encontrado ou indisponível"
 msgstr "HTML of article not found or unavailable"
 
-#: opac/webapp/main/views.py:903
+#: opac/webapp/main/views.py:907
 msgid "Parâmetros insuficientes para obter o EPDF do artigo"
 msgstr "Insufficient parameters to obtain article's EPDF"
 
-#: opac/webapp/main/views.py:920
+#: opac/webapp/main/views.py:924
 msgid "Recruso não encontrado"
 msgstr "Resource not found"
 
-#: opac/webapp/main/views.py:925
+#: opac/webapp/main/views.py:929
 msgid "Recurso não encontrado"
 msgstr "Resource not found"
 
-#: opac/webapp/main/views.py:942
+#: opac/webapp/main/views.py:946
 msgid "Recurso do Artigo não encontrado. Caminho inválido!"
 msgstr "Article resource not found. Invalid path!"
 
-#: opac/webapp/main/views.py:1055
+#: opac/webapp/main/views.py:1059
 msgid "PDF do artigo não foi encontrado"
 msgstr "Article's PDF not found"
 
-#: opac/webapp/main/views.py:1083 opac/webapp/main/views.py:1114
+#: opac/webapp/main/views.py:1087 opac/webapp/main/views.py:1118
 msgid "Requisição inválida."
 msgstr "Invalid request"
 
@@ -1370,11 +1402,13 @@ msgid "Versão original do texto"
 msgstr ""
 
 #: opac/webapp/templates/collection/about.html:23
+#: opac/webapp/templates/collection/pages.html:21
 #, python-format
 msgid " %(page)s "
 msgstr " %(page)s "
 
 #: opac/webapp/templates/collection/about.html:38
+#: opac/webapp/templates/collection/pages.html:36
 msgid " Conteúdo não cadastrado "
 msgstr "No journal information has been submitted"
 
@@ -1432,11 +1466,11 @@ msgstr "Thematic"
 msgid "Busca por periódicos"
 msgstr "Search by journals"
 
-#: opac/webapp/templates/collection/index.html:93
+#: opac/webapp/templates/collection/index.html:105
 msgid "Números <span>mais recentes</span>"
 msgstr "<span>Latest</span> issues"
 
-#: opac/webapp/templates/collection/index.html:137
+#: opac/webapp/templates/collection/index.html:149
 msgid "em perspectiva"
 msgstr "in perspective"
 
@@ -2012,4 +2046,28 @@ msgstr "Continue reading"
 
 #~ msgid "Citados no"
 #~ msgstr "Cited in"
+
+#~ msgid "AGRICULTURAL SCIENCES"
+#~ msgstr ""
+
+#~ msgid "APPLIED SOCIAL SCIENCES"
+#~ msgstr ""
+
+#~ msgid "BIOLOGICAL SCIENCES"
+#~ msgstr ""
+
+#~ msgid "ENGINEERING"
+#~ msgstr ""
+
+#~ msgid "EXACT AND EARTH SCIENCES"
+#~ msgstr ""
+
+#~ msgid "HEALTH SCIENCES"
+#~ msgstr ""
+
+#~ msgid "HUMAN SCIENCES"
+#~ msgstr ""
+
+#~ msgid "LINGUISTICS, LITERATURE AND ARTS"
+#~ msgstr ""
 

--- a/opac/webapp/translations/es/LC_MESSAGES/messages.po
+++ b/opac/webapp/translations/es/LC_MESSAGES/messages.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version:  OPAC\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-02-08 14:16-0200\n"
+"POT-Creation-Date: 2019-02-15 17:24-0200\n"
 "PO-Revision-Date: 2018-03-07 00:47+0000\n"
 "Last-Translator: jamil Atta <atta.jamil@gmail.com>\n"
 "Language: es\n"
@@ -230,6 +230,38 @@ msgstr "indización interrumpida por el comité"
 #: opac/webapp/choices.py:41
 msgid "publicação finalizada"
 msgstr "publicación finalizada"
+
+#: opac/webapp/choices.py:45
+msgid "Ciências Agrárias"
+msgstr "Ciencias Agrícolas"
+
+#: opac/webapp/choices.py:46
+msgid "Ciências Sociais Aplicadas"
+msgstr "Ciencias Sociales Aplicadas"
+
+#: opac/webapp/choices.py:47
+msgid "Ciências Biológicas"
+msgstr "Ciencias Biológicas"
+
+#: opac/webapp/choices.py:48
+msgid "Engenharias"
+msgstr "Ingeniería"
+
+#: opac/webapp/choices.py:49
+msgid "Ciências Exatas e da Terra"
+msgstr "Ciencias Exactas y de la Tierra"
+
+#: opac/webapp/choices.py:50
+msgid "Ciências da Saúde"
+msgstr "Ciencias de la Salud"
+
+#: opac/webapp/choices.py:51
+msgid "Ciências Humanas"
+msgstr "Humanidades"
+
+#: opac/webapp/choices.py:52 opac/webapp/choices.py:53
+msgid "Lingüística, Letras e Artes"
+msgstr "Linguística, Letras y Artes"
 
 #: opac/webapp/controllers.py:341
 msgid "Lista Alfabética"
@@ -906,68 +938,68 @@ msgstr ""
 msgid "Dados dos campos"
 msgstr ""
 
-#: opac/webapp/main/views.py:28
+#: opac/webapp/main/views.py:29
 msgid "O periódico está indisponível por motivo de: "
 msgstr "La revista no está disponible debido a:"
 
-#: opac/webapp/main/views.py:29
+#: opac/webapp/main/views.py:30
 msgid "O número está indisponível por motivo de: "
 msgstr "O fascículo esta indisponible por motivo de:"
 
-#: opac/webapp/main/views.py:30
+#: opac/webapp/main/views.py:31
 msgid "O artigo está indisponível por motivo de: "
 msgstr "El artículo no está disponible debido a:"
 
-#: opac/webapp/main/views.py:77
+#: opac/webapp/main/views.py:78
 msgid "Código de idioma inválido"
 msgstr "Código de idioma inválido"
 
-#: opac/webapp/main/views.py:147
+#: opac/webapp/main/views.py:148
 msgid "Últimos periódicos inseridos na coleção"
 msgstr "Últimas revistas incluidas en la colección"
 
-#: opac/webapp/main/views.py:148
+#: opac/webapp/main/views.py:149
 #, python-format
 msgid "10 últimos periódicos inseridos na coleção %s"
 msgstr "10 últimas revistas incluidas en la colección %s"
 
-#: opac/webapp/main/views.py:207
+#: opac/webapp/main/views.py:208
 msgid "Página não encontrada"
 msgstr "Página no encontrada"
 
-#: opac/webapp/main/views.py:231 opac/webapp/main/views.py:321
+#: opac/webapp/main/views.py:232 opac/webapp/main/views.py:322
 #, python-format
 msgid "Requsição inválida ao tentar acessar o artigo com pid: %s"
 msgstr "Requiere no válida al intentar tener acceso al artículo con pid:% s"
 
-#: opac/webapp/main/views.py:239 opac/webapp/main/views.py:289
-#: opac/webapp/main/views.py:333 opac/webapp/main/views.py:399
-#: opac/webapp/main/views.py:446 opac/webapp/main/views.py:584
-#: opac/webapp/main/views.py:601 opac/webapp/main/views.py:1028
+#: opac/webapp/main/views.py:240 opac/webapp/main/views.py:290
+#: opac/webapp/main/views.py:334 opac/webapp/main/views.py:403
+#: opac/webapp/main/views.py:450 opac/webapp/main/views.py:588
+#: opac/webapp/main/views.py:605 opac/webapp/main/views.py:1032
 msgid "Periódico não encontrado"
 msgstr "Revista no encontrada"
 
-#: opac/webapp/main/views.py:251 opac/webapp/main/views.py:651
-#: opac/webapp/main/views.py:707 opac/webapp/main/views.py:1037
+#: opac/webapp/main/views.py:252 opac/webapp/main/views.py:655
+#: opac/webapp/main/views.py:711 opac/webapp/main/views.py:1041
 msgid "Número não encontrado"
 msgstr "Fascículo no encontrado"
 
-#: opac/webapp/main/views.py:269 opac/webapp/main/views.py:304
-#: opac/webapp/main/views.py:755 opac/webapp/main/views.py:782
-#: opac/webapp/main/views.py:854 opac/webapp/main/views.py:857
-#: opac/webapp/main/views.py:961
+#: opac/webapp/main/views.py:270 opac/webapp/main/views.py:305
+#: opac/webapp/main/views.py:759 opac/webapp/main/views.py:786
+#: opac/webapp/main/views.py:858 opac/webapp/main/views.py:861
+#: opac/webapp/main/views.py:965
 msgid "Artigo não encontrado"
 msgstr "Artículo no encontrado"
 
-#: opac/webapp/main/views.py:423
+#: opac/webapp/main/views.py:427
 msgid "Artigo sem título"
 msgstr "Artículo sin título"
 
-#: opac/webapp/main/views.py:485 opac/webapp/main/views.py:502
+#: opac/webapp/main/views.py:489 opac/webapp/main/views.py:506
 msgid "Requisição inválida. Deve ser por ajax"
 msgstr "Solicitud no válida. Debe ser por ajax"
 
-#: opac/webapp/main/views.py:518
+#: opac/webapp/main/views.py:522
 msgid ""
 "Parámetro \"filter\" é inválido, deve ser \"areas\", \"wos\" ou "
 "\"publisher\"."
@@ -975,11 +1007,11 @@ msgstr ""
 "Parámetro \"filter\" no es válido, debe ser \"areas\", \"wos\" o "
 "\"publisher\"."
 
-#: opac/webapp/main/views.py:527
+#: opac/webapp/main/views.py:531
 msgid "Parámetro \"extension\" é inválido, deve ser \"csv\" ou \"xls\"."
 msgstr "Parámetro \"extension\" no es válido, debe ser \"csv\" o \"xls\"."
 
-#: opac/webapp/main/views.py:529
+#: opac/webapp/main/views.py:533
 msgid ""
 "Parámetro \"list_type\" é inválido, deve ser: \"alpha\", \"areas\", "
 "\"wos\" ou \"publisher\"."
@@ -987,57 +1019,57 @@ msgstr ""
 "Parámetro \"list_type\" no es válido, debe ser:  \"alpha\", \"areas\", "
 "\"wos\" o \"publisher\"."
 
-#: opac/webapp/main/views.py:550
+#: opac/webapp/main/views.py:554
 msgid "Requisição inválida, deve ser ajax."
 msgstr ""
 
-#: opac/webapp/main/views.py:559
+#: opac/webapp/main/views.py:563
 msgid "Periódico não permite envio de email."
 msgstr "La revista no permite envío de correo electrónico"
 
-#: opac/webapp/main/views.py:577
+#: opac/webapp/main/views.py:581
 msgid "Requisição inválida, captcha inválido."
 msgstr "Solicitud no válida, captcha inválida."
 
-#: opac/webapp/main/views.py:777 opac/webapp/main/views.py:956
+#: opac/webapp/main/views.py:781 opac/webapp/main/views.py:960
 msgid "Issue não encontrado"
 msgstr "Fascículo no encontrado"
 
-#: opac/webapp/main/views.py:814 opac/webapp/main/views.py:820
-#: opac/webapp/main/views.py:993 opac/webapp/main/views.py:1001
-#: opac/webapp/main/views.py:1003
+#: opac/webapp/main/views.py:818 opac/webapp/main/views.py:824
+#: opac/webapp/main/views.py:997 opac/webapp/main/views.py:1005
+#: opac/webapp/main/views.py:1007
 msgid "PDF do Artigo não encontrado"
 msgstr "PDF del artículo no encontrado"
 
-#: opac/webapp/main/views.py:830
+#: opac/webapp/main/views.py:834
 msgid "HTML do Artigo não encontrado"
 msgstr "HTML del artículo no encontrado"
 
-#: opac/webapp/main/views.py:844
+#: opac/webapp/main/views.py:848
 msgid "HTML do Artigo não encontrado ou indisponível"
 msgstr ""
 
-#: opac/webapp/main/views.py:903
+#: opac/webapp/main/views.py:907
 msgid "Parâmetros insuficientes para obter o EPDF do artigo"
 msgstr "Parámetros insuficientes para obtener el EPDF del artículo"
 
-#: opac/webapp/main/views.py:920
+#: opac/webapp/main/views.py:924
 msgid "Recruso não encontrado"
 msgstr ""
 
-#: opac/webapp/main/views.py:925
+#: opac/webapp/main/views.py:929
 msgid "Recurso não encontrado"
 msgstr "Recurso no encontrado"
 
-#: opac/webapp/main/views.py:942
+#: opac/webapp/main/views.py:946
 msgid "Recurso do Artigo não encontrado. Caminho inválido!"
 msgstr "Recurso del Artículo no encontrado. Camino inválido!"
 
-#: opac/webapp/main/views.py:1055
+#: opac/webapp/main/views.py:1059
 msgid "PDF do artigo não foi encontrado"
 msgstr "PDF del artículo no encontrado"
 
-#: opac/webapp/main/views.py:1083 opac/webapp/main/views.py:1114
+#: opac/webapp/main/views.py:1087 opac/webapp/main/views.py:1118
 msgid "Requisição inválida."
 msgstr "Petición inválida."
 
@@ -1374,11 +1406,13 @@ msgid "Versão original do texto"
 msgstr "Versión original del texto"
 
 #: opac/webapp/templates/collection/about.html:23
+#: opac/webapp/templates/collection/pages.html:21
 #, python-format
 msgid " %(page)s "
 msgstr " %(page)s"
 
 #: opac/webapp/templates/collection/about.html:38
+#: opac/webapp/templates/collection/pages.html:36
 msgid " Conteúdo não cadastrado "
 msgstr "Contenido no registrado"
 
@@ -1436,11 +1470,11 @@ msgstr "Temática"
 msgid "Busca por periódicos"
 msgstr "Búsqueda por periódicos"
 
-#: opac/webapp/templates/collection/index.html:93
+#: opac/webapp/templates/collection/index.html:105
 msgid "Números <span>mais recentes</span>"
 msgstr "Números <span>más recientes</span>"
 
-#: opac/webapp/templates/collection/index.html:137
+#: opac/webapp/templates/collection/index.html:149
 msgid "em perspectiva"
 msgstr "en perspectiva"
 
@@ -2028,4 +2062,28 @@ msgstr "Continúe leyendo"
 
 #~ msgid "Citados no"
 #~ msgstr "Citados en"
+
+#~ msgid "AGRICULTURAL SCIENCES"
+#~ msgstr ""
+
+#~ msgid "APPLIED SOCIAL SCIENCES"
+#~ msgstr ""
+
+#~ msgid "BIOLOGICAL SCIENCES"
+#~ msgstr ""
+
+#~ msgid "ENGINEERING"
+#~ msgstr ""
+
+#~ msgid "EXACT AND EARTH SCIENCES"
+#~ msgstr ""
+
+#~ msgid "HEALTH SCIENCES"
+#~ msgstr ""
+
+#~ msgid "HUMAN SCIENCES"
+#~ msgstr ""
+
+#~ msgid "LINGUISTICS, LITERATURE AND ARTS"
+#~ msgstr ""
 

--- a/opac/webapp/translations/es_ES/LC_MESSAGES/messages.po
+++ b/opac/webapp/translations/es_ES/LC_MESSAGES/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-02-08 14:16-0200\n"
+"POT-Creation-Date: 2019-02-15 17:24-0200\n"
 "PO-Revision-Date: 2016-02-09 09:39-0600\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es_ES\n"
@@ -224,6 +224,38 @@ msgstr ""
 
 #: opac/webapp/choices.py:41
 msgid "publicação finalizada"
+msgstr ""
+
+#: opac/webapp/choices.py:45
+msgid "Ciências Agrárias"
+msgstr ""
+
+#: opac/webapp/choices.py:46
+msgid "Ciências Sociais Aplicadas"
+msgstr ""
+
+#: opac/webapp/choices.py:47
+msgid "Ciências Biológicas"
+msgstr ""
+
+#: opac/webapp/choices.py:48
+msgid "Engenharias"
+msgstr ""
+
+#: opac/webapp/choices.py:49
+msgid "Ciências Exatas e da Terra"
+msgstr ""
+
+#: opac/webapp/choices.py:50
+msgid "Ciências da Saúde"
+msgstr ""
+
+#: opac/webapp/choices.py:51
+msgid "Ciências Humanas"
+msgstr ""
+
+#: opac/webapp/choices.py:52 opac/webapp/choices.py:53
+msgid "Lingüística, Letras e Artes"
 msgstr ""
 
 #: opac/webapp/controllers.py:341
@@ -892,134 +924,134 @@ msgstr ""
 msgid "Dados dos campos"
 msgstr ""
 
-#: opac/webapp/main/views.py:28
+#: opac/webapp/main/views.py:29
 msgid "O periódico está indisponível por motivo de: "
 msgstr ""
 
-#: opac/webapp/main/views.py:29
+#: opac/webapp/main/views.py:30
 msgid "O número está indisponível por motivo de: "
 msgstr ""
 
-#: opac/webapp/main/views.py:30
+#: opac/webapp/main/views.py:31
 msgid "O artigo está indisponível por motivo de: "
 msgstr ""
 
-#: opac/webapp/main/views.py:77
+#: opac/webapp/main/views.py:78
 msgid "Código de idioma inválido"
 msgstr ""
 
-#: opac/webapp/main/views.py:147
+#: opac/webapp/main/views.py:148
 msgid "Últimos periódicos inseridos na coleção"
 msgstr ""
 
-#: opac/webapp/main/views.py:148
+#: opac/webapp/main/views.py:149
 #, python-format
 msgid "10 últimos periódicos inseridos na coleção %s"
 msgstr ""
 
-#: opac/webapp/main/views.py:207
+#: opac/webapp/main/views.py:208
 msgid "Página não encontrada"
 msgstr ""
 
-#: opac/webapp/main/views.py:231 opac/webapp/main/views.py:321
+#: opac/webapp/main/views.py:232 opac/webapp/main/views.py:322
 #, python-format
 msgid "Requsição inválida ao tentar acessar o artigo com pid: %s"
 msgstr ""
 
-#: opac/webapp/main/views.py:239 opac/webapp/main/views.py:289
-#: opac/webapp/main/views.py:333 opac/webapp/main/views.py:399
-#: opac/webapp/main/views.py:446 opac/webapp/main/views.py:584
-#: opac/webapp/main/views.py:601 opac/webapp/main/views.py:1028
+#: opac/webapp/main/views.py:240 opac/webapp/main/views.py:290
+#: opac/webapp/main/views.py:334 opac/webapp/main/views.py:403
+#: opac/webapp/main/views.py:450 opac/webapp/main/views.py:588
+#: opac/webapp/main/views.py:605 opac/webapp/main/views.py:1032
 msgid "Periódico não encontrado"
 msgstr ""
 
-#: opac/webapp/main/views.py:251 opac/webapp/main/views.py:651
-#: opac/webapp/main/views.py:707 opac/webapp/main/views.py:1037
+#: opac/webapp/main/views.py:252 opac/webapp/main/views.py:655
+#: opac/webapp/main/views.py:711 opac/webapp/main/views.py:1041
 msgid "Número não encontrado"
 msgstr ""
 
-#: opac/webapp/main/views.py:269 opac/webapp/main/views.py:304
-#: opac/webapp/main/views.py:755 opac/webapp/main/views.py:782
-#: opac/webapp/main/views.py:854 opac/webapp/main/views.py:857
-#: opac/webapp/main/views.py:961
+#: opac/webapp/main/views.py:270 opac/webapp/main/views.py:305
+#: opac/webapp/main/views.py:759 opac/webapp/main/views.py:786
+#: opac/webapp/main/views.py:858 opac/webapp/main/views.py:861
+#: opac/webapp/main/views.py:965
 msgid "Artigo não encontrado"
 msgstr ""
 
-#: opac/webapp/main/views.py:423
+#: opac/webapp/main/views.py:427
 msgid "Artigo sem título"
 msgstr ""
 
-#: opac/webapp/main/views.py:485 opac/webapp/main/views.py:502
+#: opac/webapp/main/views.py:489 opac/webapp/main/views.py:506
 msgid "Requisição inválida. Deve ser por ajax"
 msgstr ""
 
-#: opac/webapp/main/views.py:518
+#: opac/webapp/main/views.py:522
 msgid ""
 "Parámetro \"filter\" é inválido, deve ser \"areas\", \"wos\" ou "
 "\"publisher\"."
 msgstr ""
 
-#: opac/webapp/main/views.py:527
+#: opac/webapp/main/views.py:531
 msgid "Parámetro \"extension\" é inválido, deve ser \"csv\" ou \"xls\"."
 msgstr ""
 
-#: opac/webapp/main/views.py:529
+#: opac/webapp/main/views.py:533
 msgid ""
 "Parámetro \"list_type\" é inválido, deve ser: \"alpha\", \"areas\", "
 "\"wos\" ou \"publisher\"."
 msgstr ""
 
-#: opac/webapp/main/views.py:550
+#: opac/webapp/main/views.py:554
 msgid "Requisição inválida, deve ser ajax."
 msgstr ""
 
-#: opac/webapp/main/views.py:559
+#: opac/webapp/main/views.py:563
 msgid "Periódico não permite envio de email."
 msgstr ""
 
-#: opac/webapp/main/views.py:577
+#: opac/webapp/main/views.py:581
 msgid "Requisição inválida, captcha inválido."
 msgstr ""
 
-#: opac/webapp/main/views.py:777 opac/webapp/main/views.py:956
+#: opac/webapp/main/views.py:781 opac/webapp/main/views.py:960
 msgid "Issue não encontrado"
 msgstr ""
 
-#: opac/webapp/main/views.py:814 opac/webapp/main/views.py:820
-#: opac/webapp/main/views.py:993 opac/webapp/main/views.py:1001
-#: opac/webapp/main/views.py:1003
+#: opac/webapp/main/views.py:818 opac/webapp/main/views.py:824
+#: opac/webapp/main/views.py:997 opac/webapp/main/views.py:1005
+#: opac/webapp/main/views.py:1007
 msgid "PDF do Artigo não encontrado"
 msgstr ""
 
-#: opac/webapp/main/views.py:830
+#: opac/webapp/main/views.py:834
 msgid "HTML do Artigo não encontrado"
 msgstr ""
 
-#: opac/webapp/main/views.py:844
+#: opac/webapp/main/views.py:848
 msgid "HTML do Artigo não encontrado ou indisponível"
 msgstr ""
 
-#: opac/webapp/main/views.py:903
+#: opac/webapp/main/views.py:907
 msgid "Parâmetros insuficientes para obter o EPDF do artigo"
 msgstr ""
 
-#: opac/webapp/main/views.py:920
+#: opac/webapp/main/views.py:924
 msgid "Recruso não encontrado"
 msgstr ""
 
-#: opac/webapp/main/views.py:925
+#: opac/webapp/main/views.py:929
 msgid "Recurso não encontrado"
 msgstr ""
 
-#: opac/webapp/main/views.py:942
+#: opac/webapp/main/views.py:946
 msgid "Recurso do Artigo não encontrado. Caminho inválido!"
 msgstr ""
 
-#: opac/webapp/main/views.py:1055
+#: opac/webapp/main/views.py:1059
 msgid "PDF do artigo não foi encontrado"
 msgstr ""
 
-#: opac/webapp/main/views.py:1083 opac/webapp/main/views.py:1114
+#: opac/webapp/main/views.py:1087 opac/webapp/main/views.py:1118
 msgid "Requisição inválida."
 msgstr ""
 
@@ -1349,11 +1381,13 @@ msgid "Versão original do texto"
 msgstr ""
 
 #: opac/webapp/templates/collection/about.html:23
+#: opac/webapp/templates/collection/pages.html:21
 #, python-format
 msgid " %(page)s "
 msgstr ""
 
 #: opac/webapp/templates/collection/about.html:38
+#: opac/webapp/templates/collection/pages.html:36
 msgid " Conteúdo não cadastrado "
 msgstr ""
 
@@ -1411,11 +1445,11 @@ msgstr ""
 msgid "Busca por periódicos"
 msgstr "Búsqueda por periódicos"
 
-#: opac/webapp/templates/collection/index.html:93
+#: opac/webapp/templates/collection/index.html:105
 msgid "Números <span>mais recentes</span>"
 msgstr "Números <span>más recientes</span>"
 
-#: opac/webapp/templates/collection/index.html:137
+#: opac/webapp/templates/collection/index.html:149
 msgid "em perspectiva"
 msgstr ""
 
@@ -2188,5 +2222,29 @@ msgstr ""
 #~ msgstr ""
 
 #~ msgid "Citados no"
+#~ msgstr ""
+
+#~ msgid "AGRICULTURAL SCIENCES"
+#~ msgstr ""
+
+#~ msgid "APPLIED SOCIAL SCIENCES"
+#~ msgstr ""
+
+#~ msgid "BIOLOGICAL SCIENCES"
+#~ msgstr ""
+
+#~ msgid "ENGINEERING"
+#~ msgstr ""
+
+#~ msgid "EXACT AND EARTH SCIENCES"
+#~ msgstr ""
+
+#~ msgid "HEALTH SCIENCES"
+#~ msgstr ""
+
+#~ msgid "HUMAN SCIENCES"
+#~ msgstr ""
+
+#~ msgid "LINGUISTICS, LITERATURE AND ARTS"
 #~ msgstr ""
 

--- a/opac/webapp/translations/es_MX/LC_MESSAGES/messages.po
+++ b/opac/webapp/translations/es_MX/LC_MESSAGES/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-02-08 14:16-0200\n"
+"POT-Creation-Date: 2019-02-15 17:24-0200\n"
 "PO-Revision-Date: 2016-02-09 09:39-0600\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es_MX\n"
@@ -224,6 +224,38 @@ msgstr ""
 
 #: opac/webapp/choices.py:41
 msgid "publicação finalizada"
+msgstr ""
+
+#: opac/webapp/choices.py:45
+msgid "Ciências Agrárias"
+msgstr ""
+
+#: opac/webapp/choices.py:46
+msgid "Ciências Sociais Aplicadas"
+msgstr ""
+
+#: opac/webapp/choices.py:47
+msgid "Ciências Biológicas"
+msgstr ""
+
+#: opac/webapp/choices.py:48
+msgid "Engenharias"
+msgstr ""
+
+#: opac/webapp/choices.py:49
+msgid "Ciências Exatas e da Terra"
+msgstr ""
+
+#: opac/webapp/choices.py:50
+msgid "Ciências da Saúde"
+msgstr ""
+
+#: opac/webapp/choices.py:51
+msgid "Ciências Humanas"
+msgstr ""
+
+#: opac/webapp/choices.py:52 opac/webapp/choices.py:53
+msgid "Lingüística, Letras e Artes"
 msgstr ""
 
 #: opac/webapp/controllers.py:341
@@ -892,134 +924,134 @@ msgstr ""
 msgid "Dados dos campos"
 msgstr ""
 
-#: opac/webapp/main/views.py:28
+#: opac/webapp/main/views.py:29
 msgid "O periódico está indisponível por motivo de: "
 msgstr ""
 
-#: opac/webapp/main/views.py:29
+#: opac/webapp/main/views.py:30
 msgid "O número está indisponível por motivo de: "
 msgstr ""
 
-#: opac/webapp/main/views.py:30
+#: opac/webapp/main/views.py:31
 msgid "O artigo está indisponível por motivo de: "
 msgstr ""
 
-#: opac/webapp/main/views.py:77
+#: opac/webapp/main/views.py:78
 msgid "Código de idioma inválido"
 msgstr ""
 
-#: opac/webapp/main/views.py:147
+#: opac/webapp/main/views.py:148
 msgid "Últimos periódicos inseridos na coleção"
 msgstr ""
 
-#: opac/webapp/main/views.py:148
+#: opac/webapp/main/views.py:149
 #, python-format
 msgid "10 últimos periódicos inseridos na coleção %s"
 msgstr ""
 
-#: opac/webapp/main/views.py:207
+#: opac/webapp/main/views.py:208
 msgid "Página não encontrada"
 msgstr ""
 
-#: opac/webapp/main/views.py:231 opac/webapp/main/views.py:321
+#: opac/webapp/main/views.py:232 opac/webapp/main/views.py:322
 #, python-format
 msgid "Requsição inválida ao tentar acessar o artigo com pid: %s"
 msgstr ""
 
-#: opac/webapp/main/views.py:239 opac/webapp/main/views.py:289
-#: opac/webapp/main/views.py:333 opac/webapp/main/views.py:399
-#: opac/webapp/main/views.py:446 opac/webapp/main/views.py:584
-#: opac/webapp/main/views.py:601 opac/webapp/main/views.py:1028
+#: opac/webapp/main/views.py:240 opac/webapp/main/views.py:290
+#: opac/webapp/main/views.py:334 opac/webapp/main/views.py:403
+#: opac/webapp/main/views.py:450 opac/webapp/main/views.py:588
+#: opac/webapp/main/views.py:605 opac/webapp/main/views.py:1032
 msgid "Periódico não encontrado"
 msgstr ""
 
-#: opac/webapp/main/views.py:251 opac/webapp/main/views.py:651
-#: opac/webapp/main/views.py:707 opac/webapp/main/views.py:1037
+#: opac/webapp/main/views.py:252 opac/webapp/main/views.py:655
+#: opac/webapp/main/views.py:711 opac/webapp/main/views.py:1041
 msgid "Número não encontrado"
 msgstr ""
 
-#: opac/webapp/main/views.py:269 opac/webapp/main/views.py:304
-#: opac/webapp/main/views.py:755 opac/webapp/main/views.py:782
-#: opac/webapp/main/views.py:854 opac/webapp/main/views.py:857
-#: opac/webapp/main/views.py:961
+#: opac/webapp/main/views.py:270 opac/webapp/main/views.py:305
+#: opac/webapp/main/views.py:759 opac/webapp/main/views.py:786
+#: opac/webapp/main/views.py:858 opac/webapp/main/views.py:861
+#: opac/webapp/main/views.py:965
 msgid "Artigo não encontrado"
 msgstr ""
 
-#: opac/webapp/main/views.py:423
+#: opac/webapp/main/views.py:427
 msgid "Artigo sem título"
 msgstr ""
 
-#: opac/webapp/main/views.py:485 opac/webapp/main/views.py:502
+#: opac/webapp/main/views.py:489 opac/webapp/main/views.py:506
 msgid "Requisição inválida. Deve ser por ajax"
 msgstr ""
 
-#: opac/webapp/main/views.py:518
+#: opac/webapp/main/views.py:522
 msgid ""
 "Parámetro \"filter\" é inválido, deve ser \"areas\", \"wos\" ou "
 "\"publisher\"."
 msgstr ""
 
-#: opac/webapp/main/views.py:527
+#: opac/webapp/main/views.py:531
 msgid "Parámetro \"extension\" é inválido, deve ser \"csv\" ou \"xls\"."
 msgstr ""
 
-#: opac/webapp/main/views.py:529
+#: opac/webapp/main/views.py:533
 msgid ""
 "Parámetro \"list_type\" é inválido, deve ser: \"alpha\", \"areas\", "
 "\"wos\" ou \"publisher\"."
 msgstr ""
 
-#: opac/webapp/main/views.py:550
+#: opac/webapp/main/views.py:554
 msgid "Requisição inválida, deve ser ajax."
 msgstr ""
 
-#: opac/webapp/main/views.py:559
+#: opac/webapp/main/views.py:563
 msgid "Periódico não permite envio de email."
 msgstr ""
 
-#: opac/webapp/main/views.py:577
+#: opac/webapp/main/views.py:581
 msgid "Requisição inválida, captcha inválido."
 msgstr ""
 
-#: opac/webapp/main/views.py:777 opac/webapp/main/views.py:956
+#: opac/webapp/main/views.py:781 opac/webapp/main/views.py:960
 msgid "Issue não encontrado"
 msgstr ""
 
-#: opac/webapp/main/views.py:814 opac/webapp/main/views.py:820
-#: opac/webapp/main/views.py:993 opac/webapp/main/views.py:1001
-#: opac/webapp/main/views.py:1003
+#: opac/webapp/main/views.py:818 opac/webapp/main/views.py:824
+#: opac/webapp/main/views.py:997 opac/webapp/main/views.py:1005
+#: opac/webapp/main/views.py:1007
 msgid "PDF do Artigo não encontrado"
 msgstr ""
 
-#: opac/webapp/main/views.py:830
+#: opac/webapp/main/views.py:834
 msgid "HTML do Artigo não encontrado"
 msgstr ""
 
-#: opac/webapp/main/views.py:844
+#: opac/webapp/main/views.py:848
 msgid "HTML do Artigo não encontrado ou indisponível"
 msgstr ""
 
-#: opac/webapp/main/views.py:903
+#: opac/webapp/main/views.py:907
 msgid "Parâmetros insuficientes para obter o EPDF do artigo"
 msgstr ""
 
-#: opac/webapp/main/views.py:920
+#: opac/webapp/main/views.py:924
 msgid "Recruso não encontrado"
 msgstr ""
 
-#: opac/webapp/main/views.py:925
+#: opac/webapp/main/views.py:929
 msgid "Recurso não encontrado"
 msgstr ""
 
-#: opac/webapp/main/views.py:942
+#: opac/webapp/main/views.py:946
 msgid "Recurso do Artigo não encontrado. Caminho inválido!"
 msgstr ""
 
-#: opac/webapp/main/views.py:1055
+#: opac/webapp/main/views.py:1059
 msgid "PDF do artigo não foi encontrado"
 msgstr ""
 
-#: opac/webapp/main/views.py:1083 opac/webapp/main/views.py:1114
+#: opac/webapp/main/views.py:1087 opac/webapp/main/views.py:1118
 msgid "Requisição inválida."
 msgstr ""
 
@@ -1349,11 +1381,13 @@ msgid "Versão original do texto"
 msgstr ""
 
 #: opac/webapp/templates/collection/about.html:23
+#: opac/webapp/templates/collection/pages.html:21
 #, python-format
 msgid " %(page)s "
 msgstr ""
 
 #: opac/webapp/templates/collection/about.html:38
+#: opac/webapp/templates/collection/pages.html:36
 msgid " Conteúdo não cadastrado "
 msgstr ""
 
@@ -1407,16 +1441,16 @@ msgstr ""
 msgid "Temática"
 msgstr ""
 
-#: opac/webapp/templates/collection/index.html:93
+#: opac/webapp/templates/collection/index.html:77
+msgid "Busca por periódicos"
+msgstr ""
+
+#: opac/webapp/templates/collection/index.html:105
 msgid "Números <span>mais recentes</span>"
 msgstr "Números <span>más recientes</span>"
 
-#: opac/webapp/templates/collection/index.html:137
+#: opac/webapp/templates/collection/index.html:149
 msgid "em perspectiva"
-msgstr ""
-
-#: opac/webapp/templates/collection/index.html:77
-msgid "Busca por periódicos"
 msgstr ""
 
 #: opac/webapp/templates/collection/list_feed_content.html:1
@@ -2188,5 +2222,29 @@ msgstr ""
 #~ msgstr ""
 
 #~ msgid "Citados no"
+#~ msgstr ""
+
+#~ msgid "AGRICULTURAL SCIENCES"
+#~ msgstr ""
+
+#~ msgid "APPLIED SOCIAL SCIENCES"
+#~ msgstr ""
+
+#~ msgid "BIOLOGICAL SCIENCES"
+#~ msgstr ""
+
+#~ msgid "ENGINEERING"
+#~ msgstr ""
+
+#~ msgid "EXACT AND EARTH SCIENCES"
+#~ msgstr ""
+
+#~ msgid "HEALTH SCIENCES"
+#~ msgstr ""
+
+#~ msgid "HUMAN SCIENCES"
+#~ msgstr ""
+
+#~ msgid "LINGUISTICS, LITERATURE AND ARTS"
 #~ msgstr ""
 

--- a/opac/webapp/translations/messages.pot
+++ b/opac/webapp/translations/messages.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-02-08 14:16-0200\n"
+"POT-Creation-Date: 2019-02-15 17:24-0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -222,6 +222,38 @@ msgstr ""
 
 #: opac/webapp/choices.py:41
 msgid "publicação finalizada"
+msgstr ""
+
+#: opac/webapp/choices.py:45
+msgid "Ciências Agrárias"
+msgstr ""
+
+#: opac/webapp/choices.py:46
+msgid "Ciências Sociais Aplicadas"
+msgstr ""
+
+#: opac/webapp/choices.py:47
+msgid "Ciências Biológicas"
+msgstr ""
+
+#: opac/webapp/choices.py:48
+msgid "Engenharias"
+msgstr ""
+
+#: opac/webapp/choices.py:49
+msgid "Ciências Exatas e da Terra"
+msgstr ""
+
+#: opac/webapp/choices.py:50
+msgid "Ciências da Saúde"
+msgstr ""
+
+#: opac/webapp/choices.py:51
+msgid "Ciências Humanas"
+msgstr ""
+
+#: opac/webapp/choices.py:52 opac/webapp/choices.py:53
+msgid "Lingüística, Letras e Artes"
 msgstr ""
 
 #: opac/webapp/controllers.py:341
@@ -890,134 +922,134 @@ msgstr ""
 msgid "Dados dos campos"
 msgstr ""
 
-#: opac/webapp/main/views.py:28
+#: opac/webapp/main/views.py:29
 msgid "O periódico está indisponível por motivo de: "
 msgstr ""
 
-#: opac/webapp/main/views.py:29
+#: opac/webapp/main/views.py:30
 msgid "O número está indisponível por motivo de: "
 msgstr ""
 
-#: opac/webapp/main/views.py:30
+#: opac/webapp/main/views.py:31
 msgid "O artigo está indisponível por motivo de: "
 msgstr ""
 
-#: opac/webapp/main/views.py:77
+#: opac/webapp/main/views.py:78
 msgid "Código de idioma inválido"
 msgstr ""
 
-#: opac/webapp/main/views.py:147
+#: opac/webapp/main/views.py:148
 msgid "Últimos periódicos inseridos na coleção"
 msgstr ""
 
-#: opac/webapp/main/views.py:148
+#: opac/webapp/main/views.py:149
 #, python-format
 msgid "10 últimos periódicos inseridos na coleção %s"
 msgstr ""
 
-#: opac/webapp/main/views.py:207
+#: opac/webapp/main/views.py:208
 msgid "Página não encontrada"
 msgstr ""
 
-#: opac/webapp/main/views.py:231 opac/webapp/main/views.py:321
+#: opac/webapp/main/views.py:232 opac/webapp/main/views.py:322
 #, python-format
 msgid "Requsição inválida ao tentar acessar o artigo com pid: %s"
 msgstr ""
 
-#: opac/webapp/main/views.py:239 opac/webapp/main/views.py:289
-#: opac/webapp/main/views.py:333 opac/webapp/main/views.py:399
-#: opac/webapp/main/views.py:446 opac/webapp/main/views.py:584
-#: opac/webapp/main/views.py:601 opac/webapp/main/views.py:1028
+#: opac/webapp/main/views.py:240 opac/webapp/main/views.py:290
+#: opac/webapp/main/views.py:334 opac/webapp/main/views.py:403
+#: opac/webapp/main/views.py:450 opac/webapp/main/views.py:588
+#: opac/webapp/main/views.py:605 opac/webapp/main/views.py:1032
 msgid "Periódico não encontrado"
 msgstr ""
 
-#: opac/webapp/main/views.py:251 opac/webapp/main/views.py:651
-#: opac/webapp/main/views.py:707 opac/webapp/main/views.py:1037
+#: opac/webapp/main/views.py:252 opac/webapp/main/views.py:655
+#: opac/webapp/main/views.py:711 opac/webapp/main/views.py:1041
 msgid "Número não encontrado"
 msgstr ""
 
-#: opac/webapp/main/views.py:269 opac/webapp/main/views.py:304
-#: opac/webapp/main/views.py:755 opac/webapp/main/views.py:782
-#: opac/webapp/main/views.py:854 opac/webapp/main/views.py:857
-#: opac/webapp/main/views.py:961
+#: opac/webapp/main/views.py:270 opac/webapp/main/views.py:305
+#: opac/webapp/main/views.py:759 opac/webapp/main/views.py:786
+#: opac/webapp/main/views.py:858 opac/webapp/main/views.py:861
+#: opac/webapp/main/views.py:965
 msgid "Artigo não encontrado"
 msgstr ""
 
-#: opac/webapp/main/views.py:423
+#: opac/webapp/main/views.py:427
 msgid "Artigo sem título"
 msgstr ""
 
-#: opac/webapp/main/views.py:485 opac/webapp/main/views.py:502
+#: opac/webapp/main/views.py:489 opac/webapp/main/views.py:506
 msgid "Requisição inválida. Deve ser por ajax"
 msgstr ""
 
-#: opac/webapp/main/views.py:518
+#: opac/webapp/main/views.py:522
 msgid ""
 "Parámetro \"filter\" é inválido, deve ser \"areas\", \"wos\" ou "
 "\"publisher\"."
 msgstr ""
 
-#: opac/webapp/main/views.py:527
+#: opac/webapp/main/views.py:531
 msgid "Parámetro \"extension\" é inválido, deve ser \"csv\" ou \"xls\"."
 msgstr ""
 
-#: opac/webapp/main/views.py:529
+#: opac/webapp/main/views.py:533
 msgid ""
 "Parámetro \"list_type\" é inválido, deve ser: \"alpha\", \"areas\", "
 "\"wos\" ou \"publisher\"."
 msgstr ""
 
-#: opac/webapp/main/views.py:550
+#: opac/webapp/main/views.py:554
 msgid "Requisição inválida, deve ser ajax."
 msgstr ""
 
-#: opac/webapp/main/views.py:559
+#: opac/webapp/main/views.py:563
 msgid "Periódico não permite envio de email."
 msgstr ""
 
-#: opac/webapp/main/views.py:577
+#: opac/webapp/main/views.py:581
 msgid "Requisição inválida, captcha inválido."
 msgstr ""
 
-#: opac/webapp/main/views.py:777 opac/webapp/main/views.py:956
+#: opac/webapp/main/views.py:781 opac/webapp/main/views.py:960
 msgid "Issue não encontrado"
 msgstr ""
 
-#: opac/webapp/main/views.py:814 opac/webapp/main/views.py:820
-#: opac/webapp/main/views.py:993 opac/webapp/main/views.py:1001
-#: opac/webapp/main/views.py:1003
+#: opac/webapp/main/views.py:818 opac/webapp/main/views.py:824
+#: opac/webapp/main/views.py:997 opac/webapp/main/views.py:1005
+#: opac/webapp/main/views.py:1007
 msgid "PDF do Artigo não encontrado"
 msgstr ""
 
-#: opac/webapp/main/views.py:830
+#: opac/webapp/main/views.py:834
 msgid "HTML do Artigo não encontrado"
 msgstr ""
 
-#: opac/webapp/main/views.py:844
+#: opac/webapp/main/views.py:848
 msgid "HTML do Artigo não encontrado ou indisponível"
 msgstr ""
 
-#: opac/webapp/main/views.py:903
+#: opac/webapp/main/views.py:907
 msgid "Parâmetros insuficientes para obter o EPDF do artigo"
 msgstr ""
 
-#: opac/webapp/main/views.py:920
+#: opac/webapp/main/views.py:924
 msgid "Recruso não encontrado"
 msgstr ""
 
-#: opac/webapp/main/views.py:925
+#: opac/webapp/main/views.py:929
 msgid "Recurso não encontrado"
 msgstr ""
 
-#: opac/webapp/main/views.py:942
+#: opac/webapp/main/views.py:946
 msgid "Recurso do Artigo não encontrado. Caminho inválido!"
 msgstr ""
 
-#: opac/webapp/main/views.py:1055
+#: opac/webapp/main/views.py:1059
 msgid "PDF do artigo não foi encontrado"
 msgstr ""
 
-#: opac/webapp/main/views.py:1083 opac/webapp/main/views.py:1114
+#: opac/webapp/main/views.py:1087 opac/webapp/main/views.py:1118
 msgid "Requisição inválida."
 msgstr ""
 
@@ -1347,11 +1379,13 @@ msgid "Versão original do texto"
 msgstr ""
 
 #: opac/webapp/templates/collection/about.html:23
+#: opac/webapp/templates/collection/pages.html:21
 #, python-format
 msgid " %(page)s "
 msgstr ""
 
 #: opac/webapp/templates/collection/about.html:38
+#: opac/webapp/templates/collection/pages.html:36
 msgid " Conteúdo não cadastrado "
 msgstr ""
 
@@ -1405,16 +1439,16 @@ msgstr ""
 msgid "Temática"
 msgstr ""
 
-#: opac/webapp/templates/collection/index.html:93
+#: opac/webapp/templates/collection/index.html:77
+msgid "Busca por periódicos"
+msgstr ""
+
+#: opac/webapp/templates/collection/index.html:105
 msgid "Números <span>mais recentes</span>"
 msgstr ""
 
-#: opac/webapp/templates/collection/index.html:137
+#: opac/webapp/templates/collection/index.html:149
 msgid "em perspectiva"
-msgstr ""
-
-#: opac/webapp/templates/collection/index.html:77
-msgid "Busca por periódicos"
 msgstr ""
 
 #: opac/webapp/templates/collection/list_feed_content.html:1


### PR DESCRIPTION
#### O que esse PR faz?
Traduz as áreas temáticas da home do periódico e remove as "subject categories" (categorias temáticas do WoS)

#### Onde a revisão poderia começar?
opac/webapp/main/views.py, linha 328:
```
@main.route('/journal/<string:url_seg>/')
```

#### Como este poderia ser testado manualmente?
Entrar em páginas home de periódicos e visualizar a localização de "Área:"
Diante de área devem aparecer todas as áreas traduzidas

#### Algum cenário de contexto que queira dar?
As áreas temáticas são constantes já usadas desde o início de SciELO. São as mesmas apresentadas em https://new.scielo.br/journals/#theme
<img width="297" alt="captura de tela 2019-02-14 as 16 52 54" src="https://user-images.githubusercontent.com/505143/52810124-fe2bc180-3078-11e9-9a84-2be490e004ba.png">

As traduções foram definidas em choices.py.
Desde o início houve um erro no código das áreas temáticas. No lugar de LETTER, deveria ser LITERATURE. Por isso, ao traduzir para o inglês, é traduzido como LITERATURE.
#1187 

Durante o processo de resolução desta questão, foi identificado um bug #1201, que é problema ao popular os campos de áreas temáticas e categorias temáticas. Por isso parecerá que esta issue não está resolvida. No entanto, pelos testes, está resolvida.

Resolverá também #1209

### Screenshots
N/A

#### Quais são tickets relevantes?
#1116
#1187 
#1209 


### Referências
N/A

