### PR TITLE
Altera os links do menu, que estavam hard coded e apontando para SciELO.org antigo

### DIFF
--- a/opac/tests/test_interface_menu.py
+++ b/opac/tests/test_interface_menu.py
@@ -67,21 +67,37 @@ class MenuTestCase(BaseTestCase):
                 expected_anchor9 = """<a href="#">\n        <strong>SciELO.org - %s</strong>\n      </a>""" % __('Rede SciELO')
                 self.assertIn(expected_anchor9, response_data)
                 # rede/scielo org
-                expected_anchor10 = """<li>\n          <a href="http://www.scielo.org/php/index.php">\n            %s\n          </a>\n        </li>""" % __('Coleções nacionais e temáticas')
+                expected_anchor10 = """<li>\n          <a target="_blank" href="%s">\n            %s\n          </a>\n        </li>""" % (
+                    current_app.config['URL_SCIELO_ORG'], __('Coleções nacionais e temáticas')
+                )
                 self.assertIn(expected_anchor10, response_data)
-                expected_anchor11 = """<li>\n          <a href="http://www.scielo.org/applications/scielo-org/php/secondLevel.php?xml=secondLevelForAlphabeticList&xsl=secondLevelForAlphabeticList">\n            %s\n          </a>\n        </li>""" % __('Lista alfabética de periódicos')
+                expected_anchor11 = """<li>\n          <a target="_blank" href="%s/pt/periodicos/listar-por-ordem-alfabetica/">\n              %s\n          </a>\n        </li>""" % (
+                    current_app.config['URL_SCIELO_ORG'], __('Lista alfabética de periódicos')
+                )
                 self.assertIn(expected_anchor11, response_data)
-                expected_anchor12 = """<li>\n          <a href="http://www.scielo.org/applications/scielo-org/php/secondLevel.php?xml=secondLevelForSubjectByLetter&xsl=secondLevelForSubjectByLetter">\n            %s\n          </a>\n        </li>""" % __('Lista de periódicos por assunto')
+                expected_anchor12 = """<li>\n          <a target="_blank" href="%s/pt/periodicos/listar-por-assunto/">\n              %s\n          </a>\n        </li>""" % (
+                    current_app.config['URL_SCIELO_ORG'], __('Lista de periódicos por assunto')
+                )
                 self.assertIn(expected_anchor12, response_data)
-                expected_anchor13 = """<li>\n          <a href="%s">\n            %s\n          </a>\n        </li>""" % (current_app.config['URL_SEARCH'], 'Busca')
+                expected_anchor13 = """<li>\n          <a target="_blank" href="%s">\n            %s\n          </a>\n        </li>""" % (
+                    current_app.config['URL_SEARCH'], 'Busca'
+                )
                 self.assertIn(expected_anchor13, response_data)
-                expected_anchor14 = """<li>\n            <a target="_blank" href="%s/?collection=%s">\n              %s\n            </a>\n          </li>""" % (current_app.config['METRICS_URL'], current_app.config['OPAC_COLLECTION'], 'Métricas')
+                expected_anchor14 = """<li>\n            <a target="_blank" href="%s/?collection=%s">\n              %s\n            </a>\n          </li>""" % (
+                    current_app.config['METRICS_URL'], current_app.config['OPAC_COLLECTION'], 'Métricas'
+                )
                 self.assertIn(expected_anchor14, response_data)
-                expected_anchor15 = """<li>\n          <a href="http://www.scielo.org/php/level.php?lang=pt&component=56&item=9">\n            %s\n          </a>\n        </li>""" % __('Acesso OAI e RSS')
+                expected_anchor15 = """<li>\n          <a target="_blank" href="%s/pt/sobre-o-scielo/acesso-via-oai-e-rss/">\n              %s\n          </a>\n        </li>""" % (
+                    current_app.config['URL_SCIELO_ORG'], __('Acesso OAI e RSS')
+                )
                 self.assertIn(expected_anchor15, response_data)
-                expected_anchor16 = """<li>\n          <a href="http://www.scielo.org/php/level.php?lang=pt&component=56&item=8">\n            %s\n          </a>\n        </li>""" % __('Sobre a Rede SciELO')
+                expected_anchor16 = """<li>\n          <a target="_blank" href="%s/pt/sobre-o-scielo/">\n              %s\n          </a>\n        </li>""" % (
+                    current_app.config['URL_SCIELO_ORG'], __('Sobre a Rede SciELO')
+                )
                 self.assertIn(expected_anchor16, response_data)
-                expected_anchor17 = """<li>\n          <a href="#">\n            %s\n          </a>\n        </li>""" % __('Contatos')
+                expected_anchor17 = """<li>\n          <a target="_blank" href="%s/pt/sobre-o-scielo/contato/">\n            %s\n          </a>\n        </li>""" % (
+                    current_app.config['URL_SCIELO_ORG'], __('Contatos')
+                )
                 self.assertIn(expected_anchor17, response_data)
 
     def test_blog_link_in_hamburger_menu(self):
@@ -104,7 +120,10 @@ class MenuTestCase(BaseTestCase):
                     follow_redirects=True)
 
                 self.assertStatus(response, 200)
-                expected_anchor = '<a href="http://blog.scielo.org/">'
+                expected_anchor_tag = '<a target="_blank" href="%s">'
+                expected_anchor = expected_anchor_tag % (
+                    current_app.config['URL_BLOG_SCIELO']
+                )
                 self.assertIn(expected_anchor, response.data.decode('utf-8'))
 
                 # idioma em 'en'
@@ -114,7 +133,9 @@ class MenuTestCase(BaseTestCase):
                     follow_redirects=True)
 
                 self.assertStatus(response, 200)
-                expected_anchor = '<a href="http://blog.scielo.org/en/">'
+                expected_anchor = expected_anchor_tag % (
+                    current_app.config['URL_BLOG_SCIELO'] + '/en/'
+                )
                 self.assertIn(expected_anchor, response.data.decode('utf-8'))
 
                 # idioma em 'es'
@@ -124,7 +145,9 @@ class MenuTestCase(BaseTestCase):
                     follow_redirects=True)
 
                 self.assertStatus(response, 200)
-                expected_anchor = '<a href="http://blog.scielo.org/es/">'
+                expected_anchor = expected_anchor_tag % (
+                    current_app.config['URL_BLOG_SCIELO'] + '/es/'
+                )
                 self.assertIn(expected_anchor, response.data.decode('utf-8'))
 
     # Journal Menu

--- a/opac/webapp/config/default.py
+++ b/opac/webapp/config/default.py
@@ -151,6 +151,12 @@ import os
 
       - MathJax:
         - OPAC_MATHJAX_CDN_URL: string com a URL do mathjax padrão; ex: "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/latest.js?config=TeX-AMS-MML_HTMLorMML"
+
+      - Links SciELO:
+        - URL_SCIELO_ORG: URL para o SciELO.org (default: '//www.scielo.org')
+        - SCIELO_ORG_URIS: URIs em SciELO.org para sessões específicas
+        - URL_BLOG_SCIELO: URL para o Blog SciELO em Perspectiva (default: '//blog.scielo.org')
+        - URL_SEARCH: URL para o Search SciELO (default: '//search.scielo.org/')
 """
 
 PROJECT_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
@@ -291,6 +297,40 @@ IMAGES_ALLOWED_EXTENSIONS = ('png', 'jpg', 'jpeg', 'gif', 'webp')
 IMAGES_ALLOWED_EXTENSIONS_RE = tuple('*.' + ext for ext in IMAGES_ALLOWED_EXTENSIONS)
 THUMBNAIL_HEIGHT = 100
 THUMBNAIL_WIDTH = 100
+
+# scielo.org
+URL_SCIELO_ORG = os.environ.get('OPAC_URL_SCIELO_ORG', '//www.scielo.org')
+
+SCIELO_ORG_URIS = {
+    'journals_by_title': {
+        'pt_BR': '/pt/periodicos/listar-por-ordem-alfabetica/',
+        'en': '/en/journals/list-by-alphabetical-order/',
+        'es': '/es/revistas/listar-por-orden-alfabetico/',
+    },
+    'journals_by_subject': {
+        'pt_BR': '/pt/periodicos/listar-por-assunto/',
+        'en': '/en/journals/list-by-subject-area/',
+        'es': '/es/revistas/listar-por-tema',
+    },
+    'oai_and_rss': {
+        'pt_BR': '/pt/sobre-o-scielo/acesso-via-oai-e-rss/',
+        'en': '/en/about-scielo/access-via-oai-and-rss/',
+        'es': '/es/sobre-el-scielo/acesso-via-oai-y-rss/',
+    },
+    'about_network': {
+        'pt_BR': '/pt/sobre-o-scielo/',
+        'en': '/en/about-scielo/',
+        'es': '/es/sobre-el-scielo',
+    },
+    'contact': {
+        'pt_BR': '/pt/sobre-o-scielo/contato/',
+        'en': '/en/about-scielo/contact/',
+        'es': '/es/sobre-el-scielo/contacto/',
+    },
+}
+
+# scielo.org
+URL_BLOG_SCIELO = os.environ.get('OPAC_URL_BLOG_SCIELO', '//blog.scielo.org')
 
 # search scielo
 URL_SEARCH = os.environ.get('OPAC_URL_SEARCH', '//search.scielo.org/')

--- a/opac/webapp/main/views.py
+++ b/opac/webapp/main/views.py
@@ -54,6 +54,16 @@ def add_forms_to_g():
     setattr(g, 'error', forms.ErrorForm())
 
 
+@main.before_app_request
+def add_scielo_org_config_to_g():
+    language = session.get('lang', get_locale())
+    scielo_org_links = {
+        key: url[language]
+        for key, url in current_app.config.get('SCIELO_ORG_URIS', {}).items()
+    }
+    setattr(g, 'scielo_org', scielo_org_links)
+
+
 @babel.localeselector
 def get_locale():
     langs = current_app.config.get('LANGUAGES')

--- a/opac/webapp/templates/collection/includes/nav.html
+++ b/opac/webapp/templates/collection/includes/nav.html
@@ -45,22 +45,22 @@
       </a>
       <ul>
         <li>
-          <a href="http://www.scielo.org/php/index.php">
+          <a target="_blank" href="{{ config.URL_SCIELO_ORG }}">
             {% trans %}Coleções nacionais e temáticas{% endtrans %}
           </a>
         </li>
         <li>
-          <a href="http://www.scielo.org/applications/scielo-org/php/secondLevel.php?xml=secondLevelForAlphabeticList&xsl=secondLevelForAlphabeticList">
-            {% trans %}Lista alfabética de periódicos{% endtrans %}
+          <a target="_blank" href="{{ config.URL_SCIELO_ORG }}{{ g.scielo_org.journals_by_title }}">
+              {% trans %}Lista alfabética de periódicos{% endtrans %}
           </a>
         </li>
         <li>
-          <a href="http://www.scielo.org/applications/scielo-org/php/secondLevel.php?xml=secondLevelForSubjectByLetter&xsl=secondLevelForSubjectByLetter">
-            {% trans %}Lista de periódicos por assunto{% endtrans %}
+          <a target="_blank" href="{{ config.URL_SCIELO_ORG }}{{ g.scielo_org.journals_by_subject }}">
+              {% trans %}Lista de periódicos por assunto{% endtrans %}
           </a>
         </li>
         <li>
-          <a href="{{ config.URL_SEARCH }}">
+          <a target="_blank" href="{{ config.URL_SEARCH }}">
             {% trans %}Busca{% endtrans %}
           </a>
         </li>
@@ -70,17 +70,17 @@
           </a>
         </li>
         <li>
-          <a href="http://www.scielo.org/php/level.php?lang=pt&component=56&item=9">
-            {% trans %}Acesso OAI e RSS{% endtrans %}
+          <a target="_blank" href="{{ config.URL_SCIELO_ORG }}{{ g.scielo_org.oai_and_rss }}">
+              {% trans %}Acesso OAI e RSS{% endtrans %}
           </a>
         </li>
         <li>
-          <a href="http://www.scielo.org/php/level.php?lang=pt&component=56&item=8">
-            {% trans %}Sobre a Rede SciELO{% endtrans %}
+          <a target="_blank" href="{{ config.URL_SCIELO_ORG }}{{ g.scielo_org.about_network }}">
+              {% trans %}Sobre a Rede SciELO{% endtrans %}
           </a>
         </li>
         <li>
-          <a href="#">
+          <a target="_blank" href="{{ config.URL_SCIELO_ORG }}{{ g.scielo_org.contact }}">
             {% trans %}Contatos{% endtrans %}
           </a>
         </li>
@@ -88,9 +88,9 @@
     </li>
     <li>
       {% if session.lang == 'pt_BR' %}
-        <a href="http://blog.scielo.org/">
+        <a target="_blank" href="{{ config.URL_BLOG_SCIELO }}">
       {% else  %}
-        <a href="http://blog.scielo.org/{{ session.lang }}/">
+        <a target="_blank" href="{{ config.URL_BLOG_SCIELO }}/{{ session.lang }}/">
       {% endif %}
           <strong>{% trans %}Blog SciELO em Perspectiva{% endtrans %}</strong>
         </a>

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,3 +31,4 @@ rq-dashboard==0.3.10
 rq-scheduler==0.8.2
 rq-scheduler-dashboard==0.0.2
 lxml==4.2.4
+Werkzeug==0.14.1


### PR DESCRIPTION
#### O que esse PR faz?
Após a migração do SciELO.org para a nova plataforma, os links do menu do site passaram a não funcionar. Este corrige os links:
- Criando configurações para que seja possível alterar o domínio de SciELO.org e Blog
- Alterando o template para utilizar as configurações
Também foi corrigido o link de "Contato"

#### Onde a revisão poderia começar?
Em `opac/webapp/config/default.py`.

#### Como este poderia ser testado manualmente?
Acessando o menu do cabeçalho do novo site, todos os links para o SciELO.org e para o Blog devem funcionar

#### Algum cenário de contexto que queira dar?
Os links do novo SciELO.org não são os mesmos da aplicação antiga. Como os links estavam hard coded no OPAC, eles passaram a não funcionar mais.

### Screenshots
N/A.

#### Quais são tickets relevantes?
#1245 

### Referências
Nenhuma.
