### PR TITLE
Adiciona o Altmetric na modal de métricas de artigos

### DIFF
--- a/docker-compose-build.yml
+++ b/docker-compose-build.yml
@@ -53,6 +53,8 @@ services:
             - OPAC_DIMENSIONS_URL=https://badge.dimensions.ai/details/doi
             - OPAC_USE_PLUMX=True
             - OPAC_PLUMX_METRICS_URL=https://plu.mx/scielo/a
+            - OPAC_USE_ALTMETRIC=True
+            - OPAC_ALTMETRIC_METRICS_URL=https://www.altmetric.com/details.php
             - OPAC_CACHE_ENABLED=False
 
 

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -67,6 +67,8 @@ services:
             - OPAC_DIMENSIONS_URL=https://badge.dimensions.ai/details/doi
             - OPAC_USE_PLUMX=True
             - OPAC_PLUMX_METRICS_URL=https://plu.mx/scielo/a
+            - OPAC_USE_ALTMETRIC=True
+            - OPAC_ALTMETRIC_METRICS_URL=https://www.altmetric.com/details.php
             # - OPAC_CACHE_ENABLED=True
             # - OPAC_CACHE_DEFAULT_TIMEOUT=3600
             # - OPAC_CACHE_REDIS_HOST=redis-cache

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,6 +52,8 @@ services:
             - OPAC_DIMENSIONS_URL=https://badge.dimensions.ai/details/doi
             - OPAC_USE_PLUMX=True
             - OPAC_PLUMX_METRICS_URL=https://plu.mx/scielo/a
+            - OPAC_USE_ALTMETRIC=True
+            - OPAC_ALTMETRIC_METRICS_URL=https://www.altmetric.com/details.php
             - OPAC_JOURNAL_PAGES_SOURCE_PATH=/app/data/pages
             - OPAC_JOURNAL_IMAGES_SOURCE_PATH=/app/data/img
 

--- a/opac/webapp/config/default.py
+++ b/opac/webapp/config/default.py
@@ -308,6 +308,10 @@ DIMENSIONS_METRICS_URL = os.environ.get(
 USE_PLUMX = os.environ.get('OPAC_USE_PLUMX', 'False') == 'True'
 PLUMX_METRICS_URL = os.environ.get('OPAC_PLUMX_METRICS_URL', 'https://plu.mx/scielo/a')
 
+
+USE_ALTMETRIC = os.environ.get('OPAC_USE_ALTMETRIC', 'False') == 'True'
+ALTMETRIC_METRICS_URL = os.environ.get('OPAC_ALTMETRIC_METRICS_URL', 'https://www.altmetric.com/details.php')
+
 NEWS_LIST_LIMIT = 10
 
 # paineis do flask-debug-toolbar somente ativos quando DEBUG = True

--- a/opac/webapp/templates/article/base.html
+++ b/opac/webapp/templates/article/base.html
@@ -45,4 +45,8 @@
   <script type="text/javascript" src="{{ url_for('static', filename='js/scielo-article-min.js') }}"></script>
   <script type="text/javascript" src="//badge.dimensions.ai/badge.js" charset="utf-8" async></script>
   <script type="text/javascript" src="//cdn.plu.mx/widget-popup.js"></script>
+
+  {% if config.USE_ALTMETRIC %}
+    <script ype="text/javascript" src="https://d1bxh8uas1mnw7.cloudfront.net/assets/embed.js"></script>
+  {% endif %}
 {% endblock %}

--- a/opac/webapp/templates/includes/metric_modal.html
+++ b/opac/webapp/templates/includes/metric_modal.html
@@ -53,6 +53,23 @@
                             </a>
                         </div>
                         {% endif %}
+
+                        {% if config.USE_ALTMETRIC %}
+                        <div class="badge-link col-center">
+                            <div class="logo-statistc logo-statistc-altmetric">
+                                <div class="badge-logo">
+                                    <div class='altmetric-embed'
+                                         data-badge-type='donut'
+                                         data-doi="{{ article.doi }}"
+                                         data-link-target='_blank'>
+                                    </div>
+                                </div>
+                            </div>
+                            <a target="_blank" href="{{ config.ALTMETRIC_METRICS_URL }}?&doi={{ article.doi }}">
+                                <div>Altmetric</div>
+                            </a>
+                        </div>
+                        {% endif %}
                     {% endif %}
                 {% elif config.USE_METRICS %}
                     <div class="badge-link col-center">


### PR DESCRIPTION
#### O que esse PR faz?
Este pull request adiciona o widget do Altmetric na modal de métricas dos artigos.

#### Onde a revisão poderia começar?
- `./docker-compose.yml`
- `opac/webapp/config/default.py`
- `opac/webapp/templates/includes/metric_modal.html`

#### Como este poderia ser testado manualmente?
- Acessando a página de um artigo
- Clicando no indicador de métricas
- Clicando no ícone do Altmetric

#### Algum cenário de contexto que queira dar?
N/A

### Screenshots

1. Artigo com dados do altmetric
![screen shot 2019-02-20 at 10 19 34 am](https://user-images.githubusercontent.com/4604104/53094531-1ed09d00-34f9-11e9-8035-df39ba1030dc.png)

2. Artigo sem dados do altmetric
![screen shot 2019-02-20 at 10 19 41 am](https://user-images.githubusercontent.com/4604104/53094542-25f7ab00-34f9-11e9-9487-b5db41b3055f.png)


#### Quais são tickets relevantes?
#1131

### Referências
http://api.altmetric.com/embeds.html

