### PR TITLE
Passa a renderizar o HTML em tempo de execução

### DIFF
--- a/opac/webapp/main/views.py
+++ b/opac/webapp/main/views.py
@@ -1158,19 +1158,6 @@ def router_legacy_pdf(journal_acron, issue_info, pdf_filename):
             url_seg_issue=issue.url_segment,
             url_seg_article=article_match.url_segment, lang_code=pdf_lang)
 
-# ##################################Search#######################################
-
-
-@main.route("/metasearch/", methods=['GET'])
-@cache.cached(key_prefix=cache_key_with_lang_with_qs)
-def metasearch():
-    url = request.args.get('url', current_app.config['URL_SEARCH'], type=str)
-    params = {}
-    for k, v in list(request.args.items()):
-        if k != 'url':
-            params[k] = v
-    xml = utils.do_request(url, request.args)
-    return Response(xml, mimetype='text/xml')
 
 # ###############################E-mail share####################################
 

--- a/opac/webapp/utils/utils.py
+++ b/opac/webapp/utils/utils.py
@@ -451,26 +451,6 @@ def get_resources_url(resource_list, type, lang):
     return None
 
 
-def do_request(url, params):
-    try:
-        response = requests.get(url, params=params)
-    except:
-        return None
-    if response.status_code == 200:
-        return response.content
-    return None
-
-
-def do_request_json(url, params):
-    try:
-        response = requests.get(url, params=params)
-    except:
-        return {}
-    if response.status_code == 200:
-        return response.json()
-    return {}
-
-
 def utc_to_local(utc_dt):
     local_tz = pytz.timezone(current_app.config['LOCAL_ZONE'])
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,3 +32,4 @@ rq-scheduler==0.8.2
 rq-scheduler-dashboard==0.0.2
 lxml==4.2.4
 Werkzeug==0.14.1
+packtools==2.4.3

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ install_requirements = [
     # for production production
     'chaussette>=1.3',
     'gevent>=1.1.0',
+    'packtools'
 ]
 
 dependency_links = [


### PR DESCRIPTION
#### O que esse PR faz?

Adiciona a responsabilidade de gerar os HTMLs dos artigos em tempo de execução. 

Adicionalmente foram realizadas algumas limpezas e melhorias nos códigos relacionados.

#### Onde a revisão poderia começar?

Sugiro que o revisor olhe para cada commit individualmente para que as limpezas e melhorias fiquem evidentes.

O módulo **opac/webapp/main/views.py** foi o mais afetado pela atividade.

#### Como este poderia ser testado manualmente?

Inicialize o servidor, com o comando **make dev_compose_up**, acesse no seu navegador e navegue pelas páginas dos documentos. Repare que o tempo de resposta agora é maior por conta da transformação XSLT realizada sob demanda. 

Os testes automáticos podem ser executados com o comando **make dev_compose_make_test**.

#### Algum cenário de contexto que queira dar?

Decidimos adicionar a renderização do artigo em tempo de execução com o objetivo de deixar as alterações de HTMLs mais rápidas, evitando a necessidade de reprocessamento de todos os documentos. Esta modificação indiretamente resolve o ticket https://github.com/scieloorg/opac_proc/issues/455

### Screenshots

Esse PR resolve a o erro de exibição de tabela como, por exemplo, desse artigo: 

<img width="1343" alt="Screenshot 2019-04-24 12 02 16" src="https://user-images.githubusercontent.com/373745/56670699-b41f1780-6689-11e9-9d38-f36fb0ebc203.png">


#### Quais são tickets relevantes?

Tk: https://github.com/scieloorg/opac_proc/issues/455

### Referências
Não há.
