### PR TITLE
Exibe imagem dos feeds do blog SciELO

### DIFF
--- a/opac/webapp/templates/news/includes/collection_news_row.html
+++ b/opac/webapp/templates/news/includes/collection_news_row.html
@@ -2,7 +2,11 @@
   <div class="col-md-12">
     <a href="{{ item.url }}" target="_blank">
       <span>{{ item.publication_date|datetimefilter }}</span>
-      <img src="../../static/img/img-post-blog-scielo-exemplo.jpg">
+      {% if item.image_url %}
+          <img src="{{ item.image_url }}">
+      {% else %}
+          <img src="../../static/img/img-post-blog-scielo-exemplo.jpg">
+      {% endif %}
       <h3 class="ellipsis">{{ item.title }}</h3>
       <div class="info">
         <div class="ellipsis">


### PR DESCRIPTION
#### O que esse PR faz?
Exibe imagem dos feeds do blog SciELO, caso existam.

#### Onde a revisão poderia começar?
Em `opac/webapp/templates/news/includes/collection_news_row.html`

#### Como este poderia ser testado manualmente?
Com os feeds atualizados na base de dados, acessar a primeira página e as imagens já devem aparecer.

#### Algum cenário de contexto que queira dar?
É necessário que, através do processamento, os feeds da base de dados do OPAC estejam atualizados. Para isso, é necessário que o OPAC-PROC seja atualizado com as alterações para gravar os feeds com as imagens.

### Screenshots
<img width="1213" alt="Screen Shot 2019-03-11 at 09 03 18" src="https://user-images.githubusercontent.com/18053487/54122789-cd6f4b80-43dc-11e9-8013-6e2e801ac59d.png">

#### Quais são tickets relevantes?
#318 

### Referências
Nenhuma.

