### PR TITLE
"Artigos recentes" - apenas periódicos ativos

### DIFF
--- a/opac/webapp/main/views.py
+++ b/opac/webapp/main/views.py
@@ -357,7 +357,7 @@ def journal_detail(url_seg):
 
     # Lista de seções
     # Mantendo sempre o idioma inglês para as seções na página incial do periódico
-    if journal.last_issue:
+    if journal.last_issue and journal.current_status == "current":
         sections = [section for section in journal.last_issue.sections if section.language == 'en']
         recent_articles = controllers.get_recent_articles_of_issue(journal.last_issue.iid, is_public=True)
     else:


### PR DESCRIPTION
#### O que esse PR faz?
- Retorna para a home do periódico as seções e artigos recentes somente
se o periódico estiver ativo

#### Onde a revisão poderia começar?
Em `opac/webapp/main/views.py`

#### Como este poderia ser testado manualmente?
Nenhum periódico listado como descontinuado deve exibir a lista de artigos mais recentes.

#### Algum cenário de contexto que queira dar?
N/A.

### Screenshots
N/A.

#### Quais são tickets relevantes?
#803 

### Referências
Nenhuma.

