### PR TITLE
Corrige Lista de áreas temáticas

### DIFF
--- a/opac/webapp/controllers.py
+++ b/opac/webapp/controllers.py
@@ -30,7 +30,7 @@ from flask_babelex import lazy_gettext as __
 from flask_mongoengine import Pagination
 from webapp import dbsql
 from .models import User
-from .choices import INDEX_NAME, JOURNAL_STATUS
+from .choices import INDEX_NAME, JOURNAL_STATUS, STUDY_AREAS
 from .utils import utils
 from uuid import uuid4
 
@@ -282,18 +282,14 @@ def get_journals_grouped_by(grouper_field, title_query='', query_filter='', is_p
         if grouper_field_iterable:
             if isinstance(grouper_field_iterable, str):
                 grouper_field_iterable = [grouper_field_iterable]
-        else:
-            continue
-
-        for grouper in grouper_field_iterable:
-
-            if grouper_field == 'index_at':
-                # tentavida de pegar o nome e não a sigla do index
-                # se não achar o nome (KeyError), ficamos com o nome da sigla
-                grouper = INDEX_NAME.get(grouper, grouper)
-
+            grouper_choices = {
+                'index_at': INDEX_NAME,
+                'study_areas': STUDY_AREAS,
+            }
             j_data = get_journal_json_data(journal, lang)
-            groups_dict.setdefault(grouper, []).append(j_data)
+            for grouper in grouper_field_iterable:
+                grouper = grouper_choices.get(grouper_field, {}).get(grouper.upper(), grouper)
+                groups_dict.setdefault(str(grouper), []).append(j_data)
 
     meta = {
         'total': journals.count(),

--- a/opac/webapp/main/views.py
+++ b/opac/webapp/main/views.py
@@ -511,9 +511,9 @@ def journals_search_by_theme_ajax():
     lang = get_lang_from_session()[:2].lower()
 
     if filter == 'areas':
-        objects = controllers.get_journals_grouped_by('subject_categories', query, query_filter=query_filter, lang=lang)
+        objects = controllers.get_journals_grouped_by('study_areas', query, query_filter=query_filter, lang=lang)
     elif filter == 'wos':
-        objects = controllers.get_journals_grouped_by('index_at', query, query_filter=query_filter, lang=lang)
+        objects = controllers.get_journals_grouped_by('subject_categories', query, query_filter=query_filter, lang=lang)
     elif filter == 'publisher':
         objects = controllers.get_journals_grouped_by('publisher_name', query, query_filter=query_filter, lang=lang)
     else:


### PR DESCRIPTION
#### O que esse PR faz?
- Corrige campo para agrupamento de periódicos (áreas temáticas exibia
as categorias de WoS e vice-versa)
- Traduz lista de áreas temáticas de acordo com o idioma selecionado

#### Onde a revisão poderia começar?
Em `opac/webapp/controllers.py`, na função `get_journals_grouped_by`

#### Como este poderia ser testado manualmente?
Ao acessar a lista de periódicos por áreas temáticas, agrupados pelas grandes áreas de conhecimento, lista deve ser exibida com o idioma da interface. Se o idioma for alterado, deve exibir a lista com a tradução correta.

#### Algum cenário de contexto que queira dar?
N/A

### Screenshots
N/A

#### Quais são tickets relevantes?
#1157 

### Referências
Nenhuma.

