### PR TITLE
Exibir área Multidisciplinar para periódicos com 3 ou mais áreas do conhecimento

### DIFF
--- a/opac/tests/test_interface_journal_home.py
+++ b/opac/tests/test_interface_journal_home.py
@@ -18,12 +18,6 @@ class JournalHomeTestCase(BaseTestCase):
         areas = [
             "Applied Social Sciences",
             "Agricultural Sciences",
-            "Biological Sciences",
-            "Engineering",
-            "Exact and Earth Sciences",
-            "Health Sciences",
-            "Human Sciences",
-            "Linguistics, Letters and Arts",
         ]
         journal = utils.makeOneJournal({'study_areas': areas})
 
@@ -35,7 +29,7 @@ class JournalHomeTestCase(BaseTestCase):
                                          url_seg=journal.url_segment)}
 
             response = c.get(url_for('main.set_locale',
-                                      lang_code='pt_BR'),
+                                     lang_code='pt_BR'),
                              headers=header,
                              follow_redirects=True)
 
@@ -43,7 +37,7 @@ class JournalHomeTestCase(BaseTestCase):
 
             self.assertEqual(flask.session['lang'], 'pt_BR')
             content = response.data.decode('utf-8')
-            expected = "Ciências Sociais Aplicadas, Ciências Agrárias, Ciências"
+            expected = "Ciências Sociais Aplicadas, Ciências Agrárias"
             self.assertIn(expected, content)
 
     def test_journal_detail_subject_areas_with_es_language(self):
@@ -54,12 +48,6 @@ class JournalHomeTestCase(BaseTestCase):
         areas = [
             "Applied Social Sciences",
             "Agricultural Sciences",
-            "Biological Sciences",
-            "Engineering",
-            "Exact and Earth Sciences",
-            "Health Sciences",
-            "Human Sciences",
-            "Linguistics, Letters and Arts",
         ]
         journal = utils.makeOneJournal({'study_areas': areas})
 
@@ -80,7 +68,7 @@ class JournalHomeTestCase(BaseTestCase):
             self.assertEqual(flask.session['lang'], 'es')
 
             content = response.data.decode('utf-8')
-            expected = "Ciencias Sociales Aplicadas, Ciencias Agrícolas,"
+            expected = "Ciencias Sociales Aplicadas, Ciencias Agrícolas"
             self.assertIn(expected, content)
 
     def test_journal_detail_subject_areas_with_en_language(self):
@@ -91,8 +79,37 @@ class JournalHomeTestCase(BaseTestCase):
         areas = [
             "Applied Social Sciences",
             "Agricultural Sciences",
-            "Biological Sciences",
-            "Engineering",
+        ]
+        journal = utils.makeOneJournal({'study_areas': areas})
+
+        with self.client as c:
+            # Criando uma coleção para termos o objeto ``g`` na interface
+            utils.makeOneCollection()
+
+            header = {'Referer': url_for('main.journal_detail',
+                                         url_seg=journal.url_segment)}
+
+            response = c.get(
+                url_for('main.set_locale', lang_code='en'),
+                headers=header,
+                follow_redirects=True)
+
+            self.assertEqual(200, response.status_code)
+
+            self.assertEqual(flask.session['lang'], 'en')
+
+            content = response.data.decode('utf-8')
+            expected = "Applied Social Sciences, Agricultural Sciences"
+
+            self.assertIn(expected, content)
+
+    def test_journal_detail_subject_areas_more_than_three(self):
+        """
+        Teste para verificar se na interface retorna ``Multidiciplinar`` quando a quantidade de areas é maior que 3.
+        """
+        areas = [
+            "Applied Social Sciences",
+            "Agricultural Sciences",
             "Exact and Earth Sciences",
             "Health Sciences",
             "Human Sciences",
@@ -117,7 +134,7 @@ class JournalHomeTestCase(BaseTestCase):
             self.assertEqual(flask.session['lang'], 'en')
 
             content = response.data.decode('utf-8')
-            expected = "Applied Social Sciences, Agricultural Sciences,"
+            expected = "Multidisciplinary"
 
             self.assertIn(expected, content)
 
@@ -452,7 +469,7 @@ class JournalHomeTestCase(BaseTestCase):
                     url_for('main.journal_detail',
                             url_seg=journal.url_segment))
                 response_data = response.data.decode('utf-8')
-                
+
                 expected = 'https://www.scimagojr.com/journalsearch.php?tip=sid&clean=0&q='
                 if '&amp;' in response_data:
                     expected = expected.replace('&', '&amp;')

--- a/opac/webapp/main/views.py
+++ b/opac/webapp/main/views.py
@@ -704,6 +704,9 @@ def issue_toc(url_seg, url_seg_issue):
         'articles': articles,
         'sections': sections,
         'section_filter': section_filter,
+        'journal_study_areas': [
+            STUDY_AREAS.get(study_area.upper()) for study_area in journal.study_areas
+        ],
         # o primiero item da lista é o último número.
         'last_issue': issues[0] if issues else None
     }

--- a/opac/webapp/templates/journal/includes/header.html
+++ b/opac/webapp/templates/journal/includes/header.html
@@ -47,7 +47,11 @@
                 {% trans %}Área:{% endtrans %}
               </span>
               {% if journal_study_areas %}
-                {{ journal_study_areas|join(', ')|title|truncate(60) }}
+                {% if journal_study_areas|length > 3 %}
+                  {% trans %}Multidiciplinar{% endtrans %}
+                {% else %}
+                  {{ journal_study_areas|join(', ')|title|truncate(60) }}
+                {% endif %}
               {% endif %}
             </span>
             <span class="issn">

--- a/opac/webapp/translations/en/LC_MESSAGES/messages.po
+++ b/opac/webapp/translations/en/LC_MESSAGES/messages.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version:  OPAC\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-02-15 17:24-0200\n"
+"POT-Creation-Date: 2019-03-15 11:46+0000\n"
 "PO-Revision-Date: 2018-03-06 19:50+0000\n"
 "Last-Translator: jamil Atta <atta.jamil@gmail.com>\n"
 "Language: en\n"
@@ -262,135 +262,139 @@ msgstr "Human Sciences"
 msgid "Lingüística, Letras e Artes"
 msgstr "Linguistics, Literature and Arts"
 
-#: opac/webapp/controllers.py:341
+#: opac/webapp/controllers.py:353
 msgid "Lista Alfabética"
 msgstr "Alphabetic List"
 
-#: opac/webapp/controllers.py:345
+#: opac/webapp/controllers.py:357
 msgid "Lista Temática"
 msgstr "Thematic List"
 
-#: opac/webapp/controllers.py:349
+#: opac/webapp/controllers.py:361
 msgid "Lista Web of Science"
 msgstr "Web of Science List"
 
-#: opac/webapp/controllers.py:353
+#: opac/webapp/controllers.py:365
 msgid "Lista by Institution"
 msgstr "List by Institution"
 
-#: opac/webapp/controllers.py:412
+#: opac/webapp/controllers.py:424
 msgid "Obrigatório um jid."
 msgstr "A jid is required."
 
-#: opac/webapp/controllers.py:428
+#: opac/webapp/controllers.py:440
 msgid "Obrigatório um acronym."
 msgstr "An acronym is required."
 
-#: opac/webapp/controllers.py:444
+#: opac/webapp/controllers.py:456
 msgid "Obrigatório um url_seg."
 msgstr "A url_seg is required."
 
-#: opac/webapp/controllers.py:460
+#: opac/webapp/controllers.py:472
 msgid "Obrigatório um issn."
 msgstr "ISSN is required."
 
-#: opac/webapp/controllers.py:475
+#: opac/webapp/controllers.py:487
 msgid "Obrigatório um title."
 msgstr ""
 
-#: opac/webapp/controllers.py:513 opac/webapp/controllers.py:657
-#: opac/webapp/controllers.py:797
+#: opac/webapp/controllers.py:525 opac/webapp/controllers.py:669
+#: opac/webapp/controllers.py:830
 msgid "Obrigatório uma lista de ids."
 msgstr "A list of id's is required."
 
-#: opac/webapp/controllers.py:619 opac/webapp/controllers.py:818
+#: opac/webapp/controllers.py:631 opac/webapp/controllers.py:851
 msgid "Obrigatório um iid."
 msgstr "A iid is required."
 
-#: opac/webapp/controllers.py:676
+#: opac/webapp/controllers.py:688
 msgid "Obrigatório um jacron e issue_label."
 msgstr "A jacron and issue_label are required."
 
-#: opac/webapp/controllers.py:689
+#: opac/webapp/controllers.py:701
 msgid "Obrigatório um PID."
 msgstr "PID is required."
 
-#: opac/webapp/controllers.py:705
+#: opac/webapp/controllers.py:717
 msgid "Obrigatório um url_seg e url_seg_issue."
 msgstr "A url_seg and url_seg_issue are required."
 
-#: opac/webapp/controllers.py:712
+#: opac/webapp/controllers.py:724
 msgid "Obrigatório um assets_code."
 msgstr " assets_code is mandatory."
 
-#: opac/webapp/controllers.py:715
+#: opac/webapp/controllers.py:727
 msgid "Obrigatório um journal."
 msgstr "Journal is mandatory."
 
-#: opac/webapp/controllers.py:731
+#: opac/webapp/controllers.py:743
 msgid "Obrigatório um aid."
 msgstr "A aid is required."
 
-#: opac/webapp/controllers.py:745
+#: opac/webapp/controllers.py:757
 msgid "Obrigatório um url_seg_article."
 msgstr "A url_seg_article is required."
 
-#: opac/webapp/controllers.py:760
+#: opac/webapp/controllers.py:772
 msgid "Obrigatório um iid and url_seg_article."
 msgstr "A iid and url_seg_article are required."
 
-#: opac/webapp/controllers.py:856
+#: opac/webapp/controllers.py:788
+msgid "Obrigatório um jid, url_seg_issue and url_seg_article."
+msgstr ""
+
+#: opac/webapp/controllers.py:889
 msgid "Obrigatório um pid."
 msgstr "pid is required."
 
-#: opac/webapp/controllers.py:869
+#: opac/webapp/controllers.py:902
 msgid "Obrigatório um aop_pid."
 msgstr "aop_pid is mandatory."
 
-#: opac/webapp/controllers.py:880
+#: opac/webapp/controllers.py:913
 msgid "Parámetro obrigatório: issue_iid."
 msgstr "issue_iid is mandatory."
 
-#: opac/webapp/controllers.py:928
+#: opac/webapp/controllers.py:961
 msgid "Parâmetro email deve ser uma string"
 msgstr "The parameter \"email\" must be a string."
 
-#: opac/webapp/controllers.py:939
+#: opac/webapp/controllers.py:972
 msgid "Parâmetro email deve ser uma inteiro"
 msgstr "The parameter \"email\" must be an integer."
 
-#: opac/webapp/controllers.py:951 opac/webapp/controllers.py:965
+#: opac/webapp/controllers.py:984 opac/webapp/controllers.py:998
 #, python-format
 msgid "Usuário deve ser do tipo %s"
 msgstr "User must be of type %s"
 
-#: opac/webapp/controllers.py:1021
+#: opac/webapp/controllers.py:1054
 msgid "Compartilhamento de link SciELO"
 msgstr "SciELO link sharing"
 
-#: opac/webapp/controllers.py:1022
+#: opac/webapp/controllers.py:1055
 #, python-format
 msgid "O usuário %s compartilha este link: %s, da SciELO"
 msgstr "The user %s share link: %s, of SciELO"
 
-#: opac/webapp/controllers.py:1030 opac/webapp/controllers.py:1066
-#: opac/webapp/controllers.py:1088
+#: opac/webapp/controllers.py:1063 opac/webapp/controllers.py:1099
+#: opac/webapp/controllers.py:1121
 msgid "Mensagem enviada!"
 msgstr "Message sent!"
 
-#: opac/webapp/controllers.py:1047
+#: opac/webapp/controllers.py:1080
 msgid "[Erro] Erro informado pelo usuário no site SciELO"
 msgstr "[Error] Error informed by the user in the SciELO site"
 
-#: opac/webapp/controllers.py:1050
+#: opac/webapp/controllers.py:1083
 msgid "aplicação"
 msgstr ""
 
-#: opac/webapp/controllers.py:1052
+#: opac/webapp/controllers.py:1085
 msgid "conteúdo"
 msgstr ""
 
-#: opac/webapp/controllers.py:1057
+#: opac/webapp/controllers.py:1090
 #, python-format
 msgid ""
 "O usuário <b>%s</b> com e-mail: <b>%s</b>, informa que existe um erro na "
@@ -401,16 +405,16 @@ msgstr ""
 " %s in the website SciELO.<br><br><b>Title of page:</b> "
 "%s<br><br><b>Link:</b> %s"
 
-#: opac/webapp/controllers.py:1078
+#: opac/webapp/controllers.py:1111
 msgid "Contato de usuário via site SciELO"
 msgstr "User contact by SciELO website"
 
-#: opac/webapp/controllers.py:1080
+#: opac/webapp/controllers.py:1113
 #, python-format
 msgid "O usuário %s, com e-mail: %s, entra em contato com a seguinte mensagem:"
 msgstr "User %s, e-mail: %s, contact us with the following message:"
 
-#: opac/webapp/controllers.py:1112
+#: opac/webapp/controllers.py:1145
 msgid "Obrigatório um slug_name."
 msgstr "An slug_name is required"
 
@@ -971,20 +975,20 @@ msgstr ""
 
 #: opac/webapp/main/views.py:240 opac/webapp/main/views.py:290
 #: opac/webapp/main/views.py:334 opac/webapp/main/views.py:403
-#: opac/webapp/main/views.py:450 opac/webapp/main/views.py:588
-#: opac/webapp/main/views.py:605 opac/webapp/main/views.py:1032
+#: opac/webapp/main/views.py:450 opac/webapp/main/views.py:597
+#: opac/webapp/main/views.py:614 opac/webapp/main/views.py:1055
 msgid "Periódico não encontrado"
 msgstr "Journal not found"
 
-#: opac/webapp/main/views.py:252 opac/webapp/main/views.py:655
-#: opac/webapp/main/views.py:711 opac/webapp/main/views.py:1041
+#: opac/webapp/main/views.py:252 opac/webapp/main/views.py:664
+#: opac/webapp/main/views.py:723 opac/webapp/main/views.py:1064
 msgid "Número não encontrado"
 msgstr "Issue not found"
 
 #: opac/webapp/main/views.py:270 opac/webapp/main/views.py:305
-#: opac/webapp/main/views.py:759 opac/webapp/main/views.py:786
-#: opac/webapp/main/views.py:858 opac/webapp/main/views.py:861
-#: opac/webapp/main/views.py:965
+#: opac/webapp/main/views.py:774 opac/webapp/main/views.py:805
+#: opac/webapp/main/views.py:881 opac/webapp/main/views.py:884
+#: opac/webapp/main/views.py:988
 msgid "Artigo não encontrado"
 msgstr "Article not found"
 
@@ -992,11 +996,11 @@ msgstr "Article not found"
 msgid "Artigo sem título"
 msgstr "Article not found"
 
-#: opac/webapp/main/views.py:489 opac/webapp/main/views.py:506
+#: opac/webapp/main/views.py:498 opac/webapp/main/views.py:515
 msgid "Requisição inválida. Deve ser por ajax"
 msgstr "Invalid request. Must be made via ajax"
 
-#: opac/webapp/main/views.py:522
+#: opac/webapp/main/views.py:531
 msgid ""
 "Parámetro \"filter\" é inválido, deve ser \"areas\", \"wos\" ou "
 "\"publisher\"."
@@ -1004,11 +1008,11 @@ msgstr ""
 "Invalid parameter \"filter\". Should be \"areas\", \"wos\" or "
 "\"publisher\"."
 
-#: opac/webapp/main/views.py:531
+#: opac/webapp/main/views.py:540
 msgid "Parámetro \"extension\" é inválido, deve ser \"csv\" ou \"xls\"."
 msgstr "Invalid parameter \"extension\". Should be \"csv\" or \"xls\"."
 
-#: opac/webapp/main/views.py:533
+#: opac/webapp/main/views.py:542
 msgid ""
 "Parámetro \"list_type\" é inválido, deve ser: \"alpha\", \"areas\", "
 "\"wos\" ou \"publisher\"."
@@ -1016,57 +1020,57 @@ msgstr ""
 "Invalid parameter \"list_type\". Should be: \"alpha\", \"areas\", \"wos\""
 " or \"publisher\"."
 
-#: opac/webapp/main/views.py:554
+#: opac/webapp/main/views.py:563
 msgid "Requisição inválida, deve ser ajax."
 msgstr ""
 
-#: opac/webapp/main/views.py:563
+#: opac/webapp/main/views.py:572
 msgid "Periódico não permite envio de email."
 msgstr ""
 
-#: opac/webapp/main/views.py:581
+#: opac/webapp/main/views.py:590
 msgid "Requisição inválida, captcha inválido."
 msgstr ""
 
-#: opac/webapp/main/views.py:781 opac/webapp/main/views.py:960
+#: opac/webapp/main/views.py:796 opac/webapp/main/views.py:983
 msgid "Issue não encontrado"
 msgstr "Issue not found"
 
-#: opac/webapp/main/views.py:818 opac/webapp/main/views.py:824
-#: opac/webapp/main/views.py:997 opac/webapp/main/views.py:1005
-#: opac/webapp/main/views.py:1007
+#: opac/webapp/main/views.py:841 opac/webapp/main/views.py:847
+#: opac/webapp/main/views.py:1020 opac/webapp/main/views.py:1028
+#: opac/webapp/main/views.py:1030
 msgid "PDF do Artigo não encontrado"
 msgstr "Article's PDF not found"
 
-#: opac/webapp/main/views.py:834
+#: opac/webapp/main/views.py:857
 msgid "HTML do Artigo não encontrado"
 msgstr "HTML of the Article not found"
 
-#: opac/webapp/main/views.py:848
+#: opac/webapp/main/views.py:871
 msgid "HTML do Artigo não encontrado ou indisponível"
 msgstr "HTML of article not found or unavailable"
 
-#: opac/webapp/main/views.py:907
+#: opac/webapp/main/views.py:930
 msgid "Parâmetros insuficientes para obter o EPDF do artigo"
 msgstr "Insufficient parameters to obtain article's EPDF"
 
-#: opac/webapp/main/views.py:924
+#: opac/webapp/main/views.py:947
 msgid "Recruso não encontrado"
 msgstr "Resource not found"
 
-#: opac/webapp/main/views.py:929
+#: opac/webapp/main/views.py:952
 msgid "Recurso não encontrado"
 msgstr "Resource not found"
 
-#: opac/webapp/main/views.py:946
+#: opac/webapp/main/views.py:969
 msgid "Recurso do Artigo não encontrado. Caminho inválido!"
 msgstr "Article resource not found. Invalid path!"
 
-#: opac/webapp/main/views.py:1059
+#: opac/webapp/main/views.py:1082
 msgid "PDF do artigo não foi encontrado"
 msgstr "Article's PDF not found"
 
-#: opac/webapp/main/views.py:1087 opac/webapp/main/views.py:1118
+#: opac/webapp/main/views.py:1110 opac/webapp/main/views.py:1141
 msgid "Requisição inválida."
 msgstr "Invalid request"
 
@@ -1204,7 +1208,7 @@ msgstr "Go to the home page of the collection:"
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:7
 #: opac/webapp/templates/issue/includes/alternative_header.html:121
 #: opac/webapp/templates/journal/includes/alternative_header.html:117
-#: opac/webapp/templates/journal/includes/header.html:117
+#: opac/webapp/templates/journal/includes/header.html:118
 msgid "Submissão de manuscritos"
 msgstr "Submission of manuscripts"
 
@@ -1212,7 +1216,7 @@ msgstr "Submission of manuscripts"
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:16
 #: opac/webapp/templates/issue/includes/alternative_header.html:127
 #: opac/webapp/templates/journal/includes/alternative_header.html:123
-#: opac/webapp/templates/journal/includes/header.html:123
+#: opac/webapp/templates/journal/includes/header.html:124
 msgid "Sobre o periódico"
 msgstr "About the journal"
 
@@ -1220,7 +1224,7 @@ msgstr "About the journal"
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:10
 #: opac/webapp/templates/issue/includes/alternative_header.html:132
 #: opac/webapp/templates/journal/includes/alternative_header.html:128
-#: opac/webapp/templates/journal/includes/header.html:128
+#: opac/webapp/templates/journal/includes/header.html:129
 msgid "Corpo Editorial"
 msgstr "Editorial Board"
 
@@ -1228,7 +1232,7 @@ msgstr "Editorial Board"
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:13
 #: opac/webapp/templates/issue/includes/alternative_header.html:137
 #: opac/webapp/templates/journal/includes/alternative_header.html:133
-#: opac/webapp/templates/journal/includes/header.html:133
+#: opac/webapp/templates/journal/includes/header.html:134
 msgid "Instruções aos autores"
 msgstr "Instructions to authors"
 
@@ -1236,7 +1240,7 @@ msgstr "Instructions to authors"
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:19
 #: opac/webapp/templates/issue/includes/alternative_header.html:142
 #: opac/webapp/templates/journal/includes/alternative_header.html:138
-#: opac/webapp/templates/journal/includes/header.html:139
+#: opac/webapp/templates/journal/includes/header.html:140
 msgid "Contato"
 msgstr "Contact"
 
@@ -1378,9 +1382,9 @@ msgid "Documento sem título"
 msgstr "Untitled document"
 
 #: opac/webapp/templates/article/includes/recent_articles_row.html:13
-#: opac/webapp/templates/news/includes/collection_news_row.html:11
-msgid "continue lendo"
-msgstr "continue reading"
+#: opac/webapp/templates/news/includes/journal_news_row.html:9
+msgid "Continue lendo"
+msgstr "Continue reading"
 
 #: opac/webapp/templates/article/includes/modal/download.html:6
 #: opac/webapp/templates/article/includes/modal/related_article.html:7
@@ -1402,13 +1406,11 @@ msgid "Versão original do texto"
 msgstr ""
 
 #: opac/webapp/templates/collection/about.html:23
-#: opac/webapp/templates/collection/pages.html:21
 #, python-format
 msgid " %(page)s "
 msgstr " %(page)s "
 
 #: opac/webapp/templates/collection/about.html:38
-#: opac/webapp/templates/collection/pages.html:36
 msgid " Conteúdo não cadastrado "
 msgstr "No journal information has been submitted"
 
@@ -1961,23 +1963,27 @@ msgstr "Publication of:"
 msgid "Área:"
 msgstr "Area:"
 
-#: opac/webapp/templates/journal/includes/header.html:59
+#: opac/webapp/templates/journal/includes/header.html:51
+msgid "Multidiciplinar"
+msgstr "Multidisciplinary"
+
+#: opac/webapp/templates/journal/includes/header.html:60
 msgid "Versão impressa ISSN:"
 msgstr "ISSN printed version:"
 
-#: opac/webapp/templates/journal/includes/header.html:66
+#: opac/webapp/templates/journal/includes/header.html:67
 msgid "Versão on-line ISSN:"
 msgstr "ISSN online version:"
 
-#: opac/webapp/templates/journal/includes/header.html:75
+#: opac/webapp/templates/journal/includes/header.html:76
 msgid "Novo título:"
 msgstr "New title:"
 
-#: opac/webapp/templates/journal/includes/header.html:92
+#: opac/webapp/templates/journal/includes/header.html:93
 msgid "Título anterior:"
 msgstr "Previous title"
 
-#: opac/webapp/templates/journal/includes/header.html:147
+#: opac/webapp/templates/journal/includes/header.html:148
 msgid "Siga-nos"
 msgstr "Follow us"
 
@@ -2026,6 +2032,10 @@ msgstr " special issue "
 msgid "número especial"
 msgstr "special issue"
 
+#: opac/webapp/templates/news/includes/collection_news_row.html:11
+msgid "continue lendo"
+msgstr "continue reading"
+
 #: opac/webapp/templates/news/includes/issue_last_row.html:15
 msgid "Suplemento"
 msgstr ""
@@ -2033,10 +2043,6 @@ msgstr ""
 #: opac/webapp/templates/news/includes/issue_last_row.html:20
 msgid "Ver"
 msgstr "Open"
-
-#: opac/webapp/templates/news/includes/journal_news_row.html:8
-msgid "Continue lendo"
-msgstr "Continue reading"
 
 #~ msgid "Periódico não encontrada"
 #~ msgstr "Journal not found"

--- a/opac/webapp/translations/es/LC_MESSAGES/messages.po
+++ b/opac/webapp/translations/es/LC_MESSAGES/messages.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version:  OPAC\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-02-15 17:24-0200\n"
+"POT-Creation-Date: 2019-03-15 11:46+0000\n"
 "PO-Revision-Date: 2018-03-07 00:47+0000\n"
 "Last-Translator: jamil Atta <atta.jamil@gmail.com>\n"
 "Language: es\n"
@@ -263,135 +263,139 @@ msgstr "Humanidades"
 msgid "Lingüística, Letras e Artes"
 msgstr "Linguística, Letras y Artes"
 
-#: opac/webapp/controllers.py:341
+#: opac/webapp/controllers.py:353
 msgid "Lista Alfabética"
 msgstr "Lista Alfabética"
 
-#: opac/webapp/controllers.py:345
+#: opac/webapp/controllers.py:357
 msgid "Lista Temática"
 msgstr "Lista Temática"
 
-#: opac/webapp/controllers.py:349
+#: opac/webapp/controllers.py:361
 msgid "Lista Web of Science"
 msgstr "Lista Web of Science"
 
-#: opac/webapp/controllers.py:353
+#: opac/webapp/controllers.py:365
 msgid "Lista by Institution"
 msgstr "Lista por Institución"
 
-#: opac/webapp/controllers.py:412
+#: opac/webapp/controllers.py:424
 msgid "Obrigatório um jid."
 msgstr "Obligatorio un jid."
 
-#: opac/webapp/controllers.py:428
+#: opac/webapp/controllers.py:440
 msgid "Obrigatório um acronym."
 msgstr "Obligatorio un acronym."
 
-#: opac/webapp/controllers.py:444
+#: opac/webapp/controllers.py:456
 msgid "Obrigatório um url_seg."
 msgstr "Obligatorio un url_seg."
 
-#: opac/webapp/controllers.py:460
+#: opac/webapp/controllers.py:472
 msgid "Obrigatório um issn."
 msgstr "ISSN obligatorio."
 
-#: opac/webapp/controllers.py:475
+#: opac/webapp/controllers.py:487
 msgid "Obrigatório um title."
 msgstr ""
 
-#: opac/webapp/controllers.py:513 opac/webapp/controllers.py:657
-#: opac/webapp/controllers.py:797
+#: opac/webapp/controllers.py:525 opac/webapp/controllers.py:669
+#: opac/webapp/controllers.py:830
 msgid "Obrigatório uma lista de ids."
 msgstr "Obligatorio un listado de ids."
 
-#: opac/webapp/controllers.py:619 opac/webapp/controllers.py:818
+#: opac/webapp/controllers.py:631 opac/webapp/controllers.py:851
 msgid "Obrigatório um iid."
 msgstr "Obligatorio un iid."
 
-#: opac/webapp/controllers.py:676
+#: opac/webapp/controllers.py:688
 msgid "Obrigatório um jacron e issue_label."
 msgstr "Obligatorio un jacron e issue_label."
 
-#: opac/webapp/controllers.py:689
+#: opac/webapp/controllers.py:701
 msgid "Obrigatório um PID."
 msgstr "PID obligatorio."
 
-#: opac/webapp/controllers.py:705
+#: opac/webapp/controllers.py:717
 msgid "Obrigatório um url_seg e url_seg_issue."
 msgstr "Obligatorio un url_seg y url_seg_issue."
 
-#: opac/webapp/controllers.py:712
+#: opac/webapp/controllers.py:724
 msgid "Obrigatório um assets_code."
 msgstr "assets_code es obligatório."
 
-#: opac/webapp/controllers.py:715
+#: opac/webapp/controllers.py:727
 msgid "Obrigatório um journal."
 msgstr "journal es obligatorio."
 
-#: opac/webapp/controllers.py:731
+#: opac/webapp/controllers.py:743
 msgid "Obrigatório um aid."
 msgstr "Obligatorio un aid."
 
-#: opac/webapp/controllers.py:745
+#: opac/webapp/controllers.py:757
 msgid "Obrigatório um url_seg_article."
 msgstr "Obligatorio un url_seg_article."
 
-#: opac/webapp/controllers.py:760
+#: opac/webapp/controllers.py:772
 msgid "Obrigatório um iid and url_seg_article."
 msgstr "Obligatorio un iid and url_seg_article."
 
-#: opac/webapp/controllers.py:856
+#: opac/webapp/controllers.py:788
+msgid "Obrigatório um jid, url_seg_issue and url_seg_article."
+msgstr ""
+
+#: opac/webapp/controllers.py:889
 msgid "Obrigatório um pid."
 msgstr "PID obligatorio."
 
-#: opac/webapp/controllers.py:869
+#: opac/webapp/controllers.py:902
 msgid "Obrigatório um aop_pid."
 msgstr "Obligatorio un aop_pid."
 
-#: opac/webapp/controllers.py:880
+#: opac/webapp/controllers.py:913
 msgid "Parámetro obrigatório: issue_iid."
 msgstr "Parámetro obligatorio: issue_iid."
 
-#: opac/webapp/controllers.py:928
+#: opac/webapp/controllers.py:961
 msgid "Parâmetro email deve ser uma string"
 msgstr "Parámetro email debe ser un string"
 
-#: opac/webapp/controllers.py:939
+#: opac/webapp/controllers.py:972
 msgid "Parâmetro email deve ser uma inteiro"
 msgstr "Parámetro email debe ser un entero"
 
-#: opac/webapp/controllers.py:951 opac/webapp/controllers.py:965
+#: opac/webapp/controllers.py:984 opac/webapp/controllers.py:998
 #, python-format
 msgid "Usuário deve ser do tipo %s"
 msgstr "Usuario debe ser del tipo %s"
 
-#: opac/webapp/controllers.py:1021
+#: opac/webapp/controllers.py:1054
 msgid "Compartilhamento de link SciELO"
 msgstr "Compartir enlace SciELO"
 
-#: opac/webapp/controllers.py:1022
+#: opac/webapp/controllers.py:1055
 #, python-format
 msgid "O usuário %s compartilha este link: %s, da SciELO"
 msgstr "El usuario %s comparte este enlace: %s, de SciELO"
 
-#: opac/webapp/controllers.py:1030 opac/webapp/controllers.py:1066
-#: opac/webapp/controllers.py:1088
+#: opac/webapp/controllers.py:1063 opac/webapp/controllers.py:1099
+#: opac/webapp/controllers.py:1121
 msgid "Mensagem enviada!"
 msgstr "Mensaje enviado!"
 
-#: opac/webapp/controllers.py:1047
+#: opac/webapp/controllers.py:1080
 msgid "[Erro] Erro informado pelo usuário no site SciELO"
 msgstr ""
 
-#: opac/webapp/controllers.py:1050
+#: opac/webapp/controllers.py:1083
 msgid "aplicação"
 msgstr ""
 
-#: opac/webapp/controllers.py:1052
+#: opac/webapp/controllers.py:1085
 msgid "conteúdo"
 msgstr ""
 
-#: opac/webapp/controllers.py:1057
+#: opac/webapp/controllers.py:1090
 #, python-format
 msgid ""
 "O usuário <b>%s</b> com e-mail: <b>%s</b>, informa que existe um erro na "
@@ -402,16 +406,16 @@ msgstr ""
 " en la% s en el sitio SciELO. <br> <br> <b> Título de la página: </ b>% s"
 " <br> <br> <b> Link: </ b% s"
 
-#: opac/webapp/controllers.py:1078
+#: opac/webapp/controllers.py:1111
 msgid "Contato de usuário via site SciELO"
 msgstr "Contacto de usuário por sitio SciELO"
 
-#: opac/webapp/controllers.py:1080
+#: opac/webapp/controllers.py:1113
 #, python-format
 msgid "O usuário %s, com e-mail: %s, entra em contato com a seguinte mensagem:"
 msgstr "El usuario %s, con e-mail: %s, entra en contacto com la siguiente mensaje:"
 
-#: opac/webapp/controllers.py:1112
+#: opac/webapp/controllers.py:1145
 msgid "Obrigatório um slug_name."
 msgstr ""
 
@@ -974,20 +978,20 @@ msgstr "Requiere no válida al intentar tener acceso al artículo con pid:% s"
 
 #: opac/webapp/main/views.py:240 opac/webapp/main/views.py:290
 #: opac/webapp/main/views.py:334 opac/webapp/main/views.py:403
-#: opac/webapp/main/views.py:450 opac/webapp/main/views.py:588
-#: opac/webapp/main/views.py:605 opac/webapp/main/views.py:1032
+#: opac/webapp/main/views.py:450 opac/webapp/main/views.py:597
+#: opac/webapp/main/views.py:614 opac/webapp/main/views.py:1055
 msgid "Periódico não encontrado"
 msgstr "Revista no encontrada"
 
-#: opac/webapp/main/views.py:252 opac/webapp/main/views.py:655
-#: opac/webapp/main/views.py:711 opac/webapp/main/views.py:1041
+#: opac/webapp/main/views.py:252 opac/webapp/main/views.py:664
+#: opac/webapp/main/views.py:723 opac/webapp/main/views.py:1064
 msgid "Número não encontrado"
 msgstr "Fascículo no encontrado"
 
 #: opac/webapp/main/views.py:270 opac/webapp/main/views.py:305
-#: opac/webapp/main/views.py:759 opac/webapp/main/views.py:786
-#: opac/webapp/main/views.py:858 opac/webapp/main/views.py:861
-#: opac/webapp/main/views.py:965
+#: opac/webapp/main/views.py:774 opac/webapp/main/views.py:805
+#: opac/webapp/main/views.py:881 opac/webapp/main/views.py:884
+#: opac/webapp/main/views.py:988
 msgid "Artigo não encontrado"
 msgstr "Artículo no encontrado"
 
@@ -995,11 +999,11 @@ msgstr "Artículo no encontrado"
 msgid "Artigo sem título"
 msgstr "Artículo sin título"
 
-#: opac/webapp/main/views.py:489 opac/webapp/main/views.py:506
+#: opac/webapp/main/views.py:498 opac/webapp/main/views.py:515
 msgid "Requisição inválida. Deve ser por ajax"
 msgstr "Solicitud no válida. Debe ser por ajax"
 
-#: opac/webapp/main/views.py:522
+#: opac/webapp/main/views.py:531
 msgid ""
 "Parámetro \"filter\" é inválido, deve ser \"areas\", \"wos\" ou "
 "\"publisher\"."
@@ -1007,11 +1011,11 @@ msgstr ""
 "Parámetro \"filter\" no es válido, debe ser \"areas\", \"wos\" o "
 "\"publisher\"."
 
-#: opac/webapp/main/views.py:531
+#: opac/webapp/main/views.py:540
 msgid "Parámetro \"extension\" é inválido, deve ser \"csv\" ou \"xls\"."
 msgstr "Parámetro \"extension\" no es válido, debe ser \"csv\" o \"xls\"."
 
-#: opac/webapp/main/views.py:533
+#: opac/webapp/main/views.py:542
 msgid ""
 "Parámetro \"list_type\" é inválido, deve ser: \"alpha\", \"areas\", "
 "\"wos\" ou \"publisher\"."
@@ -1019,57 +1023,57 @@ msgstr ""
 "Parámetro \"list_type\" no es válido, debe ser:  \"alpha\", \"areas\", "
 "\"wos\" o \"publisher\"."
 
-#: opac/webapp/main/views.py:554
+#: opac/webapp/main/views.py:563
 msgid "Requisição inválida, deve ser ajax."
 msgstr ""
 
-#: opac/webapp/main/views.py:563
+#: opac/webapp/main/views.py:572
 msgid "Periódico não permite envio de email."
 msgstr "La revista no permite envío de correo electrónico"
 
-#: opac/webapp/main/views.py:581
+#: opac/webapp/main/views.py:590
 msgid "Requisição inválida, captcha inválido."
 msgstr "Solicitud no válida, captcha inválida."
 
-#: opac/webapp/main/views.py:781 opac/webapp/main/views.py:960
+#: opac/webapp/main/views.py:796 opac/webapp/main/views.py:983
 msgid "Issue não encontrado"
 msgstr "Fascículo no encontrado"
 
-#: opac/webapp/main/views.py:818 opac/webapp/main/views.py:824
-#: opac/webapp/main/views.py:997 opac/webapp/main/views.py:1005
-#: opac/webapp/main/views.py:1007
+#: opac/webapp/main/views.py:841 opac/webapp/main/views.py:847
+#: opac/webapp/main/views.py:1020 opac/webapp/main/views.py:1028
+#: opac/webapp/main/views.py:1030
 msgid "PDF do Artigo não encontrado"
 msgstr "PDF del artículo no encontrado"
 
-#: opac/webapp/main/views.py:834
+#: opac/webapp/main/views.py:857
 msgid "HTML do Artigo não encontrado"
 msgstr "HTML del artículo no encontrado"
 
-#: opac/webapp/main/views.py:848
+#: opac/webapp/main/views.py:871
 msgid "HTML do Artigo não encontrado ou indisponível"
 msgstr ""
 
-#: opac/webapp/main/views.py:907
+#: opac/webapp/main/views.py:930
 msgid "Parâmetros insuficientes para obter o EPDF do artigo"
 msgstr "Parámetros insuficientes para obtener el EPDF del artículo"
 
-#: opac/webapp/main/views.py:924
+#: opac/webapp/main/views.py:947
 msgid "Recruso não encontrado"
 msgstr ""
 
-#: opac/webapp/main/views.py:929
+#: opac/webapp/main/views.py:952
 msgid "Recurso não encontrado"
 msgstr "Recurso no encontrado"
 
-#: opac/webapp/main/views.py:946
+#: opac/webapp/main/views.py:969
 msgid "Recurso do Artigo não encontrado. Caminho inválido!"
 msgstr "Recurso del Artículo no encontrado. Camino inválido!"
 
-#: opac/webapp/main/views.py:1059
+#: opac/webapp/main/views.py:1082
 msgid "PDF do artigo não foi encontrado"
 msgstr "PDF del artículo no encontrado"
 
-#: opac/webapp/main/views.py:1087 opac/webapp/main/views.py:1118
+#: opac/webapp/main/views.py:1110 opac/webapp/main/views.py:1141
 msgid "Requisição inválida."
 msgstr "Petición inválida."
 
@@ -1208,7 +1212,7 @@ msgstr "Ir a la página de inicio de la colección:"
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:7
 #: opac/webapp/templates/issue/includes/alternative_header.html:121
 #: opac/webapp/templates/journal/includes/alternative_header.html:117
-#: opac/webapp/templates/journal/includes/header.html:117
+#: opac/webapp/templates/journal/includes/header.html:118
 msgid "Submissão de manuscritos"
 msgstr "Envío de manuscritos"
 
@@ -1216,7 +1220,7 @@ msgstr "Envío de manuscritos"
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:16
 #: opac/webapp/templates/issue/includes/alternative_header.html:127
 #: opac/webapp/templates/journal/includes/alternative_header.html:123
-#: opac/webapp/templates/journal/includes/header.html:123
+#: opac/webapp/templates/journal/includes/header.html:124
 msgid "Sobre o periódico"
 msgstr "Acerca de la revista"
 
@@ -1224,7 +1228,7 @@ msgstr "Acerca de la revista"
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:10
 #: opac/webapp/templates/issue/includes/alternative_header.html:132
 #: opac/webapp/templates/journal/includes/alternative_header.html:128
-#: opac/webapp/templates/journal/includes/header.html:128
+#: opac/webapp/templates/journal/includes/header.html:129
 msgid "Corpo Editorial"
 msgstr "Cuerpo Editorial"
 
@@ -1232,7 +1236,7 @@ msgstr "Cuerpo Editorial"
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:13
 #: opac/webapp/templates/issue/includes/alternative_header.html:137
 #: opac/webapp/templates/journal/includes/alternative_header.html:133
-#: opac/webapp/templates/journal/includes/header.html:133
+#: opac/webapp/templates/journal/includes/header.html:134
 msgid "Instruções aos autores"
 msgstr "Instrucciones a los autores"
 
@@ -1240,7 +1244,7 @@ msgstr "Instrucciones a los autores"
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:19
 #: opac/webapp/templates/issue/includes/alternative_header.html:142
 #: opac/webapp/templates/journal/includes/alternative_header.html:138
-#: opac/webapp/templates/journal/includes/header.html:139
+#: opac/webapp/templates/journal/includes/header.html:140
 msgid "Contato"
 msgstr "Contacto"
 
@@ -1382,9 +1386,9 @@ msgid "Documento sem título"
 msgstr "Documento sin título"
 
 #: opac/webapp/templates/article/includes/recent_articles_row.html:13
-#: opac/webapp/templates/news/includes/collection_news_row.html:11
-msgid "continue lendo"
-msgstr "seguir leyendo"
+#: opac/webapp/templates/news/includes/journal_news_row.html:9
+msgid "Continue lendo"
+msgstr "Continúe leyendo"
 
 #: opac/webapp/templates/article/includes/modal/download.html:6
 #: opac/webapp/templates/article/includes/modal/related_article.html:7
@@ -1406,13 +1410,11 @@ msgid "Versão original do texto"
 msgstr "Versión original del texto"
 
 #: opac/webapp/templates/collection/about.html:23
-#: opac/webapp/templates/collection/pages.html:21
 #, python-format
 msgid " %(page)s "
 msgstr " %(page)s"
 
 #: opac/webapp/templates/collection/about.html:38
-#: opac/webapp/templates/collection/pages.html:36
 msgid " Conteúdo não cadastrado "
 msgstr "Contenido no registrado"
 
@@ -1963,23 +1965,27 @@ msgstr "Publicación de:"
 msgid "Área:"
 msgstr "Área:"
 
-#: opac/webapp/templates/journal/includes/header.html:59
+#: opac/webapp/templates/journal/includes/header.html:51
+msgid "Multidiciplinar"
+msgstr "Multidisciplinaria"
+
+#: opac/webapp/templates/journal/includes/header.html:60
 msgid "Versão impressa ISSN:"
 msgstr "Versión impresa ISSN:"
 
-#: opac/webapp/templates/journal/includes/header.html:66
+#: opac/webapp/templates/journal/includes/header.html:67
 msgid "Versão on-line ISSN:"
 msgstr "Versión on-line ISSN:"
 
-#: opac/webapp/templates/journal/includes/header.html:75
+#: opac/webapp/templates/journal/includes/header.html:76
 msgid "Novo título:"
 msgstr "Nuevo titulo:"
 
-#: opac/webapp/templates/journal/includes/header.html:92
+#: opac/webapp/templates/journal/includes/header.html:93
 msgid "Título anterior:"
 msgstr "Titulo anterior"
 
-#: opac/webapp/templates/journal/includes/header.html:147
+#: opac/webapp/templates/journal/includes/header.html:148
 msgid "Siga-nos"
 msgstr "Síganos"
 
@@ -2028,6 +2034,10 @@ msgstr ""
 msgid "número especial"
 msgstr ""
 
+#: opac/webapp/templates/news/includes/collection_news_row.html:11
+msgid "continue lendo"
+msgstr "seguir leyendo"
+
 #: opac/webapp/templates/news/includes/issue_last_row.html:15
 msgid "Suplemento"
 msgstr ""
@@ -2035,10 +2045,6 @@ msgstr ""
 #: opac/webapp/templates/news/includes/issue_last_row.html:20
 msgid "Ver"
 msgstr "Ver"
-
-#: opac/webapp/templates/news/includes/journal_news_row.html:8
-msgid "Continue lendo"
-msgstr "Continúe leyendo"
 
 #~ msgid "Periódico não encontrada"
 #~ msgstr "Revista no encontrada"

--- a/opac/webapp/translations/es_ES/LC_MESSAGES/messages.po
+++ b/opac/webapp/translations/es_ES/LC_MESSAGES/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-02-15 17:24-0200\n"
+"POT-Creation-Date: 2019-03-15 11:46+0000\n"
 "PO-Revision-Date: 2016-02-09 09:39-0600\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es_ES\n"
@@ -258,135 +258,139 @@ msgstr ""
 msgid "Lingüística, Letras e Artes"
 msgstr ""
 
-#: opac/webapp/controllers.py:341
+#: opac/webapp/controllers.py:353
 msgid "Lista Alfabética"
 msgstr ""
 
-#: opac/webapp/controllers.py:345
+#: opac/webapp/controllers.py:357
 msgid "Lista Temática"
 msgstr ""
 
-#: opac/webapp/controllers.py:349
+#: opac/webapp/controllers.py:361
 msgid "Lista Web of Science"
 msgstr ""
 
-#: opac/webapp/controllers.py:353
+#: opac/webapp/controllers.py:365
 msgid "Lista by Institution"
 msgstr ""
 
-#: opac/webapp/controllers.py:412
+#: opac/webapp/controllers.py:424
 msgid "Obrigatório um jid."
 msgstr ""
 
-#: opac/webapp/controllers.py:428
+#: opac/webapp/controllers.py:440
 msgid "Obrigatório um acronym."
 msgstr ""
 
-#: opac/webapp/controllers.py:444
+#: opac/webapp/controllers.py:456
 msgid "Obrigatório um url_seg."
 msgstr ""
 
-#: opac/webapp/controllers.py:460
+#: opac/webapp/controllers.py:472
 msgid "Obrigatório um issn."
 msgstr ""
 
-#: opac/webapp/controllers.py:475
+#: opac/webapp/controllers.py:487
 msgid "Obrigatório um title."
 msgstr ""
 
-#: opac/webapp/controllers.py:513 opac/webapp/controllers.py:657
-#: opac/webapp/controllers.py:797
+#: opac/webapp/controllers.py:525 opac/webapp/controllers.py:669
+#: opac/webapp/controllers.py:830
 msgid "Obrigatório uma lista de ids."
 msgstr ""
 
-#: opac/webapp/controllers.py:619 opac/webapp/controllers.py:818
+#: opac/webapp/controllers.py:631 opac/webapp/controllers.py:851
 msgid "Obrigatório um iid."
 msgstr ""
 
-#: opac/webapp/controllers.py:676
+#: opac/webapp/controllers.py:688
 msgid "Obrigatório um jacron e issue_label."
 msgstr ""
 
-#: opac/webapp/controllers.py:689
+#: opac/webapp/controllers.py:701
 msgid "Obrigatório um PID."
 msgstr ""
 
-#: opac/webapp/controllers.py:705
+#: opac/webapp/controllers.py:717
 msgid "Obrigatório um url_seg e url_seg_issue."
 msgstr ""
 
-#: opac/webapp/controllers.py:712
+#: opac/webapp/controllers.py:724
 msgid "Obrigatório um assets_code."
 msgstr ""
 
-#: opac/webapp/controllers.py:715
+#: opac/webapp/controllers.py:727
 msgid "Obrigatório um journal."
 msgstr ""
 
-#: opac/webapp/controllers.py:731
+#: opac/webapp/controllers.py:743
 msgid "Obrigatório um aid."
 msgstr ""
 
-#: opac/webapp/controllers.py:745
+#: opac/webapp/controllers.py:757
 msgid "Obrigatório um url_seg_article."
 msgstr ""
 
-#: opac/webapp/controllers.py:760
+#: opac/webapp/controllers.py:772
 msgid "Obrigatório um iid and url_seg_article."
 msgstr ""
 
-#: opac/webapp/controllers.py:856
+#: opac/webapp/controllers.py:788
+msgid "Obrigatório um jid, url_seg_issue and url_seg_article."
+msgstr ""
+
+#: opac/webapp/controllers.py:889
 msgid "Obrigatório um pid."
 msgstr ""
 
-#: opac/webapp/controllers.py:869
+#: opac/webapp/controllers.py:902
 msgid "Obrigatório um aop_pid."
 msgstr ""
 
-#: opac/webapp/controllers.py:880
+#: opac/webapp/controllers.py:913
 msgid "Parámetro obrigatório: issue_iid."
 msgstr ""
 
-#: opac/webapp/controllers.py:928
+#: opac/webapp/controllers.py:961
 msgid "Parâmetro email deve ser uma string"
 msgstr ""
 
-#: opac/webapp/controllers.py:939
+#: opac/webapp/controllers.py:972
 msgid "Parâmetro email deve ser uma inteiro"
 msgstr ""
 
-#: opac/webapp/controllers.py:951 opac/webapp/controllers.py:965
+#: opac/webapp/controllers.py:984 opac/webapp/controllers.py:998
 #, python-format
 msgid "Usuário deve ser do tipo %s"
 msgstr ""
 
-#: opac/webapp/controllers.py:1021
+#: opac/webapp/controllers.py:1054
 msgid "Compartilhamento de link SciELO"
 msgstr ""
 
-#: opac/webapp/controllers.py:1022
+#: opac/webapp/controllers.py:1055
 #, python-format
 msgid "O usuário %s compartilha este link: %s, da SciELO"
 msgstr ""
 
-#: opac/webapp/controllers.py:1030 opac/webapp/controllers.py:1066
-#: opac/webapp/controllers.py:1088
+#: opac/webapp/controllers.py:1063 opac/webapp/controllers.py:1099
+#: opac/webapp/controllers.py:1121
 msgid "Mensagem enviada!"
 msgstr ""
 
-#: opac/webapp/controllers.py:1047
+#: opac/webapp/controllers.py:1080
 msgid "[Erro] Erro informado pelo usuário no site SciELO"
 msgstr ""
 
-#: opac/webapp/controllers.py:1050
+#: opac/webapp/controllers.py:1083
 msgid "aplicação"
 msgstr ""
 
-#: opac/webapp/controllers.py:1052
+#: opac/webapp/controllers.py:1085
 msgid "conteúdo"
 msgstr ""
 
-#: opac/webapp/controllers.py:1057
+#: opac/webapp/controllers.py:1090
 #, python-format
 msgid ""
 "O usuário <b>%s</b> com e-mail: <b>%s</b>, informa que existe um erro na "
@@ -394,16 +398,16 @@ msgid ""
 " %s"
 msgstr ""
 
-#: opac/webapp/controllers.py:1078
+#: opac/webapp/controllers.py:1111
 msgid "Contato de usuário via site SciELO"
 msgstr ""
 
-#: opac/webapp/controllers.py:1080
+#: opac/webapp/controllers.py:1113
 #, python-format
 msgid "O usuário %s, com e-mail: %s, entra em contato com a seguinte mensagem:"
 msgstr ""
 
-#: opac/webapp/controllers.py:1112
+#: opac/webapp/controllers.py:1145
 msgid "Obrigatório um slug_name."
 msgstr ""
 
@@ -960,20 +964,20 @@ msgstr ""
 
 #: opac/webapp/main/views.py:240 opac/webapp/main/views.py:290
 #: opac/webapp/main/views.py:334 opac/webapp/main/views.py:403
-#: opac/webapp/main/views.py:450 opac/webapp/main/views.py:588
-#: opac/webapp/main/views.py:605 opac/webapp/main/views.py:1032
+#: opac/webapp/main/views.py:450 opac/webapp/main/views.py:597
+#: opac/webapp/main/views.py:614 opac/webapp/main/views.py:1055
 msgid "Periódico não encontrado"
 msgstr ""
 
-#: opac/webapp/main/views.py:252 opac/webapp/main/views.py:655
-#: opac/webapp/main/views.py:711 opac/webapp/main/views.py:1041
+#: opac/webapp/main/views.py:252 opac/webapp/main/views.py:664
+#: opac/webapp/main/views.py:723 opac/webapp/main/views.py:1064
 msgid "Número não encontrado"
 msgstr ""
 
 #: opac/webapp/main/views.py:270 opac/webapp/main/views.py:305
-#: opac/webapp/main/views.py:759 opac/webapp/main/views.py:786
-#: opac/webapp/main/views.py:858 opac/webapp/main/views.py:861
-#: opac/webapp/main/views.py:965
+#: opac/webapp/main/views.py:774 opac/webapp/main/views.py:805
+#: opac/webapp/main/views.py:881 opac/webapp/main/views.py:884
+#: opac/webapp/main/views.py:988
 msgid "Artigo não encontrado"
 msgstr ""
 
@@ -981,77 +985,77 @@ msgstr ""
 msgid "Artigo sem título"
 msgstr ""
 
-#: opac/webapp/main/views.py:489 opac/webapp/main/views.py:506
+#: opac/webapp/main/views.py:498 opac/webapp/main/views.py:515
 msgid "Requisição inválida. Deve ser por ajax"
 msgstr ""
 
-#: opac/webapp/main/views.py:522
+#: opac/webapp/main/views.py:531
 msgid ""
 "Parámetro \"filter\" é inválido, deve ser \"areas\", \"wos\" ou "
 "\"publisher\"."
 msgstr ""
 
-#: opac/webapp/main/views.py:531
+#: opac/webapp/main/views.py:540
 msgid "Parámetro \"extension\" é inválido, deve ser \"csv\" ou \"xls\"."
 msgstr ""
 
-#: opac/webapp/main/views.py:533
+#: opac/webapp/main/views.py:542
 msgid ""
 "Parámetro \"list_type\" é inválido, deve ser: \"alpha\", \"areas\", "
 "\"wos\" ou \"publisher\"."
 msgstr ""
 
-#: opac/webapp/main/views.py:554
+#: opac/webapp/main/views.py:563
 msgid "Requisição inválida, deve ser ajax."
 msgstr ""
 
-#: opac/webapp/main/views.py:563
+#: opac/webapp/main/views.py:572
 msgid "Periódico não permite envio de email."
 msgstr ""
 
-#: opac/webapp/main/views.py:581
+#: opac/webapp/main/views.py:590
 msgid "Requisição inválida, captcha inválido."
 msgstr ""
 
-#: opac/webapp/main/views.py:781 opac/webapp/main/views.py:960
+#: opac/webapp/main/views.py:796 opac/webapp/main/views.py:983
 msgid "Issue não encontrado"
 msgstr ""
 
-#: opac/webapp/main/views.py:818 opac/webapp/main/views.py:824
-#: opac/webapp/main/views.py:997 opac/webapp/main/views.py:1005
-#: opac/webapp/main/views.py:1007
+#: opac/webapp/main/views.py:841 opac/webapp/main/views.py:847
+#: opac/webapp/main/views.py:1020 opac/webapp/main/views.py:1028
+#: opac/webapp/main/views.py:1030
 msgid "PDF do Artigo não encontrado"
 msgstr ""
 
-#: opac/webapp/main/views.py:834
+#: opac/webapp/main/views.py:857
 msgid "HTML do Artigo não encontrado"
 msgstr ""
 
-#: opac/webapp/main/views.py:848
+#: opac/webapp/main/views.py:871
 msgid "HTML do Artigo não encontrado ou indisponível"
 msgstr ""
 
-#: opac/webapp/main/views.py:907
+#: opac/webapp/main/views.py:930
 msgid "Parâmetros insuficientes para obter o EPDF do artigo"
 msgstr ""
 
-#: opac/webapp/main/views.py:924
+#: opac/webapp/main/views.py:947
 msgid "Recruso não encontrado"
 msgstr ""
 
-#: opac/webapp/main/views.py:929
+#: opac/webapp/main/views.py:952
 msgid "Recurso não encontrado"
 msgstr ""
 
-#: opac/webapp/main/views.py:946
+#: opac/webapp/main/views.py:969
 msgid "Recurso do Artigo não encontrado. Caminho inválido!"
 msgstr ""
 
-#: opac/webapp/main/views.py:1059
+#: opac/webapp/main/views.py:1082
 msgid "PDF do artigo não foi encontrado"
 msgstr ""
 
-#: opac/webapp/main/views.py:1087 opac/webapp/main/views.py:1118
+#: opac/webapp/main/views.py:1110 opac/webapp/main/views.py:1141
 msgid "Requisição inválida."
 msgstr ""
 
@@ -1183,7 +1187,7 @@ msgstr ""
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:7
 #: opac/webapp/templates/issue/includes/alternative_header.html:121
 #: opac/webapp/templates/journal/includes/alternative_header.html:117
-#: opac/webapp/templates/journal/includes/header.html:117
+#: opac/webapp/templates/journal/includes/header.html:118
 msgid "Submissão de manuscritos"
 msgstr ""
 
@@ -1191,7 +1195,7 @@ msgstr ""
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:16
 #: opac/webapp/templates/issue/includes/alternative_header.html:127
 #: opac/webapp/templates/journal/includes/alternative_header.html:123
-#: opac/webapp/templates/journal/includes/header.html:123
+#: opac/webapp/templates/journal/includes/header.html:124
 msgid "Sobre o periódico"
 msgstr ""
 
@@ -1199,7 +1203,7 @@ msgstr ""
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:10
 #: opac/webapp/templates/issue/includes/alternative_header.html:132
 #: opac/webapp/templates/journal/includes/alternative_header.html:128
-#: opac/webapp/templates/journal/includes/header.html:128
+#: opac/webapp/templates/journal/includes/header.html:129
 msgid "Corpo Editorial"
 msgstr ""
 
@@ -1207,7 +1211,7 @@ msgstr ""
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:13
 #: opac/webapp/templates/issue/includes/alternative_header.html:137
 #: opac/webapp/templates/journal/includes/alternative_header.html:133
-#: opac/webapp/templates/journal/includes/header.html:133
+#: opac/webapp/templates/journal/includes/header.html:134
 msgid "Instruções aos autores"
 msgstr ""
 
@@ -1215,7 +1219,7 @@ msgstr ""
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:19
 #: opac/webapp/templates/issue/includes/alternative_header.html:142
 #: opac/webapp/templates/journal/includes/alternative_header.html:138
-#: opac/webapp/templates/journal/includes/header.html:139
+#: opac/webapp/templates/journal/includes/header.html:140
 msgid "Contato"
 msgstr ""
 
@@ -1357,8 +1361,8 @@ msgid "Documento sem título"
 msgstr ""
 
 #: opac/webapp/templates/article/includes/recent_articles_row.html:13
-#: opac/webapp/templates/news/includes/collection_news_row.html:11
-msgid "continue lendo"
+#: opac/webapp/templates/news/includes/journal_news_row.html:9
+msgid "Continue lendo"
 msgstr ""
 
 #: opac/webapp/templates/article/includes/modal/download.html:6
@@ -1381,13 +1385,11 @@ msgid "Versão original do texto"
 msgstr ""
 
 #: opac/webapp/templates/collection/about.html:23
-#: opac/webapp/templates/collection/pages.html:21
 #, python-format
 msgid " %(page)s "
 msgstr ""
 
 #: opac/webapp/templates/collection/about.html:38
-#: opac/webapp/templates/collection/pages.html:36
 msgid " Conteúdo não cadastrado "
 msgstr ""
 
@@ -1934,23 +1936,27 @@ msgstr ""
 msgid "Área:"
 msgstr ""
 
-#: opac/webapp/templates/journal/includes/header.html:59
+#: opac/webapp/templates/journal/includes/header.html:51
+msgid "Multidiciplinar"
+msgstr "Multidisciplinaria"
+
+#: opac/webapp/templates/journal/includes/header.html:60
 msgid "Versão impressa ISSN:"
 msgstr ""
 
-#: opac/webapp/templates/journal/includes/header.html:66
+#: opac/webapp/templates/journal/includes/header.html:67
 msgid "Versão on-line ISSN:"
 msgstr ""
 
-#: opac/webapp/templates/journal/includes/header.html:75
+#: opac/webapp/templates/journal/includes/header.html:76
 msgid "Novo título:"
 msgstr ""
 
-#: opac/webapp/templates/journal/includes/header.html:92
+#: opac/webapp/templates/journal/includes/header.html:93
 msgid "Título anterior:"
 msgstr ""
 
-#: opac/webapp/templates/journal/includes/header.html:147
+#: opac/webapp/templates/journal/includes/header.html:148
 msgid "Siga-nos"
 msgstr ""
 
@@ -1999,16 +2005,16 @@ msgstr ""
 msgid "número especial"
 msgstr ""
 
+#: opac/webapp/templates/news/includes/collection_news_row.html:11
+msgid "continue lendo"
+msgstr ""
+
 #: opac/webapp/templates/news/includes/issue_last_row.html:15
 msgid "Suplemento"
 msgstr ""
 
 #: opac/webapp/templates/news/includes/issue_last_row.html:20
 msgid "Ver"
-msgstr ""
-
-#: opac/webapp/templates/news/includes/journal_news_row.html:8
-msgid "Continue lendo"
 msgstr ""
 
 #~ msgid "Fascículo"

--- a/opac/webapp/translations/es_MX/LC_MESSAGES/messages.po
+++ b/opac/webapp/translations/es_MX/LC_MESSAGES/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-02-15 17:24-0200\n"
+"POT-Creation-Date: 2019-03-15 11:46+0000\n"
 "PO-Revision-Date: 2016-02-09 09:39-0600\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es_MX\n"
@@ -258,135 +258,139 @@ msgstr ""
 msgid "Lingüística, Letras e Artes"
 msgstr ""
 
-#: opac/webapp/controllers.py:341
+#: opac/webapp/controllers.py:353
 msgid "Lista Alfabética"
 msgstr ""
 
-#: opac/webapp/controllers.py:345
+#: opac/webapp/controllers.py:357
 msgid "Lista Temática"
 msgstr ""
 
-#: opac/webapp/controllers.py:349
+#: opac/webapp/controllers.py:361
 msgid "Lista Web of Science"
 msgstr ""
 
-#: opac/webapp/controllers.py:353
+#: opac/webapp/controllers.py:365
 msgid "Lista by Institution"
 msgstr ""
 
-#: opac/webapp/controllers.py:412
+#: opac/webapp/controllers.py:424
 msgid "Obrigatório um jid."
 msgstr ""
 
-#: opac/webapp/controllers.py:428
+#: opac/webapp/controllers.py:440
 msgid "Obrigatório um acronym."
 msgstr ""
 
-#: opac/webapp/controllers.py:444
+#: opac/webapp/controllers.py:456
 msgid "Obrigatório um url_seg."
 msgstr ""
 
-#: opac/webapp/controllers.py:460
+#: opac/webapp/controllers.py:472
 msgid "Obrigatório um issn."
 msgstr ""
 
-#: opac/webapp/controllers.py:475
+#: opac/webapp/controllers.py:487
 msgid "Obrigatório um title."
 msgstr ""
 
-#: opac/webapp/controllers.py:513 opac/webapp/controllers.py:657
-#: opac/webapp/controllers.py:797
+#: opac/webapp/controllers.py:525 opac/webapp/controllers.py:669
+#: opac/webapp/controllers.py:830
 msgid "Obrigatório uma lista de ids."
 msgstr ""
 
-#: opac/webapp/controllers.py:619 opac/webapp/controllers.py:818
+#: opac/webapp/controllers.py:631 opac/webapp/controllers.py:851
 msgid "Obrigatório um iid."
 msgstr ""
 
-#: opac/webapp/controllers.py:676
+#: opac/webapp/controllers.py:688
 msgid "Obrigatório um jacron e issue_label."
 msgstr ""
 
-#: opac/webapp/controllers.py:689
+#: opac/webapp/controllers.py:701
 msgid "Obrigatório um PID."
 msgstr ""
 
-#: opac/webapp/controllers.py:705
+#: opac/webapp/controllers.py:717
 msgid "Obrigatório um url_seg e url_seg_issue."
 msgstr ""
 
-#: opac/webapp/controllers.py:712
+#: opac/webapp/controllers.py:724
 msgid "Obrigatório um assets_code."
 msgstr ""
 
-#: opac/webapp/controllers.py:715
+#: opac/webapp/controllers.py:727
 msgid "Obrigatório um journal."
 msgstr ""
 
-#: opac/webapp/controllers.py:731
+#: opac/webapp/controllers.py:743
 msgid "Obrigatório um aid."
 msgstr ""
 
-#: opac/webapp/controllers.py:745
+#: opac/webapp/controllers.py:757
 msgid "Obrigatório um url_seg_article."
 msgstr ""
 
-#: opac/webapp/controllers.py:760
+#: opac/webapp/controllers.py:772
 msgid "Obrigatório um iid and url_seg_article."
 msgstr ""
 
-#: opac/webapp/controllers.py:856
+#: opac/webapp/controllers.py:788
+msgid "Obrigatório um jid, url_seg_issue and url_seg_article."
+msgstr ""
+
+#: opac/webapp/controllers.py:889
 msgid "Obrigatório um pid."
 msgstr ""
 
-#: opac/webapp/controllers.py:869
+#: opac/webapp/controllers.py:902
 msgid "Obrigatório um aop_pid."
 msgstr ""
 
-#: opac/webapp/controllers.py:880
+#: opac/webapp/controllers.py:913
 msgid "Parámetro obrigatório: issue_iid."
 msgstr ""
 
-#: opac/webapp/controllers.py:928
+#: opac/webapp/controllers.py:961
 msgid "Parâmetro email deve ser uma string"
 msgstr ""
 
-#: opac/webapp/controllers.py:939
+#: opac/webapp/controllers.py:972
 msgid "Parâmetro email deve ser uma inteiro"
 msgstr ""
 
-#: opac/webapp/controllers.py:951 opac/webapp/controllers.py:965
+#: opac/webapp/controllers.py:984 opac/webapp/controllers.py:998
 #, python-format
 msgid "Usuário deve ser do tipo %s"
 msgstr ""
 
-#: opac/webapp/controllers.py:1021
+#: opac/webapp/controllers.py:1054
 msgid "Compartilhamento de link SciELO"
 msgstr ""
 
-#: opac/webapp/controllers.py:1022
+#: opac/webapp/controllers.py:1055
 #, python-format
 msgid "O usuário %s compartilha este link: %s, da SciELO"
 msgstr ""
 
-#: opac/webapp/controllers.py:1030 opac/webapp/controllers.py:1066
-#: opac/webapp/controllers.py:1088
+#: opac/webapp/controllers.py:1063 opac/webapp/controllers.py:1099
+#: opac/webapp/controllers.py:1121
 msgid "Mensagem enviada!"
 msgstr ""
 
-#: opac/webapp/controllers.py:1047
+#: opac/webapp/controllers.py:1080
 msgid "[Erro] Erro informado pelo usuário no site SciELO"
 msgstr ""
 
-#: opac/webapp/controllers.py:1050
+#: opac/webapp/controllers.py:1083
 msgid "aplicação"
 msgstr ""
 
-#: opac/webapp/controllers.py:1052
+#: opac/webapp/controllers.py:1085
 msgid "conteúdo"
 msgstr ""
 
-#: opac/webapp/controllers.py:1057
+#: opac/webapp/controllers.py:1090
 #, python-format
 msgid ""
 "O usuário <b>%s</b> com e-mail: <b>%s</b>, informa que existe um erro na "
@@ -394,16 +398,16 @@ msgid ""
 " %s"
 msgstr ""
 
-#: opac/webapp/controllers.py:1078
+#: opac/webapp/controllers.py:1111
 msgid "Contato de usuário via site SciELO"
 msgstr ""
 
-#: opac/webapp/controllers.py:1080
+#: opac/webapp/controllers.py:1113
 #, python-format
 msgid "O usuário %s, com e-mail: %s, entra em contato com a seguinte mensagem:"
 msgstr ""
 
-#: opac/webapp/controllers.py:1112
+#: opac/webapp/controllers.py:1145
 msgid "Obrigatório um slug_name."
 msgstr ""
 
@@ -960,20 +964,20 @@ msgstr ""
 
 #: opac/webapp/main/views.py:240 opac/webapp/main/views.py:290
 #: opac/webapp/main/views.py:334 opac/webapp/main/views.py:403
-#: opac/webapp/main/views.py:450 opac/webapp/main/views.py:588
-#: opac/webapp/main/views.py:605 opac/webapp/main/views.py:1032
+#: opac/webapp/main/views.py:450 opac/webapp/main/views.py:597
+#: opac/webapp/main/views.py:614 opac/webapp/main/views.py:1055
 msgid "Periódico não encontrado"
 msgstr ""
 
-#: opac/webapp/main/views.py:252 opac/webapp/main/views.py:655
-#: opac/webapp/main/views.py:711 opac/webapp/main/views.py:1041
+#: opac/webapp/main/views.py:252 opac/webapp/main/views.py:664
+#: opac/webapp/main/views.py:723 opac/webapp/main/views.py:1064
 msgid "Número não encontrado"
 msgstr ""
 
 #: opac/webapp/main/views.py:270 opac/webapp/main/views.py:305
-#: opac/webapp/main/views.py:759 opac/webapp/main/views.py:786
-#: opac/webapp/main/views.py:858 opac/webapp/main/views.py:861
-#: opac/webapp/main/views.py:965
+#: opac/webapp/main/views.py:774 opac/webapp/main/views.py:805
+#: opac/webapp/main/views.py:881 opac/webapp/main/views.py:884
+#: opac/webapp/main/views.py:988
 msgid "Artigo não encontrado"
 msgstr ""
 
@@ -981,77 +985,77 @@ msgstr ""
 msgid "Artigo sem título"
 msgstr ""
 
-#: opac/webapp/main/views.py:489 opac/webapp/main/views.py:506
+#: opac/webapp/main/views.py:498 opac/webapp/main/views.py:515
 msgid "Requisição inválida. Deve ser por ajax"
 msgstr ""
 
-#: opac/webapp/main/views.py:522
+#: opac/webapp/main/views.py:531
 msgid ""
 "Parámetro \"filter\" é inválido, deve ser \"areas\", \"wos\" ou "
 "\"publisher\"."
 msgstr ""
 
-#: opac/webapp/main/views.py:531
+#: opac/webapp/main/views.py:540
 msgid "Parámetro \"extension\" é inválido, deve ser \"csv\" ou \"xls\"."
 msgstr ""
 
-#: opac/webapp/main/views.py:533
+#: opac/webapp/main/views.py:542
 msgid ""
 "Parámetro \"list_type\" é inválido, deve ser: \"alpha\", \"areas\", "
 "\"wos\" ou \"publisher\"."
 msgstr ""
 
-#: opac/webapp/main/views.py:554
+#: opac/webapp/main/views.py:563
 msgid "Requisição inválida, deve ser ajax."
 msgstr ""
 
-#: opac/webapp/main/views.py:563
+#: opac/webapp/main/views.py:572
 msgid "Periódico não permite envio de email."
 msgstr ""
 
-#: opac/webapp/main/views.py:581
+#: opac/webapp/main/views.py:590
 msgid "Requisição inválida, captcha inválido."
 msgstr ""
 
-#: opac/webapp/main/views.py:781 opac/webapp/main/views.py:960
+#: opac/webapp/main/views.py:796 opac/webapp/main/views.py:983
 msgid "Issue não encontrado"
 msgstr ""
 
-#: opac/webapp/main/views.py:818 opac/webapp/main/views.py:824
-#: opac/webapp/main/views.py:997 opac/webapp/main/views.py:1005
-#: opac/webapp/main/views.py:1007
+#: opac/webapp/main/views.py:841 opac/webapp/main/views.py:847
+#: opac/webapp/main/views.py:1020 opac/webapp/main/views.py:1028
+#: opac/webapp/main/views.py:1030
 msgid "PDF do Artigo não encontrado"
 msgstr ""
 
-#: opac/webapp/main/views.py:834
+#: opac/webapp/main/views.py:857
 msgid "HTML do Artigo não encontrado"
 msgstr ""
 
-#: opac/webapp/main/views.py:848
+#: opac/webapp/main/views.py:871
 msgid "HTML do Artigo não encontrado ou indisponível"
 msgstr ""
 
-#: opac/webapp/main/views.py:907
+#: opac/webapp/main/views.py:930
 msgid "Parâmetros insuficientes para obter o EPDF do artigo"
 msgstr ""
 
-#: opac/webapp/main/views.py:924
+#: opac/webapp/main/views.py:947
 msgid "Recruso não encontrado"
 msgstr ""
 
-#: opac/webapp/main/views.py:929
+#: opac/webapp/main/views.py:952
 msgid "Recurso não encontrado"
 msgstr ""
 
-#: opac/webapp/main/views.py:946
+#: opac/webapp/main/views.py:969
 msgid "Recurso do Artigo não encontrado. Caminho inválido!"
 msgstr ""
 
-#: opac/webapp/main/views.py:1059
+#: opac/webapp/main/views.py:1082
 msgid "PDF do artigo não foi encontrado"
 msgstr ""
 
-#: opac/webapp/main/views.py:1087 opac/webapp/main/views.py:1118
+#: opac/webapp/main/views.py:1110 opac/webapp/main/views.py:1141
 msgid "Requisição inválida."
 msgstr ""
 
@@ -1183,7 +1187,7 @@ msgstr ""
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:7
 #: opac/webapp/templates/issue/includes/alternative_header.html:121
 #: opac/webapp/templates/journal/includes/alternative_header.html:117
-#: opac/webapp/templates/journal/includes/header.html:117
+#: opac/webapp/templates/journal/includes/header.html:118
 msgid "Submissão de manuscritos"
 msgstr ""
 
@@ -1191,7 +1195,7 @@ msgstr ""
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:16
 #: opac/webapp/templates/issue/includes/alternative_header.html:127
 #: opac/webapp/templates/journal/includes/alternative_header.html:123
-#: opac/webapp/templates/journal/includes/header.html:123
+#: opac/webapp/templates/journal/includes/header.html:124
 msgid "Sobre o periódico"
 msgstr ""
 
@@ -1199,7 +1203,7 @@ msgstr ""
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:10
 #: opac/webapp/templates/issue/includes/alternative_header.html:132
 #: opac/webapp/templates/journal/includes/alternative_header.html:128
-#: opac/webapp/templates/journal/includes/header.html:128
+#: opac/webapp/templates/journal/includes/header.html:129
 msgid "Corpo Editorial"
 msgstr ""
 
@@ -1207,7 +1211,7 @@ msgstr ""
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:13
 #: opac/webapp/templates/issue/includes/alternative_header.html:137
 #: opac/webapp/templates/journal/includes/alternative_header.html:133
-#: opac/webapp/templates/journal/includes/header.html:133
+#: opac/webapp/templates/journal/includes/header.html:134
 msgid "Instruções aos autores"
 msgstr ""
 
@@ -1215,7 +1219,7 @@ msgstr ""
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:19
 #: opac/webapp/templates/issue/includes/alternative_header.html:142
 #: opac/webapp/templates/journal/includes/alternative_header.html:138
-#: opac/webapp/templates/journal/includes/header.html:139
+#: opac/webapp/templates/journal/includes/header.html:140
 msgid "Contato"
 msgstr ""
 
@@ -1357,8 +1361,8 @@ msgid "Documento sem título"
 msgstr ""
 
 #: opac/webapp/templates/article/includes/recent_articles_row.html:13
-#: opac/webapp/templates/news/includes/collection_news_row.html:11
-msgid "continue lendo"
+#: opac/webapp/templates/news/includes/journal_news_row.html:9
+msgid "Continue lendo"
 msgstr ""
 
 #: opac/webapp/templates/article/includes/modal/download.html:6
@@ -1381,13 +1385,11 @@ msgid "Versão original do texto"
 msgstr ""
 
 #: opac/webapp/templates/collection/about.html:23
-#: opac/webapp/templates/collection/pages.html:21
 #, python-format
 msgid " %(page)s "
 msgstr ""
 
 #: opac/webapp/templates/collection/about.html:38
-#: opac/webapp/templates/collection/pages.html:36
 msgid " Conteúdo não cadastrado "
 msgstr ""
 
@@ -1934,23 +1936,27 @@ msgstr ""
 msgid "Área:"
 msgstr ""
 
-#: opac/webapp/templates/journal/includes/header.html:59
+#: opac/webapp/templates/journal/includes/header.html:51
+msgid "Multidiciplinar"
+msgstr ""
+
+#: opac/webapp/templates/journal/includes/header.html:60
 msgid "Versão impressa ISSN:"
 msgstr ""
 
-#: opac/webapp/templates/journal/includes/header.html:66
+#: opac/webapp/templates/journal/includes/header.html:67
 msgid "Versão on-line ISSN:"
 msgstr ""
 
-#: opac/webapp/templates/journal/includes/header.html:75
+#: opac/webapp/templates/journal/includes/header.html:76
 msgid "Novo título:"
 msgstr ""
 
-#: opac/webapp/templates/journal/includes/header.html:92
+#: opac/webapp/templates/journal/includes/header.html:93
 msgid "Título anterior:"
 msgstr ""
 
-#: opac/webapp/templates/journal/includes/header.html:147
+#: opac/webapp/templates/journal/includes/header.html:148
 msgid "Siga-nos"
 msgstr ""
 
@@ -1999,16 +2005,16 @@ msgstr ""
 msgid "número especial"
 msgstr ""
 
+#: opac/webapp/templates/news/includes/collection_news_row.html:11
+msgid "continue lendo"
+msgstr ""
+
 #: opac/webapp/templates/news/includes/issue_last_row.html:15
 msgid "Suplemento"
 msgstr ""
 
 #: opac/webapp/templates/news/includes/issue_last_row.html:20
 msgid "Ver"
-msgstr ""
-
-#: opac/webapp/templates/news/includes/journal_news_row.html:8
-msgid "Continue lendo"
 msgstr ""
 
 #~ msgid "Fascículo"

--- a/opac/webapp/translations/messages.pot
+++ b/opac/webapp/translations/messages.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-02-15 17:24-0200\n"
+"POT-Creation-Date: 2019-03-15 11:46+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -256,135 +256,139 @@ msgstr ""
 msgid "Lingüística, Letras e Artes"
 msgstr ""
 
-#: opac/webapp/controllers.py:341
+#: opac/webapp/controllers.py:353
 msgid "Lista Alfabética"
 msgstr ""
 
-#: opac/webapp/controllers.py:345
+#: opac/webapp/controllers.py:357
 msgid "Lista Temática"
 msgstr ""
 
-#: opac/webapp/controllers.py:349
+#: opac/webapp/controllers.py:361
 msgid "Lista Web of Science"
 msgstr ""
 
-#: opac/webapp/controllers.py:353
+#: opac/webapp/controllers.py:365
 msgid "Lista by Institution"
 msgstr ""
 
-#: opac/webapp/controllers.py:412
+#: opac/webapp/controllers.py:424
 msgid "Obrigatório um jid."
 msgstr ""
 
-#: opac/webapp/controllers.py:428
+#: opac/webapp/controllers.py:440
 msgid "Obrigatório um acronym."
 msgstr ""
 
-#: opac/webapp/controllers.py:444
+#: opac/webapp/controllers.py:456
 msgid "Obrigatório um url_seg."
 msgstr ""
 
-#: opac/webapp/controllers.py:460
+#: opac/webapp/controllers.py:472
 msgid "Obrigatório um issn."
 msgstr ""
 
-#: opac/webapp/controllers.py:475
+#: opac/webapp/controllers.py:487
 msgid "Obrigatório um title."
 msgstr ""
 
-#: opac/webapp/controllers.py:513 opac/webapp/controllers.py:657
-#: opac/webapp/controllers.py:797
+#: opac/webapp/controllers.py:525 opac/webapp/controllers.py:669
+#: opac/webapp/controllers.py:830
 msgid "Obrigatório uma lista de ids."
 msgstr ""
 
-#: opac/webapp/controllers.py:619 opac/webapp/controllers.py:818
+#: opac/webapp/controllers.py:631 opac/webapp/controllers.py:851
 msgid "Obrigatório um iid."
 msgstr ""
 
-#: opac/webapp/controllers.py:676
+#: opac/webapp/controllers.py:688
 msgid "Obrigatório um jacron e issue_label."
 msgstr ""
 
-#: opac/webapp/controllers.py:689
+#: opac/webapp/controllers.py:701
 msgid "Obrigatório um PID."
 msgstr ""
 
-#: opac/webapp/controllers.py:705
+#: opac/webapp/controllers.py:717
 msgid "Obrigatório um url_seg e url_seg_issue."
 msgstr ""
 
-#: opac/webapp/controllers.py:712
+#: opac/webapp/controllers.py:724
 msgid "Obrigatório um assets_code."
 msgstr ""
 
-#: opac/webapp/controllers.py:715
+#: opac/webapp/controllers.py:727
 msgid "Obrigatório um journal."
 msgstr ""
 
-#: opac/webapp/controllers.py:731
+#: opac/webapp/controllers.py:743
 msgid "Obrigatório um aid."
 msgstr ""
 
-#: opac/webapp/controllers.py:745
+#: opac/webapp/controllers.py:757
 msgid "Obrigatório um url_seg_article."
 msgstr ""
 
-#: opac/webapp/controllers.py:760
+#: opac/webapp/controllers.py:772
 msgid "Obrigatório um iid and url_seg_article."
 msgstr ""
 
-#: opac/webapp/controllers.py:856
+#: opac/webapp/controllers.py:788
+msgid "Obrigatório um jid, url_seg_issue and url_seg_article."
+msgstr ""
+
+#: opac/webapp/controllers.py:889
 msgid "Obrigatório um pid."
 msgstr ""
 
-#: opac/webapp/controllers.py:869
+#: opac/webapp/controllers.py:902
 msgid "Obrigatório um aop_pid."
 msgstr ""
 
-#: opac/webapp/controllers.py:880
+#: opac/webapp/controllers.py:913
 msgid "Parámetro obrigatório: issue_iid."
 msgstr ""
 
-#: opac/webapp/controllers.py:928
+#: opac/webapp/controllers.py:961
 msgid "Parâmetro email deve ser uma string"
 msgstr ""
 
-#: opac/webapp/controllers.py:939
+#: opac/webapp/controllers.py:972
 msgid "Parâmetro email deve ser uma inteiro"
 msgstr ""
 
-#: opac/webapp/controllers.py:951 opac/webapp/controllers.py:965
+#: opac/webapp/controllers.py:984 opac/webapp/controllers.py:998
 #, python-format
 msgid "Usuário deve ser do tipo %s"
 msgstr ""
 
-#: opac/webapp/controllers.py:1021
+#: opac/webapp/controllers.py:1054
 msgid "Compartilhamento de link SciELO"
 msgstr ""
 
-#: opac/webapp/controllers.py:1022
+#: opac/webapp/controllers.py:1055
 #, python-format
 msgid "O usuário %s compartilha este link: %s, da SciELO"
 msgstr ""
 
-#: opac/webapp/controllers.py:1030 opac/webapp/controllers.py:1066
-#: opac/webapp/controllers.py:1088
+#: opac/webapp/controllers.py:1063 opac/webapp/controllers.py:1099
+#: opac/webapp/controllers.py:1121
 msgid "Mensagem enviada!"
 msgstr ""
 
-#: opac/webapp/controllers.py:1047
+#: opac/webapp/controllers.py:1080
 msgid "[Erro] Erro informado pelo usuário no site SciELO"
 msgstr ""
 
-#: opac/webapp/controllers.py:1050
+#: opac/webapp/controllers.py:1083
 msgid "aplicação"
 msgstr ""
 
-#: opac/webapp/controllers.py:1052
+#: opac/webapp/controllers.py:1085
 msgid "conteúdo"
 msgstr ""
 
-#: opac/webapp/controllers.py:1057
+#: opac/webapp/controllers.py:1090
 #, python-format
 msgid ""
 "O usuário <b>%s</b> com e-mail: <b>%s</b>, informa que existe um erro na "
@@ -392,16 +396,16 @@ msgid ""
 " %s"
 msgstr ""
 
-#: opac/webapp/controllers.py:1078
+#: opac/webapp/controllers.py:1111
 msgid "Contato de usuário via site SciELO"
 msgstr ""
 
-#: opac/webapp/controllers.py:1080
+#: opac/webapp/controllers.py:1113
 #, python-format
 msgid "O usuário %s, com e-mail: %s, entra em contato com a seguinte mensagem:"
 msgstr ""
 
-#: opac/webapp/controllers.py:1112
+#: opac/webapp/controllers.py:1145
 msgid "Obrigatório um slug_name."
 msgstr ""
 
@@ -958,20 +962,20 @@ msgstr ""
 
 #: opac/webapp/main/views.py:240 opac/webapp/main/views.py:290
 #: opac/webapp/main/views.py:334 opac/webapp/main/views.py:403
-#: opac/webapp/main/views.py:450 opac/webapp/main/views.py:588
-#: opac/webapp/main/views.py:605 opac/webapp/main/views.py:1032
+#: opac/webapp/main/views.py:450 opac/webapp/main/views.py:597
+#: opac/webapp/main/views.py:614 opac/webapp/main/views.py:1055
 msgid "Periódico não encontrado"
 msgstr ""
 
-#: opac/webapp/main/views.py:252 opac/webapp/main/views.py:655
-#: opac/webapp/main/views.py:711 opac/webapp/main/views.py:1041
+#: opac/webapp/main/views.py:252 opac/webapp/main/views.py:664
+#: opac/webapp/main/views.py:723 opac/webapp/main/views.py:1064
 msgid "Número não encontrado"
 msgstr ""
 
 #: opac/webapp/main/views.py:270 opac/webapp/main/views.py:305
-#: opac/webapp/main/views.py:759 opac/webapp/main/views.py:786
-#: opac/webapp/main/views.py:858 opac/webapp/main/views.py:861
-#: opac/webapp/main/views.py:965
+#: opac/webapp/main/views.py:774 opac/webapp/main/views.py:805
+#: opac/webapp/main/views.py:881 opac/webapp/main/views.py:884
+#: opac/webapp/main/views.py:988
 msgid "Artigo não encontrado"
 msgstr ""
 
@@ -979,77 +983,77 @@ msgstr ""
 msgid "Artigo sem título"
 msgstr ""
 
-#: opac/webapp/main/views.py:489 opac/webapp/main/views.py:506
+#: opac/webapp/main/views.py:498 opac/webapp/main/views.py:515
 msgid "Requisição inválida. Deve ser por ajax"
 msgstr ""
 
-#: opac/webapp/main/views.py:522
+#: opac/webapp/main/views.py:531
 msgid ""
 "Parámetro \"filter\" é inválido, deve ser \"areas\", \"wos\" ou "
 "\"publisher\"."
 msgstr ""
 
-#: opac/webapp/main/views.py:531
+#: opac/webapp/main/views.py:540
 msgid "Parámetro \"extension\" é inválido, deve ser \"csv\" ou \"xls\"."
 msgstr ""
 
-#: opac/webapp/main/views.py:533
+#: opac/webapp/main/views.py:542
 msgid ""
 "Parámetro \"list_type\" é inválido, deve ser: \"alpha\", \"areas\", "
 "\"wos\" ou \"publisher\"."
 msgstr ""
 
-#: opac/webapp/main/views.py:554
+#: opac/webapp/main/views.py:563
 msgid "Requisição inválida, deve ser ajax."
 msgstr ""
 
-#: opac/webapp/main/views.py:563
+#: opac/webapp/main/views.py:572
 msgid "Periódico não permite envio de email."
 msgstr ""
 
-#: opac/webapp/main/views.py:581
+#: opac/webapp/main/views.py:590
 msgid "Requisição inválida, captcha inválido."
 msgstr ""
 
-#: opac/webapp/main/views.py:781 opac/webapp/main/views.py:960
+#: opac/webapp/main/views.py:796 opac/webapp/main/views.py:983
 msgid "Issue não encontrado"
 msgstr ""
 
-#: opac/webapp/main/views.py:818 opac/webapp/main/views.py:824
-#: opac/webapp/main/views.py:997 opac/webapp/main/views.py:1005
-#: opac/webapp/main/views.py:1007
+#: opac/webapp/main/views.py:841 opac/webapp/main/views.py:847
+#: opac/webapp/main/views.py:1020 opac/webapp/main/views.py:1028
+#: opac/webapp/main/views.py:1030
 msgid "PDF do Artigo não encontrado"
 msgstr ""
 
-#: opac/webapp/main/views.py:834
+#: opac/webapp/main/views.py:857
 msgid "HTML do Artigo não encontrado"
 msgstr ""
 
-#: opac/webapp/main/views.py:848
+#: opac/webapp/main/views.py:871
 msgid "HTML do Artigo não encontrado ou indisponível"
 msgstr ""
 
-#: opac/webapp/main/views.py:907
+#: opac/webapp/main/views.py:930
 msgid "Parâmetros insuficientes para obter o EPDF do artigo"
 msgstr ""
 
-#: opac/webapp/main/views.py:924
+#: opac/webapp/main/views.py:947
 msgid "Recruso não encontrado"
 msgstr ""
 
-#: opac/webapp/main/views.py:929
+#: opac/webapp/main/views.py:952
 msgid "Recurso não encontrado"
 msgstr ""
 
-#: opac/webapp/main/views.py:946
+#: opac/webapp/main/views.py:969
 msgid "Recurso do Artigo não encontrado. Caminho inválido!"
 msgstr ""
 
-#: opac/webapp/main/views.py:1059
+#: opac/webapp/main/views.py:1082
 msgid "PDF do artigo não foi encontrado"
 msgstr ""
 
-#: opac/webapp/main/views.py:1087 opac/webapp/main/views.py:1118
+#: opac/webapp/main/views.py:1110 opac/webapp/main/views.py:1141
 msgid "Requisição inválida."
 msgstr ""
 
@@ -1181,7 +1185,7 @@ msgstr ""
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:7
 #: opac/webapp/templates/issue/includes/alternative_header.html:121
 #: opac/webapp/templates/journal/includes/alternative_header.html:117
-#: opac/webapp/templates/journal/includes/header.html:117
+#: opac/webapp/templates/journal/includes/header.html:118
 msgid "Submissão de manuscritos"
 msgstr ""
 
@@ -1189,7 +1193,7 @@ msgstr ""
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:16
 #: opac/webapp/templates/issue/includes/alternative_header.html:127
 #: opac/webapp/templates/journal/includes/alternative_header.html:123
-#: opac/webapp/templates/journal/includes/header.html:123
+#: opac/webapp/templates/journal/includes/header.html:124
 msgid "Sobre o periódico"
 msgstr ""
 
@@ -1197,7 +1201,7 @@ msgstr ""
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:10
 #: opac/webapp/templates/issue/includes/alternative_header.html:132
 #: opac/webapp/templates/journal/includes/alternative_header.html:128
-#: opac/webapp/templates/journal/includes/header.html:128
+#: opac/webapp/templates/journal/includes/header.html:129
 msgid "Corpo Editorial"
 msgstr ""
 
@@ -1205,7 +1209,7 @@ msgstr ""
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:13
 #: opac/webapp/templates/issue/includes/alternative_header.html:137
 #: opac/webapp/templates/journal/includes/alternative_header.html:133
-#: opac/webapp/templates/journal/includes/header.html:133
+#: opac/webapp/templates/journal/includes/header.html:134
 msgid "Instruções aos autores"
 msgstr ""
 
@@ -1213,7 +1217,7 @@ msgstr ""
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:19
 #: opac/webapp/templates/issue/includes/alternative_header.html:142
 #: opac/webapp/templates/journal/includes/alternative_header.html:138
-#: opac/webapp/templates/journal/includes/header.html:139
+#: opac/webapp/templates/journal/includes/header.html:140
 msgid "Contato"
 msgstr ""
 
@@ -1355,8 +1359,8 @@ msgid "Documento sem título"
 msgstr ""
 
 #: opac/webapp/templates/article/includes/recent_articles_row.html:13
-#: opac/webapp/templates/news/includes/collection_news_row.html:11
-msgid "continue lendo"
+#: opac/webapp/templates/news/includes/journal_news_row.html:9
+msgid "Continue lendo"
 msgstr ""
 
 #: opac/webapp/templates/article/includes/modal/download.html:6
@@ -1379,13 +1383,11 @@ msgid "Versão original do texto"
 msgstr ""
 
 #: opac/webapp/templates/collection/about.html:23
-#: opac/webapp/templates/collection/pages.html:21
 #, python-format
 msgid " %(page)s "
 msgstr ""
 
 #: opac/webapp/templates/collection/about.html:38
-#: opac/webapp/templates/collection/pages.html:36
 msgid " Conteúdo não cadastrado "
 msgstr ""
 
@@ -1932,23 +1934,27 @@ msgstr ""
 msgid "Área:"
 msgstr ""
 
-#: opac/webapp/templates/journal/includes/header.html:59
+#: opac/webapp/templates/journal/includes/header.html:51
+msgid "Multidiciplinar"
+msgstr ""
+
+#: opac/webapp/templates/journal/includes/header.html:60
 msgid "Versão impressa ISSN:"
 msgstr ""
 
-#: opac/webapp/templates/journal/includes/header.html:66
+#: opac/webapp/templates/journal/includes/header.html:67
 msgid "Versão on-line ISSN:"
 msgstr ""
 
-#: opac/webapp/templates/journal/includes/header.html:75
+#: opac/webapp/templates/journal/includes/header.html:76
 msgid "Novo título:"
 msgstr ""
 
-#: opac/webapp/templates/journal/includes/header.html:92
+#: opac/webapp/templates/journal/includes/header.html:93
 msgid "Título anterior:"
 msgstr ""
 
-#: opac/webapp/templates/journal/includes/header.html:147
+#: opac/webapp/templates/journal/includes/header.html:148
 msgid "Siga-nos"
 msgstr ""
 
@@ -1997,15 +2003,15 @@ msgstr ""
 msgid "número especial"
 msgstr ""
 
+#: opac/webapp/templates/news/includes/collection_news_row.html:11
+msgid "continue lendo"
+msgstr ""
+
 #: opac/webapp/templates/news/includes/issue_last_row.html:15
 msgid "Suplemento"
 msgstr ""
 
 #: opac/webapp/templates/news/includes/issue_last_row.html:20
 msgid "Ver"
-msgstr ""
-
-#: opac/webapp/templates/news/includes/journal_news_row.html:8
-msgid "Continue lendo"
 msgstr ""
 


### PR DESCRIPTION
#### O que esse PR faz?

Exibi área "Multidisciplinar" para periódicos com 3 ou mais áreas do conhecimento

#### Onde a revisão poderia começar?

 Nos seguintes módulos:

opac/webapp/main/views.py
opac/webapp/templates/journal/includes/header.html
opac/webapp/translations/en/LC_MESSAGES/messages.po
opac/webapp/translations/es/LC_MESSAGES/messages.po
opac/webapp/translations/es_ES/LC_MESSAGES/messages.po
opac/webapp/translations/es_MX/LC_MESSAGES/messages.po


#### Como este poderia ser testado manualmente?

Acessando a página do periódico: **Anais da Academia Brasileira de Ciências**

http://localhost:8000/journal/aabc/

#### Algum cenário de contexto que queira dar?

Não há.

### Screenshots
![Screenshot 2019-03-15 08 50 30](https://user-images.githubusercontent.com/373745/54429469-682e9980-46ff-11e9-92cb-5dd7e8a3da2f.png)


#### Quais são tickets relevantes?

https://github.com/scieloorg/opac/issues/1216

### Referências

Não há.

