### PR TITLE
Tratamento de URL do ahead of print na publicação do ex-ahead

### DIFF
--- a/opac/webapp/controllers.py
+++ b/opac/webapp/controllers.py
@@ -762,6 +762,27 @@ def get_article_by_issue_article_seg(iid, url_seg_article, **kwargs):
     return Article.objects(issue=iid, url_segment=url_seg_article, **kwargs).first()
 
 
+def get_article_by_aop_url_segs(jid, url_seg_issue, url_seg_article, **kwargs):
+    """
+    Retorna um artigo considerando os parâmetros ``jid``, ``url_seg_issue``,
+    ``url_seg_article`` e ``kwargs``.
+
+    - ``jid``: string, id do journal;
+    - ``url_seg_issue``: string, segmento do url do fascículo;
+    - ``url_seg_article``: string, segmento do url do artigo;
+    - ``kwargs``: parâmetros de filtragem.
+    """
+    if not (jid and url_seg_issue and url_seg_article):
+        raise ValueError(__('Obrigatório um jid, url_seg_issue and url_seg_article.'))
+
+    aop_url_segs = {
+        "url_seg_article": url_seg_article,
+        "url_seg_issue": url_seg_issue
+    }
+
+    return Article.objects(journal=jid, aop_url_segs=aop_url_segs, **kwargs).first()
+
+
 def get_articles_by_aid(aids):
     """
     Retorna um dicionário de artigos aonde o atributo ``aid`` de cada um deles

--- a/opac/webapp/main/views.py
+++ b/opac/webapp/main/views.py
@@ -752,6 +752,9 @@ def article_detail_pid(pid):
     article = controllers.get_article_by_pid(pid)
 
     if not article:
+        article = controllers.get_article_by_oap_pid(pid)
+
+    if not article:
         abort(404, _('Artigo não encontrado'))
 
     return redirect(url_for('main.article_detail',
@@ -779,7 +782,15 @@ def article_detail(url_seg, url_seg_issue, url_seg_article, lang_code=''):
     article = controllers.get_article_by_issue_article_seg(issue.iid, url_seg_article)
 
     if not article:
-        abort(404, _('Artigo não encontrado'))
+        article = controllers.get_article_by_aop_url_segs(
+            issue.journal, url_seg_issue, url_seg_article
+        )
+        if not article:
+            abort(404, _('Artigo não encontrado'))
+        return redirect(url_for('main.article_detail',
+                                url_seg=article.journal.acronym,
+                                url_seg_issue=article.issue.url_segment,
+                                url_seg_article=article.url_segment))
 
     if lang_code not in article.languages:
         # Se não tem idioma na URL mostra o artigo no idioma original.

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ Flask-Migrate==2.2.1
 unicodecsv==0.14.1
 feedparser==5.2.1
 legendarium==2.0.2
--e git+https://git@github.com/scieloorg/opac_schema@v2.51#egg=opac_schema
+-e git+https://git@github.com/scieloorg/opac_schema@v2.52#egg=opac_schema
 Flask-HTMLmin==1.4.0
 python-slugify==1.2.4
 requests>=2.20.0


### PR DESCRIPTION
#### O que esse PR faz?
- Ajusta a view `article_detail_pid` para, caso não encontrar o artigo
pelo PID, buscar artigos com `aop_pid` com o valor
- Ajustar a view `article_detail` para, caso não encontrar o artigo pelo
`url_segment` do artigo, buscar pelos url_segments de AOP

#### Onde a revisão poderia começar?
Em `opac/webapp/main/views.py`, na view `article_detail`

#### Como este poderia ser testado manualmente?
Tentar acessar um ex-ahead of print que já tenha sido publicado em um fascículo regular mas usando a URL de ahead.

#### Algum cenário de contexto que queira dar?
Detalhes descritos em #937.

### Screenshots
N/A.

#### Quais são tickets relevantes?
#937.

### Referências
Nenhuma.
