### PR TITLE
Corrige o valor de citation_language para ficar correspondente a citation_title

### DIFF
--- a/opac/tests/test_interface_journal_home.py
+++ b/opac/tests/test_interface_journal_home.py
@@ -124,19 +124,23 @@ class JournalHomeTestCase(BaseTestCase):
             header = {'Referer': url_for('main.journal_detail',
                                          url_seg=journal.url_segment)}
 
-            response = c.get(
-                url_for('main.set_locale', lang_code='en'),
-                headers=header,
-                follow_redirects=True)
+            for lang, expected in zip(['en', 'es', 'pt_BR'],
+                                      ['Multidisciplinary',
+                                       'Multidisciplinaria',
+                                       'Multidisciplinar']):
 
-            self.assertEqual(200, response.status_code)
+                with self.subTest(lang):
+                    response = c.get(
+                        url_for('main.set_locale', lang_code=lang),
+                        headers=header,
+                        follow_redirects=True)
 
-            self.assertEqual(flask.session['lang'], 'en')
+                    self.assertEqual(200, response.status_code)
 
-            content = response.data.decode('utf-8')
-            expected = "Multidisciplinary"
+                    self.assertEqual(flask.session['lang'], lang)
 
-            self.assertIn(expected, content)
+                    content = response.data.decode('utf-8')
+                    self.assertIn(expected, content)
 
     # Mission
     def test_journal_detail_mission_with_pt_language(self):

--- a/opac/webapp/templates/article/includes/meta.html
+++ b/opac/webapp/templates/article/includes/meta.html
@@ -67,19 +67,17 @@
     {% if article.title -%}
         <meta name="citation_title" content="{{ article.title|escape }}"></meta>
     {% endif -%}
+{%else -%}
+    {%- if article.translated_titles -%}
+        {%- for title in article.translated_titles -%}
+            {%- if article_lang == title.language -%}
+                <meta name="citation_title" content="{{ title.name|escape }}"></meta>
+            {%- endif -%}
+        {%- endfor -%}
+    {%- endif -%}
 {% endif -%}
 
-{%- if article.translated_titles -%}
-    {%- for title in article.translated_titles -%}
-        {%- if article_lang == title.language -%}
-            <meta name="citation_title" content="{{ title.name|escape }}"></meta>
-        {%- endif -%}
-    {%- endfor -%}
-{%- endif -%}
-
-{% if article.original_language -%}
-    <meta name="citation_language" content="{{ article.original_language }}"></meta>
-{% endif -%}
+<meta name="citation_language" content="{{ article_lang }}"></meta>
 
 {% if article.abstract -%}
     <meta name="citation_abstract" content="{{ article.abstract|escape }}"></meta>

--- a/opac/webapp/templates/journal/includes/header.html
+++ b/opac/webapp/templates/journal/includes/header.html
@@ -48,7 +48,7 @@
               </span>
               {% if journal_study_areas %}
                 {% if journal_study_areas|length > 3 %}
-                  {% trans %}Multidiciplinar{% endtrans %}
+                  {% trans %}Multidisciplinar{% endtrans %}
                 {% else %}
                   {{ journal_study_areas|join(', ')|title|truncate(60) }}
                 {% endif %}

--- a/opac/webapp/translations/en/LC_MESSAGES/messages.po
+++ b/opac/webapp/translations/en/LC_MESSAGES/messages.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version:  OPAC\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-03-15 11:46+0000\n"
+"POT-Creation-Date: 2019-05-09 17:02-0300\n"
 "PO-Revision-Date: 2018-03-06 19:50+0000\n"
 "Last-Translator: jamil Atta <atta.jamil@gmail.com>\n"
 "Language: en\n"
@@ -23,6 +23,23 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.6.0\n"
 
+#: build/lib/opac/tests/test_admin_custom_filters.py:100
+#: build/lib/opac/tests/test_admin_custom_filters.py:114
+#: build/lib/opac/tests/test_admin_custom_filters.py:129
+#: build/lib/opac/tests/test_admin_custom_filters.py:144
+#: build/lib/opac/tests/test_admin_custom_filters.py:158
+#: build/lib/opac/webapp/__init__.py:119
+#: build/lib/opac/webapp/admin/views.py:533
+#: build/lib/opac/webapp/admin/views.py:610
+#: build/lib/opac/webapp/admin/views.py:680
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:28
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:71
+#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_grouper_table_row.html:15
+#: build/lib/opac/webapp/templates/collection/list_journal.html:49
+#: build/lib/opac/webapp/templates/collection/list_journal.html:221
+#: build/lib/opac/webapp/templates/collection/list_journal.html:235
+#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:116
+#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:112
 #: opac/tests/test_admin_custom_filters.py:100
 #: opac/tests/test_admin_custom_filters.py:114
 #: opac/tests/test_admin_custom_filters.py:129
@@ -41,21 +58,38 @@ msgstr ""
 msgid "Periódico"
 msgstr "Journal"
 
+#: build/lib/opac/tests/test_interface_menu.py:51
 #: opac/tests/test_interface_menu.py:51
 msgid "NOME DA COLEÇÃO!!"
 msgstr "COLLECTION NAME!!"
 
-#: opac/tests/test_interface_menu.py:53 opac/tests/test_interface_menu.py:72
+#: build/lib/opac/tests/test_interface_menu.py:53
+#: build/lib/opac/tests/test_interface_menu.py:75
+#: build/lib/opac/webapp/templates/collection/includes/nav.html:12
+#: build/lib/opac/webapp/templates/collection/includes/nav.html:54
+#: opac/tests/test_interface_menu.py:53 opac/tests/test_interface_menu.py:75
 #: opac/webapp/templates/collection/includes/nav.html:12
 #: opac/webapp/templates/collection/includes/nav.html:54
 msgid "Lista alfabética de periódicos"
 msgstr "Journal list by title"
 
+#: build/lib/opac/tests/test_interface_menu.py:55
+#: build/lib/opac/webapp/templates/collection/includes/nav.html:17
 #: opac/tests/test_interface_menu.py:55
 #: opac/webapp/templates/collection/includes/nav.html:17
 msgid "Lista temática de periódicos"
 msgstr "Journal list by subject area"
 
+#: build/lib/opac/tests/test_interface_menu.py:61
+#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:11
+#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:70
+#: build/lib/opac/webapp/templates/collection/includes/nav.html:27
+#: build/lib/opac/webapp/templates/collection/includes/nav.html:69
+#: build/lib/opac/webapp/templates/includes/metric_modal.html:7
+#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:101
+#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:105
+#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:97
+#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:101
 #: opac/tests/test_interface_menu.py:61
 #: opac/webapp/templates/article/includes/floating_menu.html:11
 #: opac/webapp/templates/article/includes/floating_menu.html:70
@@ -69,332 +103,383 @@ msgstr "Journal list by subject area"
 msgid "Métricas"
 msgstr "Metrics"
 
+#: build/lib/opac/tests/test_interface_menu.py:63
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu.html:12
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu.html:29
 #: opac/tests/test_interface_menu.py:63
 #: opac/webapp/templates/collection/includes/levelMenu.html:12
 #: opac/webapp/templates/collection/includes/levelMenu.html:29
 msgid "Sobre o SciELO"
 msgstr "About SciELO"
 
-#: opac/tests/test_interface_menu.py:65 opac/tests/test_interface_menu.py:84
+#: build/lib/opac/tests/test_interface_menu.py:65
+#: build/lib/opac/tests/test_interface_menu.py:99
+#: build/lib/opac/webapp/templates/collection/includes/nav.html:37
+#: build/lib/opac/webapp/templates/collection/includes/nav.html:84
+#: opac/tests/test_interface_menu.py:65 opac/tests/test_interface_menu.py:99
 #: opac/webapp/templates/collection/includes/nav.html:37
 #: opac/webapp/templates/collection/includes/nav.html:84
 msgid "Contatos"
 msgstr "Contacts"
 
+#: build/lib/opac/tests/test_interface_menu.py:67
 #: opac/tests/test_interface_menu.py:67
 msgid "Rede SciELO"
 msgstr "The SciELO Network"
 
-#: opac/tests/test_interface_menu.py:70
+#: build/lib/opac/tests/test_interface_menu.py:71
+#: build/lib/opac/webapp/templates/collection/includes/nav.html:49
+#: opac/tests/test_interface_menu.py:71
 #: opac/webapp/templates/collection/includes/nav.html:49
 msgid "Coleções nacionais e temáticas"
 msgstr "National and thematic collections"
 
-#: opac/tests/test_interface_menu.py:74
+#: build/lib/opac/tests/test_interface_menu.py:79
+#: build/lib/opac/webapp/templates/collection/includes/nav.html:59
+#: opac/tests/test_interface_menu.py:79
 #: opac/webapp/templates/collection/includes/nav.html:59
 msgid "Lista de periódicos por assunto"
 msgstr "Journal list by subject"
 
-#: opac/tests/test_interface_menu.py:80
+#: build/lib/opac/tests/test_interface_menu.py:91
+#: build/lib/opac/webapp/templates/collection/includes/nav.html:74
+#: opac/tests/test_interface_menu.py:91
 #: opac/webapp/templates/collection/includes/nav.html:74
 msgid "Acesso OAI e RSS"
 msgstr "OAI and RSS"
 
-#: opac/tests/test_interface_menu.py:82
+#: build/lib/opac/tests/test_interface_menu.py:95
+#: build/lib/opac/webapp/templates/collection/includes/nav.html:79
+#: opac/tests/test_interface_menu.py:95
 #: opac/webapp/templates/collection/includes/nav.html:79
 msgid "Sobre a Rede SciELO"
 msgstr "About the SciELO Network"
 
-#: opac/tests/test_main_errors.py:8
+#: build/lib/opac/tests/test_main_errors.py:8 opac/tests/test_main_errors.py:8
 msgid "Mensagem de erro explicativo para o usuário"
 msgstr "Explanatory user error message"
 
+#: build/lib/opac/webapp/__init__.py:118 build/lib/opac/webapp/__init__.py:119
+#: build/lib/opac/webapp/__init__.py:120 build/lib/opac/webapp/__init__.py:121
+#: build/lib/opac/webapp/__init__.py:122 build/lib/opac/webapp/__init__.py:123
 #: opac/webapp/__init__.py:118 opac/webapp/__init__.py:119
 #: opac/webapp/__init__.py:120 opac/webapp/__init__.py:121
 #: opac/webapp/__init__.py:122 opac/webapp/__init__.py:123
 msgid "Catálogo"
 msgstr "Catalog"
 
-#: opac/webapp/__init__.py:118 opac/webapp/admin/views.py:452
+#: build/lib/opac/webapp/__init__.py:118
+#: build/lib/opac/webapp/admin/views.py:452 opac/webapp/__init__.py:118
+#: opac/webapp/admin/views.py:452
 msgid "Coleção"
 msgstr "Collection"
 
+#: build/lib/opac/webapp/__init__.py:120
+#: build/lib/opac/webapp/admin/views.py:537
+#: build/lib/opac/webapp/admin/views.py:609
+#: build/lib/opac/webapp/templates/issue/grid.html:41
+#: build/lib/opac/webapp/templates/news/includes/issue_last_row.html:11
 #: opac/webapp/__init__.py:120 opac/webapp/admin/views.py:537
 #: opac/webapp/admin/views.py:609 opac/webapp/templates/issue/grid.html:41
 #: opac/webapp/templates/news/includes/issue_last_row.html:11
 msgid "Número"
 msgstr "Number"
 
-#: opac/webapp/__init__.py:121
+#: build/lib/opac/webapp/__init__.py:121 opac/webapp/__init__.py:121
 msgid "Artigo"
 msgstr "Article"
 
+#: build/lib/opac/webapp/__init__.py:122
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:27
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:70
 #: opac/webapp/__init__.py:122
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:27
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:70
 msgid "Financiador"
 msgstr "Funder"
 
-#: opac/webapp/__init__.py:123
+#: build/lib/opac/webapp/__init__.py:123 opac/webapp/__init__.py:123
 msgid "Press Release"
 msgstr "Press release"
 
+#: build/lib/opac/webapp/__init__.py:124
+#: build/lib/opac/webapp/templates/journal/detail.html:160
 #: opac/webapp/__init__.py:124 opac/webapp/templates/journal/detail.html:160
 msgid "Notícias"
 msgstr "News"
 
+#: build/lib/opac/webapp/__init__.py:125 build/lib/opac/webapp/__init__.py:126
 #: opac/webapp/__init__.py:125 opac/webapp/__init__.py:126
 msgid "Ativos"
 msgstr "Static files"
 
-#: opac/webapp/__init__.py:127
+#: build/lib/opac/webapp/__init__.py:127 opac/webapp/__init__.py:127
 msgid "Páginas"
 msgstr "Pages"
 
+#: build/lib/opac/webapp/__init__.py:128 build/lib/opac/webapp/__init__.py:129
 #: opac/webapp/__init__.py:128 opac/webapp/__init__.py:129
 msgid "Gestão"
 msgstr "Management"
 
-#: opac/webapp/__init__.py:128
+#: build/lib/opac/webapp/__init__.py:128 opac/webapp/__init__.py:128
 msgid "Auditoria: Páginas"
 msgstr "Auditoria: Pages"
 
-#: opac/webapp/__init__.py:129 opac/webapp/admin/views.py:896
+#: build/lib/opac/webapp/__init__.py:129
+#: build/lib/opac/webapp/admin/views.py:896 opac/webapp/__init__.py:129
+#: opac/webapp/admin/views.py:896
 msgid "Usuário"
 msgstr "User"
 
-#: opac/webapp/choices.py:7
+#: build/lib/opac/webapp/choices.py:7 opac/webapp/choices.py:7
 msgid "Conteúdo temporariamente indisponível"
 msgstr "Content temporarily unavailable"
 
+#: build/lib/opac/webapp/choices.py:11 build/lib/opac/webapp/choices.py:23
+#: build/lib/opac/webapp/templates/article/includes/modal/download.html:26
 #: opac/webapp/choices.py:11 opac/webapp/choices.py:23
 #: opac/webapp/templates/article/includes/modal/download.html:26
 msgid "Português"
 msgstr "Portuguese"
 
+#: build/lib/opac/webapp/choices.py:12 build/lib/opac/webapp/choices.py:24
+#: build/lib/opac/webapp/templates/article/includes/modal/download.html:24
 #: opac/webapp/choices.py:12 opac/webapp/choices.py:24
 #: opac/webapp/templates/article/includes/modal/download.html:24
 msgid "Inglês"
 msgstr "English"
 
+#: build/lib/opac/webapp/choices.py:13 build/lib/opac/webapp/choices.py:25
+#: build/lib/opac/webapp/templates/article/includes/modal/download.html:22
 #: opac/webapp/choices.py:13 opac/webapp/choices.py:25
 #: opac/webapp/templates/article/includes/modal/download.html:22
 msgid "Espanhol"
 msgstr "Spanish"
 
-#: opac/webapp/choices.py:26
+#: build/lib/opac/webapp/choices.py:26 opac/webapp/choices.py:26
 msgid "Albanês"
 msgstr "Albanian"
 
+#: build/lib/opac/webapp/choices.py:27 build/lib/opac/webapp/choices.py:33
 #: opac/webapp/choices.py:27 opac/webapp/choices.py:33
 msgid "Chinês"
 msgstr "Chinese"
 
-#: opac/webapp/choices.py:28
+#: build/lib/opac/webapp/choices.py:28 opac/webapp/choices.py:28
 msgid "Romeno"
 msgstr "Romanian"
 
-#: opac/webapp/choices.py:29
+#: build/lib/opac/webapp/choices.py:29 opac/webapp/choices.py:29
 msgid "Francês"
 msgstr "French"
 
-#: opac/webapp/choices.py:30
+#: build/lib/opac/webapp/choices.py:30 opac/webapp/choices.py:30
 msgid "Italiano"
 msgstr "Italian"
 
-#: opac/webapp/choices.py:31
+#: build/lib/opac/webapp/choices.py:31 opac/webapp/choices.py:31
 msgid "Russo"
 msgstr "Russian"
 
-#: opac/webapp/choices.py:32
+#: build/lib/opac/webapp/choices.py:32 opac/webapp/choices.py:32
 msgid "Árabe"
 msgstr "Arabic"
 
-#: opac/webapp/choices.py:37
+#: build/lib/opac/webapp/choices.py:37 opac/webapp/choices.py:37
 msgid "corrente"
 msgstr "current"
 
-#: opac/webapp/choices.py:38
+#: build/lib/opac/webapp/choices.py:38 opac/webapp/choices.py:38
 msgid "terminado"
 msgstr "deceased"
 
-#: opac/webapp/choices.py:39
+#: build/lib/opac/webapp/choices.py:39 opac/webapp/choices.py:39
 msgid "indexação interrompida"
 msgstr "indexing interrupted"
 
-#: opac/webapp/choices.py:40
+#: build/lib/opac/webapp/choices.py:40 opac/webapp/choices.py:40
 msgid "indexação interrompida pelo Comitê"
 msgstr "indexing interrupted by the committee"
 
-#: opac/webapp/choices.py:41
+#: build/lib/opac/webapp/choices.py:41 opac/webapp/choices.py:41
 msgid "publicação finalizada"
 msgstr "publication finished"
 
-#: opac/webapp/choices.py:45
+#: build/lib/opac/webapp/choices.py:45 opac/webapp/choices.py:45
 msgid "Ciências Agrárias"
 msgstr "Agricultural Sciences"
 
-#: opac/webapp/choices.py:46
+#: build/lib/opac/webapp/choices.py:46 opac/webapp/choices.py:46
 msgid "Ciências Sociais Aplicadas"
 msgstr "Applied Social Sciences"
 
-#: opac/webapp/choices.py:47
+#: build/lib/opac/webapp/choices.py:47 opac/webapp/choices.py:47
 msgid "Ciências Biológicas"
 msgstr "Biological Sciences"
 
-#: opac/webapp/choices.py:48
+#: build/lib/opac/webapp/choices.py:48 opac/webapp/choices.py:48
 msgid "Engenharias"
 msgstr "Engineering"
 
-#: opac/webapp/choices.py:49
+#: build/lib/opac/webapp/choices.py:49 opac/webapp/choices.py:49
 msgid "Ciências Exatas e da Terra"
 msgstr "Exact and Earth Sciences"
 
-#: opac/webapp/choices.py:50
+#: build/lib/opac/webapp/choices.py:50 opac/webapp/choices.py:50
 msgid "Ciências da Saúde"
 msgstr "Health Sciences"
 
-#: opac/webapp/choices.py:51
+#: build/lib/opac/webapp/choices.py:51 opac/webapp/choices.py:51
 msgid "Ciências Humanas"
 msgstr "Human Sciences"
 
+#: build/lib/opac/webapp/choices.py:52 build/lib/opac/webapp/choices.py:53
 #: opac/webapp/choices.py:52 opac/webapp/choices.py:53
 msgid "Lingüística, Letras e Artes"
 msgstr "Linguistics, Literature and Arts"
 
-#: opac/webapp/controllers.py:353
+#: build/lib/opac/webapp/controllers.py:353 opac/webapp/controllers.py:353
 msgid "Lista Alfabética"
 msgstr "Alphabetic List"
 
-#: opac/webapp/controllers.py:357
+#: build/lib/opac/webapp/controllers.py:357 opac/webapp/controllers.py:357
 msgid "Lista Temática"
 msgstr "Thematic List"
 
-#: opac/webapp/controllers.py:361
+#: build/lib/opac/webapp/controllers.py:361 opac/webapp/controllers.py:361
 msgid "Lista Web of Science"
 msgstr "Web of Science List"
 
-#: opac/webapp/controllers.py:365
+#: build/lib/opac/webapp/controllers.py:365 opac/webapp/controllers.py:365
 msgid "Lista by Institution"
 msgstr "List by Institution"
 
-#: opac/webapp/controllers.py:424
+#: build/lib/opac/webapp/controllers.py:424 opac/webapp/controllers.py:424
 msgid "Obrigatório um jid."
 msgstr "A jid is required."
 
-#: opac/webapp/controllers.py:440
+#: build/lib/opac/webapp/controllers.py:440 opac/webapp/controllers.py:440
 msgid "Obrigatório um acronym."
 msgstr "An acronym is required."
 
-#: opac/webapp/controllers.py:456
+#: build/lib/opac/webapp/controllers.py:456 opac/webapp/controllers.py:456
 msgid "Obrigatório um url_seg."
 msgstr "A url_seg is required."
 
-#: opac/webapp/controllers.py:472
+#: build/lib/opac/webapp/controllers.py:472 opac/webapp/controllers.py:472
 msgid "Obrigatório um issn."
 msgstr "ISSN is required."
 
-#: opac/webapp/controllers.py:487
+#: build/lib/opac/webapp/controllers.py:487 opac/webapp/controllers.py:487
 msgid "Obrigatório um title."
 msgstr ""
 
-#: opac/webapp/controllers.py:525 opac/webapp/controllers.py:669
-#: opac/webapp/controllers.py:830
+#: build/lib/opac/webapp/controllers.py:525
+#: build/lib/opac/webapp/controllers.py:669
+#: build/lib/opac/webapp/controllers.py:830 opac/webapp/controllers.py:525
+#: opac/webapp/controllers.py:669 opac/webapp/controllers.py:830
 msgid "Obrigatório uma lista de ids."
 msgstr "A list of id's is required."
 
-#: opac/webapp/controllers.py:631 opac/webapp/controllers.py:851
+#: build/lib/opac/webapp/controllers.py:631
+#: build/lib/opac/webapp/controllers.py:851 opac/webapp/controllers.py:631
+#: opac/webapp/controllers.py:851
 msgid "Obrigatório um iid."
 msgstr "A iid is required."
 
-#: opac/webapp/controllers.py:688
+#: build/lib/opac/webapp/controllers.py:688 opac/webapp/controllers.py:688
 msgid "Obrigatório um jacron e issue_label."
 msgstr "A jacron and issue_label are required."
 
-#: opac/webapp/controllers.py:701
+#: build/lib/opac/webapp/controllers.py:701 opac/webapp/controllers.py:701
 msgid "Obrigatório um PID."
 msgstr "PID is required."
 
-#: opac/webapp/controllers.py:717
+#: build/lib/opac/webapp/controllers.py:717 opac/webapp/controllers.py:717
 msgid "Obrigatório um url_seg e url_seg_issue."
 msgstr "A url_seg and url_seg_issue are required."
 
-#: opac/webapp/controllers.py:724
+#: build/lib/opac/webapp/controllers.py:724 opac/webapp/controllers.py:724
 msgid "Obrigatório um assets_code."
 msgstr " assets_code is mandatory."
 
-#: opac/webapp/controllers.py:727
+#: build/lib/opac/webapp/controllers.py:727 opac/webapp/controllers.py:727
 msgid "Obrigatório um journal."
 msgstr "Journal is mandatory."
 
-#: opac/webapp/controllers.py:743
+#: build/lib/opac/webapp/controllers.py:743 opac/webapp/controllers.py:743
 msgid "Obrigatório um aid."
 msgstr "A aid is required."
 
-#: opac/webapp/controllers.py:757
+#: build/lib/opac/webapp/controllers.py:757 opac/webapp/controllers.py:757
 msgid "Obrigatório um url_seg_article."
 msgstr "A url_seg_article is required."
 
-#: opac/webapp/controllers.py:772
+#: build/lib/opac/webapp/controllers.py:772 opac/webapp/controllers.py:772
 msgid "Obrigatório um iid and url_seg_article."
 msgstr "A iid and url_seg_article are required."
 
-#: opac/webapp/controllers.py:788
+#: build/lib/opac/webapp/controllers.py:788 opac/webapp/controllers.py:788
 msgid "Obrigatório um jid, url_seg_issue and url_seg_article."
 msgstr ""
 
-#: opac/webapp/controllers.py:889
+#: build/lib/opac/webapp/controllers.py:889 opac/webapp/controllers.py:889
 msgid "Obrigatório um pid."
 msgstr "pid is required."
 
-#: opac/webapp/controllers.py:902
+#: build/lib/opac/webapp/controllers.py:902 opac/webapp/controllers.py:902
 msgid "Obrigatório um aop_pid."
 msgstr "aop_pid is mandatory."
 
-#: opac/webapp/controllers.py:913
+#: build/lib/opac/webapp/controllers.py:913 opac/webapp/controllers.py:913
 msgid "Parámetro obrigatório: issue_iid."
 msgstr "issue_iid is mandatory."
 
-#: opac/webapp/controllers.py:961
+#: build/lib/opac/webapp/controllers.py:961 opac/webapp/controllers.py:961
 msgid "Parâmetro email deve ser uma string"
 msgstr "The parameter \"email\" must be a string."
 
-#: opac/webapp/controllers.py:972
+#: build/lib/opac/webapp/controllers.py:972 opac/webapp/controllers.py:972
 msgid "Parâmetro email deve ser uma inteiro"
 msgstr "The parameter \"email\" must be an integer."
 
-#: opac/webapp/controllers.py:984 opac/webapp/controllers.py:998
+#: build/lib/opac/webapp/controllers.py:984
+#: build/lib/opac/webapp/controllers.py:998 opac/webapp/controllers.py:984
+#: opac/webapp/controllers.py:998
 #, python-format
 msgid "Usuário deve ser do tipo %s"
 msgstr "User must be of type %s"
 
-#: opac/webapp/controllers.py:1054
+#: build/lib/opac/webapp/controllers.py:1054 opac/webapp/controllers.py:1054
 msgid "Compartilhamento de link SciELO"
 msgstr "SciELO link sharing"
 
-#: opac/webapp/controllers.py:1055
+#: build/lib/opac/webapp/controllers.py:1055 opac/webapp/controllers.py:1055
 #, python-format
 msgid "O usuário %s compartilha este link: %s, da SciELO"
 msgstr "The user %s share link: %s, of SciELO"
 
-#: opac/webapp/controllers.py:1063 opac/webapp/controllers.py:1099
-#: opac/webapp/controllers.py:1121
+#: build/lib/opac/webapp/controllers.py:1063
+#: build/lib/opac/webapp/controllers.py:1099
+#: build/lib/opac/webapp/controllers.py:1121 opac/webapp/controllers.py:1063
+#: opac/webapp/controllers.py:1099 opac/webapp/controllers.py:1121
 msgid "Mensagem enviada!"
 msgstr "Message sent!"
 
-#: opac/webapp/controllers.py:1080
+#: build/lib/opac/webapp/controllers.py:1080 opac/webapp/controllers.py:1080
 msgid "[Erro] Erro informado pelo usuário no site SciELO"
 msgstr "[Error] Error informed by the user in the SciELO site"
 
-#: opac/webapp/controllers.py:1083
+#: build/lib/opac/webapp/controllers.py:1083 opac/webapp/controllers.py:1083
 msgid "aplicação"
 msgstr ""
 
-#: opac/webapp/controllers.py:1085
+#: build/lib/opac/webapp/controllers.py:1085 opac/webapp/controllers.py:1085
 msgid "conteúdo"
 msgstr ""
 
-#: opac/webapp/controllers.py:1090
+#: build/lib/opac/webapp/controllers.py:1090 opac/webapp/controllers.py:1090
 #, python-format
 msgid ""
 "O usuário <b>%s</b> com e-mail: <b>%s</b>, informa que existe um erro na "
@@ -405,72 +490,78 @@ msgstr ""
 " %s in the website SciELO.<br><br><b>Title of page:</b> "
 "%s<br><br><b>Link:</b> %s"
 
-#: opac/webapp/controllers.py:1111
+#: build/lib/opac/webapp/controllers.py:1111 opac/webapp/controllers.py:1111
 msgid "Contato de usuário via site SciELO"
 msgstr "User contact by SciELO website"
 
-#: opac/webapp/controllers.py:1113
+#: build/lib/opac/webapp/controllers.py:1113 opac/webapp/controllers.py:1113
 #, python-format
 msgid "O usuário %s, com e-mail: %s, entra em contato com a seguinte mensagem:"
 msgstr "User %s, e-mail: %s, contact us with the following message:"
 
-#: opac/webapp/controllers.py:1145
+#: build/lib/opac/webapp/controllers.py:1145 opac/webapp/controllers.py:1145
 msgid "Obrigatório um slug_name."
 msgstr "An slug_name is required"
 
-#: opac/webapp/forms.py:29
+#: build/lib/opac/webapp/forms.py:29 opac/webapp/forms.py:29
 msgid "Endereço de e-mail inválido."
 msgstr "Invalid e-mail address."
 
-#: opac/webapp/admin/forms.py:9 opac/webapp/admin/forms.py:21
+#: build/lib/opac/webapp/admin/forms.py:9
+#: build/lib/opac/webapp/admin/forms.py:21 opac/webapp/admin/forms.py:9
+#: opac/webapp/admin/forms.py:21
 msgid "Email"
 msgstr "Email"
 
-#: opac/webapp/admin/forms.py:10 opac/webapp/admin/forms.py:25
+#: build/lib/opac/webapp/admin/forms.py:10
+#: build/lib/opac/webapp/admin/forms.py:25 opac/webapp/admin/forms.py:10
+#: opac/webapp/admin/forms.py:25
 msgid "Senha"
 msgstr "Password"
 
-#: opac/webapp/admin/forms.py:15
+#: build/lib/opac/webapp/admin/forms.py:15 opac/webapp/admin/forms.py:15
 msgid "Usuário inválido"
 msgstr "Invalid user"
 
-#: opac/webapp/admin/forms.py:17
+#: build/lib/opac/webapp/admin/forms.py:17 opac/webapp/admin/forms.py:17
 msgid "Senha inválida"
 msgstr "Invalid password"
 
-#: opac/webapp/admin/views.py:28
+#: build/lib/opac/webapp/admin/views.py:28 opac/webapp/admin/views.py:28
 msgid "Tem certeza que quer publicar os itens selecionados?"
 msgstr "Are you sure you want to publish the selected items?"
 
-#: opac/webapp/admin/views.py:29
+#: build/lib/opac/webapp/admin/views.py:29 opac/webapp/admin/views.py:29
 msgid "Tem certeza que quer despublicar os itens selecionados?"
 msgstr "Are you sure you want to unpublish the selected items?"
 
-#: opac/webapp/admin/views.py:30
+#: build/lib/opac/webapp/admin/views.py:30 opac/webapp/admin/views.py:30
 msgid "Tem certeza que quer reconstruir os artigos selecionados?"
 msgstr "Are you sure you want to rebuild the selected articles?"
 
-#: opac/webapp/admin/views.py:31
+#: build/lib/opac/webapp/admin/views.py:31 opac/webapp/admin/views.py:31
 msgid ""
 "Tem certeza que quer enviar email de confirmação aos usuários "
 "selecionados?"
 msgstr "Are you sure you want to send a confirmation email to the selected users?"
 
-#: opac/webapp/admin/views.py:91 opac/webapp/admin/views.py:104
+#: build/lib/opac/webapp/admin/views.py:91
+#: build/lib/opac/webapp/admin/views.py:104 opac/webapp/admin/views.py:91
+#: opac/webapp/admin/views.py:104
 msgid "Usuário não encontrado"
 msgstr "User not found"
 
-#: opac/webapp/admin/views.py:94
+#: build/lib/opac/webapp/admin/views.py:94 opac/webapp/admin/views.py:94
 #, python-format
 msgid "Email: %(email)s confirmado com sucesso!"
 msgstr "Email: %(email)s successfully confirmed!"
 
-#: opac/webapp/admin/views.py:110
+#: build/lib/opac/webapp/admin/views.py:110 opac/webapp/admin/views.py:110
 #, python-format
 msgid "Enviamos as instruções para recuperar a senha para: %(email)s"
 msgstr "The instructions to reset the password have been sent to: %(email)s "
 
-#: opac/webapp/admin/views.py:113
+#: build/lib/opac/webapp/admin/views.py:113 opac/webapp/admin/views.py:113
 #, python-format
 msgid ""
 "Ocorreu um erro no envio das instruções por email para: %(email)s. Erro: "
@@ -479,314 +570,354 @@ msgstr ""
 "Error in sending the instructions via email to: %(email)s. Error: "
 "%(error)s"
 
-#: opac/webapp/admin/views.py:139
+#: build/lib/opac/webapp/admin/views.py:139 opac/webapp/admin/views.py:139
 msgid "Nova senha salva com sucesso!!"
 msgstr "New password successfully saved!!"
 
-#: opac/webapp/admin/views.py:167 opac/webapp/admin/views.py:186
+#: build/lib/opac/webapp/admin/views.py:167
+#: build/lib/opac/webapp/admin/views.py:186 opac/webapp/admin/views.py:167
+#: opac/webapp/admin/views.py:186
 #, python-format
 msgid "Enviamos o email de confirmação para: %(email)s"
 msgstr "A confirmation email has been sent to: %(email)s"
 
-#: opac/webapp/admin/views.py:170
+#: build/lib/opac/webapp/admin/views.py:170 opac/webapp/admin/views.py:170
 #, python-format
 msgid ""
 "Ocorreu um erro no envio do email de confirmação para: %(email)s "
 "%(error_msg)s"
 msgstr "There was an error sending confirmation email to: %(email)s %(error_msg)s"
 
-#: opac/webapp/admin/views.py:177
+#: build/lib/opac/webapp/admin/views.py:177 opac/webapp/admin/views.py:177
 msgid "Enviar email de confirmação"
 msgstr "Send a confirmation email"
 
-#: opac/webapp/admin/views.py:189
+#: build/lib/opac/webapp/admin/views.py:189 opac/webapp/admin/views.py:189
 #, python-format
 msgid "Ocorreu um erro no envio do email de confirmação para: %(email)s"
 msgstr "An error occurred in sending the confirmation email to: %(email)s"
 
-#: opac/webapp/admin/views.py:193
+#: build/lib/opac/webapp/admin/views.py:193 opac/webapp/admin/views.py:193
 #, python-format
 msgid "%(count)s usuários foram notificados com sucesso!"
 msgstr "%(count)s users were successfully notified!"
 
-#: opac/webapp/admin/views.py:196
+#: build/lib/opac/webapp/admin/views.py:196 opac/webapp/admin/views.py:196
 #, python-format
 msgid "Ocorreu um erro no envio do emails de confirmação. Erro: %(ex)s"
 msgstr "An error occurred in sending the confirmation emails. Error: %(ex)s"
 
-#: opac/webapp/admin/views.py:231 opac/webapp/admin/views.py:265
-#: opac/webapp/admin/views.py:363 opac/webapp/admin/views.py:393
-#: opac/webapp/admin/views.py:677
+#: build/lib/opac/webapp/admin/views.py:231
+#: build/lib/opac/webapp/admin/views.py:265
+#: build/lib/opac/webapp/admin/views.py:363
+#: build/lib/opac/webapp/admin/views.py:393
+#: build/lib/opac/webapp/admin/views.py:677 opac/webapp/admin/views.py:231
+#: opac/webapp/admin/views.py:265 opac/webapp/admin/views.py:363
+#: opac/webapp/admin/views.py:393 opac/webapp/admin/views.py:677
 msgid "Nome"
 msgstr "Name"
 
-#: opac/webapp/admin/views.py:232 opac/webapp/admin/views.py:267
+#: build/lib/opac/webapp/admin/views.py:232
+#: build/lib/opac/webapp/admin/views.py:267 opac/webapp/admin/views.py:232
+#: opac/webapp/admin/views.py:267
 msgid "Link"
 msgstr "Link"
 
-#: opac/webapp/admin/views.py:233 opac/webapp/admin/views.py:268
-#: opac/webapp/admin/views.py:678
+#: build/lib/opac/webapp/admin/views.py:233
+#: build/lib/opac/webapp/admin/views.py:268
+#: build/lib/opac/webapp/admin/views.py:678 opac/webapp/admin/views.py:233
+#: opac/webapp/admin/views.py:268 opac/webapp/admin/views.py:678
 msgid "Idioma"
 msgstr "Language"
 
-#: opac/webapp/admin/views.py:266
+#: build/lib/opac/webapp/admin/views.py:266 opac/webapp/admin/views.py:266
 msgid "Previsualização"
 msgstr "Preview"
 
-#: opac/webapp/admin/views.py:362 opac/webapp/admin/views.py:547
-#: opac/webapp/admin/views.py:627
+#: build/lib/opac/webapp/admin/views.py:362
+#: build/lib/opac/webapp/admin/views.py:547
+#: build/lib/opac/webapp/admin/views.py:627 opac/webapp/admin/views.py:362
+#: opac/webapp/admin/views.py:547 opac/webapp/admin/views.py:627
 msgid "Ordem"
 msgstr "Order"
 
-#: opac/webapp/admin/views.py:364
+#: build/lib/opac/webapp/admin/views.py:364 opac/webapp/admin/views.py:364
 msgid "URL"
 msgstr "URL"
 
-#: opac/webapp/admin/views.py:365
+#: build/lib/opac/webapp/admin/views.py:365 opac/webapp/admin/views.py:365
 msgid "URL da logomarca"
 msgstr "Logo URL"
 
-#: opac/webapp/admin/views.py:375
+#: build/lib/opac/webapp/admin/views.py:375 opac/webapp/admin/views.py:375
 msgid "Financiador com Ordem ou Nome já cadastrado!"
 msgstr "Sponsor Order or Name already registered!"
 
-#: opac/webapp/admin/views.py:394
+#: build/lib/opac/webapp/admin/views.py:394 opac/webapp/admin/views.py:394
 msgid "Acerca de"
 msgstr "About"
 
-#: opac/webapp/admin/views.py:395 opac/webapp/admin/views.py:462
+#: build/lib/opac/webapp/admin/views.py:395
+#: build/lib/opac/webapp/admin/views.py:462 opac/webapp/admin/views.py:395
+#: opac/webapp/admin/views.py:462
 msgid "Acrônimo"
 msgstr "Acronym"
 
-#: opac/webapp/admin/views.py:396
+#: build/lib/opac/webapp/admin/views.py:396 opac/webapp/admin/views.py:396
 msgid "Endereço principal"
 msgstr "Main address"
 
-#: opac/webapp/admin/views.py:397
+#: build/lib/opac/webapp/admin/views.py:397 opac/webapp/admin/views.py:397
 msgid "Endereço secundário"
 msgstr "Secondary address"
 
-#: opac/webapp/admin/views.py:398
+#: build/lib/opac/webapp/admin/views.py:398 opac/webapp/admin/views.py:398
 msgid "Logo da Home (PT)"
 msgstr "Homepage's logo (PT)"
 
-#: opac/webapp/admin/views.py:399
+#: build/lib/opac/webapp/admin/views.py:399 opac/webapp/admin/views.py:399
 msgid "Logo da Home (EN)"
 msgstr "Homepage's logo (EN)"
 
-#: opac/webapp/admin/views.py:400
+#: build/lib/opac/webapp/admin/views.py:400 opac/webapp/admin/views.py:400
 msgid "Logo da Home (ES)"
 msgstr "Homepage's logo (ES)"
 
-#: opac/webapp/admin/views.py:401
+#: build/lib/opac/webapp/admin/views.py:401 opac/webapp/admin/views.py:401
 msgid "Logo do cabeçalho (PT)"
 msgstr "Header's logo (PT)"
 
-#: opac/webapp/admin/views.py:402
+#: build/lib/opac/webapp/admin/views.py:402 opac/webapp/admin/views.py:402
 msgid "Logo do cabeçalho (EN)"
 msgstr "Header's logo (EN)"
 
-#: opac/webapp/admin/views.py:403
+#: build/lib/opac/webapp/admin/views.py:403 opac/webapp/admin/views.py:403
 msgid "Logo do cabeçalho (ES)"
 msgstr "Header's logo (ES)"
 
-#: opac/webapp/admin/views.py:404
+#: build/lib/opac/webapp/admin/views.py:404 opac/webapp/admin/views.py:404
 msgid "Logo do menu (PT)"
 msgstr "Menu's logo (PT)"
 
-#: opac/webapp/admin/views.py:405 opac/webapp/admin/views.py:406
+#: build/lib/opac/webapp/admin/views.py:405
+#: build/lib/opac/webapp/admin/views.py:406 opac/webapp/admin/views.py:405
+#: opac/webapp/admin/views.py:406
 msgid "Logo do menu (ES)"
 msgstr "Menu's logo (ES)"
 
-#: opac/webapp/admin/views.py:407
+#: build/lib/opac/webapp/admin/views.py:407 opac/webapp/admin/views.py:407
 msgid "Logo do menu (drop)"
 msgstr "Drop menu's logo"
 
-#: opac/webapp/admin/views.py:408
+#: build/lib/opac/webapp/admin/views.py:408 opac/webapp/admin/views.py:408
 msgid "Logo do rodapé"
 msgstr "Footer's logo"
 
-#: opac/webapp/admin/views.py:451
+#: build/lib/opac/webapp/admin/views.py:451 opac/webapp/admin/views.py:451
 msgid "Id Periódico"
 msgstr "Journal Id"
 
-#: opac/webapp/admin/views.py:453
+#: build/lib/opac/webapp/admin/views.py:453 opac/webapp/admin/views.py:453
 msgid "Linha do tempo"
 msgstr "Timeline"
 
-#: opac/webapp/admin/views.py:454
+#: build/lib/opac/webapp/admin/views.py:454 opac/webapp/admin/views.py:454
 msgid "Categorias de assunto"
 msgstr "Subject Categories"
 
-#: opac/webapp/admin/views.py:455
+#: build/lib/opac/webapp/admin/views.py:455 opac/webapp/admin/views.py:455
 msgid "Áreas de estudo"
 msgstr "Areas of study"
 
-#: opac/webapp/admin/views.py:456
+#: build/lib/opac/webapp/admin/views.py:456 opac/webapp/admin/views.py:456
 msgid "Redes sociais"
 msgstr "Social networks"
 
+#: build/lib/opac/webapp/admin/views.py:457
+#: build/lib/opac/webapp/admin/views.py:611
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:30
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:73
 #: opac/webapp/admin/views.py:457 opac/webapp/admin/views.py:611
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:30
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:73
 msgid "Título"
 msgstr "Title"
 
-#: opac/webapp/admin/views.py:458
+#: build/lib/opac/webapp/admin/views.py:458 opac/webapp/admin/views.py:458
 msgid "Título ISO"
 msgstr "ISO title"
 
-#: opac/webapp/admin/views.py:459
+#: build/lib/opac/webapp/admin/views.py:459 opac/webapp/admin/views.py:459
 msgid "Título curto"
 msgstr "Abbreviated title"
 
-#: opac/webapp/admin/views.py:460 opac/webapp/admin/views.py:538
-#: opac/webapp/admin/views.py:614
+#: build/lib/opac/webapp/admin/views.py:460
+#: build/lib/opac/webapp/admin/views.py:538
+#: build/lib/opac/webapp/admin/views.py:614 opac/webapp/admin/views.py:460
+#: opac/webapp/admin/views.py:538 opac/webapp/admin/views.py:614
 msgid "Criado"
 msgstr "Created"
 
-#: opac/webapp/admin/views.py:461 opac/webapp/admin/views.py:539
-#: opac/webapp/admin/views.py:615
+#: build/lib/opac/webapp/admin/views.py:461
+#: build/lib/opac/webapp/admin/views.py:539
+#: build/lib/opac/webapp/admin/views.py:615 opac/webapp/admin/views.py:461
+#: opac/webapp/admin/views.py:539 opac/webapp/admin/views.py:615
 msgid "Atualizado"
 msgstr "Updated"
 
-#: opac/webapp/admin/views.py:463
+#: build/lib/opac/webapp/admin/views.py:463 opac/webapp/admin/views.py:463
 msgid "ISSN SciELO"
 msgstr "SciELO ISSN"
 
-#: opac/webapp/admin/views.py:464
+#: build/lib/opac/webapp/admin/views.py:464 opac/webapp/admin/views.py:464
 msgid "ISSN impresso"
 msgstr "print ISSN"
 
-#: opac/webapp/admin/views.py:465
+#: build/lib/opac/webapp/admin/views.py:465 opac/webapp/admin/views.py:465
 msgid "ISSN eletrônico"
 msgstr "electronic ISSN"
 
-#: opac/webapp/admin/views.py:466
+#: build/lib/opac/webapp/admin/views.py:466 opac/webapp/admin/views.py:466
 msgid "Descritores de assunto"
 msgstr "Subject descriptors"
 
-#: opac/webapp/admin/views.py:467
+#: build/lib/opac/webapp/admin/views.py:467 opac/webapp/admin/views.py:467
 msgid "Url da submissão online"
 msgstr "online submission URL"
 
-#: opac/webapp/admin/views.py:468
+#: build/lib/opac/webapp/admin/views.py:468 opac/webapp/admin/views.py:468
 msgid "Url do capa"
 msgstr "Cover URL"
 
-#: opac/webapp/admin/views.py:469
+#: build/lib/opac/webapp/admin/views.py:469 opac/webapp/admin/views.py:469
 msgid "Url do logotipo"
 msgstr "Logo URL"
 
-#: opac/webapp/admin/views.py:470
+#: build/lib/opac/webapp/admin/views.py:470 opac/webapp/admin/views.py:470
 msgid "Outros títulos"
 msgstr "Other titles"
 
-#: opac/webapp/admin/views.py:471
+#: build/lib/opac/webapp/admin/views.py:471 opac/webapp/admin/views.py:471
 msgid "Nome da editora"
 msgstr "Publisher name"
 
-#: opac/webapp/admin/views.py:472
+#: build/lib/opac/webapp/admin/views.py:472 opac/webapp/admin/views.py:472
 msgid "País da editora"
 msgstr "Publisher country"
 
-#: opac/webapp/admin/views.py:473
+#: build/lib/opac/webapp/admin/views.py:473 opac/webapp/admin/views.py:473
 msgid "Estado da editora"
 msgstr "Publisher state"
 
-#: opac/webapp/admin/views.py:474
+#: build/lib/opac/webapp/admin/views.py:474 opac/webapp/admin/views.py:474
 msgid "Cidade da editora"
 msgstr "Publisher city"
 
-#: opac/webapp/admin/views.py:475
+#: build/lib/opac/webapp/admin/views.py:475 opac/webapp/admin/views.py:475
 msgid "Endereço da editora"
 msgstr "Publisher address"
 
-#: opac/webapp/admin/views.py:476
+#: build/lib/opac/webapp/admin/views.py:476 opac/webapp/admin/views.py:476
 msgid "Telefone da editora"
 msgstr "Publisher telephone"
 
-#: opac/webapp/admin/views.py:477
+#: build/lib/opac/webapp/admin/views.py:477 opac/webapp/admin/views.py:477
 msgid "Missão"
 msgstr "Mission"
 
-#: opac/webapp/admin/views.py:478
+#: build/lib/opac/webapp/admin/views.py:478 opac/webapp/admin/views.py:478
 msgid "No índice"
 msgstr "In index"
 
-#: opac/webapp/admin/views.py:479
+#: build/lib/opac/webapp/admin/views.py:479 opac/webapp/admin/views.py:479
 msgid "Patrocinadores"
 msgstr "Sponsors"
 
-#: opac/webapp/admin/views.py:480
+#: build/lib/opac/webapp/admin/views.py:480 opac/webapp/admin/views.py:480
 msgid "Ref periódico anterior"
 msgstr "Previous journal reference"
 
-#: opac/webapp/admin/views.py:481
+#: build/lib/opac/webapp/admin/views.py:481 opac/webapp/admin/views.py:481
 msgid "Situação atual"
 msgstr "Journal status"
 
-#: opac/webapp/admin/views.py:482
+#: build/lib/opac/webapp/admin/views.py:482 opac/webapp/admin/views.py:482
 msgid "Total de números"
 msgstr "Total number of issues"
 
-#: opac/webapp/admin/views.py:483 opac/webapp/admin/views.py:548
-#: opac/webapp/admin/views.py:618
+#: build/lib/opac/webapp/admin/views.py:483
+#: build/lib/opac/webapp/admin/views.py:548
+#: build/lib/opac/webapp/admin/views.py:618 opac/webapp/admin/views.py:483
+#: opac/webapp/admin/views.py:548 opac/webapp/admin/views.py:618
 msgid "Publicado?"
 msgstr "Published?"
 
-#: opac/webapp/admin/views.py:484 opac/webapp/admin/views.py:549
-#: opac/webapp/admin/views.py:619
+#: build/lib/opac/webapp/admin/views.py:484
+#: build/lib/opac/webapp/admin/views.py:549
+#: build/lib/opac/webapp/admin/views.py:619 opac/webapp/admin/views.py:484
+#: opac/webapp/admin/views.py:549 opac/webapp/admin/views.py:619
 msgid "Motivo de despublicação"
 msgstr "Reason for unpublishing"
 
-#: opac/webapp/admin/views.py:485 opac/webapp/admin/views.py:551
-#: opac/webapp/admin/views.py:620
+#: build/lib/opac/webapp/admin/views.py:485
+#: build/lib/opac/webapp/admin/views.py:551
+#: build/lib/opac/webapp/admin/views.py:620 opac/webapp/admin/views.py:485
+#: opac/webapp/admin/views.py:551 opac/webapp/admin/views.py:620
 msgid "Segmento de URL"
 msgstr "URL Segment"
 
-#: opac/webapp/admin/views.py:488 opac/webapp/admin/views.py:554
-#: opac/webapp/admin/views.py:633
+#: build/lib/opac/webapp/admin/views.py:488
+#: build/lib/opac/webapp/admin/views.py:554
+#: build/lib/opac/webapp/admin/views.py:633 opac/webapp/admin/views.py:488
+#: opac/webapp/admin/views.py:554 opac/webapp/admin/views.py:633
 msgid "Publicar"
 msgstr "Publish"
 
-#: opac/webapp/admin/views.py:493
+#: build/lib/opac/webapp/admin/views.py:493 opac/webapp/admin/views.py:493
 msgid "Periódico(s) publicado(s) com sucesso!!"
 msgstr "Journal(s) successfully published!!"
 
-#: opac/webapp/admin/views.py:495
+#: build/lib/opac/webapp/admin/views.py:495 opac/webapp/admin/views.py:495
 msgid "Ocorreu um erro tentando publicar o(s) periódico(s)!!"
 msgstr "An error occurred trying to publish the journal(s)!!"
 
-#: opac/webapp/admin/views.py:501
+#: build/lib/opac/webapp/admin/views.py:501 opac/webapp/admin/views.py:501
 msgid "Periódico(s) despublicado com sucesso!!"
 msgstr "Journal(s) successfully unpublished!!"
 
-#: opac/webapp/admin/views.py:504
+#: build/lib/opac/webapp/admin/views.py:504 opac/webapp/admin/views.py:504
 #, python-format
 msgid "Ocorreu um erro tentando despublicar o(s) periódico(s)!!. Erro: %(ex)s"
 msgstr ""
 "An error occurred while attempting to unpublish the journal(s)!!. Error: "
 "%(ex)s"
 
-#: opac/webapp/admin/views.py:508 opac/webapp/admin/views.py:576
-#: opac/webapp/admin/views.py:656
+#: build/lib/opac/webapp/admin/views.py:508
+#: build/lib/opac/webapp/admin/views.py:576
+#: build/lib/opac/webapp/admin/views.py:656 opac/webapp/admin/views.py:508
+#: opac/webapp/admin/views.py:576 opac/webapp/admin/views.py:656
 #, python-format
 msgid "Despublicar por %s"
 msgstr "Unpublished because of %s"
 
-#: opac/webapp/admin/views.py:532
+#: build/lib/opac/webapp/admin/views.py:532 opac/webapp/admin/views.py:532
 msgid "Id Número"
 msgstr "ID number"
 
-#: opac/webapp/admin/views.py:534 opac/webapp/admin/views.py:624
+#: build/lib/opac/webapp/admin/views.py:534
+#: build/lib/opac/webapp/admin/views.py:624 opac/webapp/admin/views.py:534
+#: opac/webapp/admin/views.py:624
 msgid "Seções"
 msgstr "Sections"
 
-#: opac/webapp/admin/views.py:535
+#: build/lib/opac/webapp/admin/views.py:535 opac/webapp/admin/views.py:535
 msgid "Url da capa"
 msgstr "Cover's URL"
 
+#: build/lib/opac/webapp/admin/views.py:536
+#: build/lib/opac/webapp/templates/collection/list_feed_content.html:3
+#: build/lib/opac/webapp/templates/issue/grid.html:40
+#: build/lib/opac/webapp/templates/news/includes/issue_last_row.html:7
 #: opac/webapp/admin/views.py:536
 #: opac/webapp/templates/collection/list_feed_content.html:3
 #: opac/webapp/templates/issue/grid.html:40
@@ -794,26 +925,31 @@ msgstr "Cover's URL"
 msgid "Volume"
 msgstr "Volume"
 
-#: opac/webapp/admin/views.py:540
+#: build/lib/opac/webapp/admin/views.py:540 opac/webapp/admin/views.py:540
 msgid "Tipo"
 msgstr "Type"
 
-#: opac/webapp/admin/views.py:541
+#: build/lib/opac/webapp/admin/views.py:541 opac/webapp/admin/views.py:541
 msgid "Texto do suplemento"
 msgstr "Text for supplement"
 
-#: opac/webapp/admin/views.py:542
+#: build/lib/opac/webapp/admin/views.py:542 opac/webapp/admin/views.py:542
 msgid "Texto do especial"
 msgstr "Text for special"
 
-#: opac/webapp/admin/views.py:543
+#: build/lib/opac/webapp/admin/views.py:543 opac/webapp/admin/views.py:543
 msgid "Mês inicial"
 msgstr "Beginning month"
 
-#: opac/webapp/admin/views.py:544
+#: build/lib/opac/webapp/admin/views.py:544 opac/webapp/admin/views.py:544
 msgid "Mês final"
 msgstr "End month"
 
+#: build/lib/opac/webapp/admin/views.py:545
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:25
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:68
+#: build/lib/opac/webapp/templates/issue/grid.html:39
+#: build/lib/opac/webapp/templates/news/includes/issue_last_row.html:5
 #: opac/webapp/admin/views.py:545
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:25
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:68
@@ -822,64 +958,74 @@ msgstr "End month"
 msgid "Ano"
 msgstr "Year"
 
-#: opac/webapp/admin/views.py:546
+#: build/lib/opac/webapp/admin/views.py:546 opac/webapp/admin/views.py:546
 msgid "Etiqueta"
 msgstr "Tag"
 
-#: opac/webapp/admin/views.py:550 opac/webapp/admin/views.py:621
+#: build/lib/opac/webapp/admin/views.py:550
+#: build/lib/opac/webapp/admin/views.py:621 opac/webapp/admin/views.py:550
+#: opac/webapp/admin/views.py:621
 msgid "PID"
 msgstr "PID"
 
-#: opac/webapp/admin/views.py:559
+#: build/lib/opac/webapp/admin/views.py:559 opac/webapp/admin/views.py:559
 msgid "Número(s) publicado(s) com sucesso!!"
 msgstr "Issue(s) published successfully!!"
 
-#: opac/webapp/admin/views.py:562 opac/webapp/admin/views.py:642
+#: build/lib/opac/webapp/admin/views.py:562
+#: build/lib/opac/webapp/admin/views.py:642 opac/webapp/admin/views.py:562
+#: opac/webapp/admin/views.py:642
 #, python-format
 msgid "Ocorreu um erro tentando publicar o(s) número(s)!!. Erro: %(ex)s"
 msgstr "There was an error trying to publish the Issue(s) !!. Error: %(ex)s"
 
-#: opac/webapp/admin/views.py:569
+#: build/lib/opac/webapp/admin/views.py:569 opac/webapp/admin/views.py:569
 msgid "Número(s) despublicado(s) com sucesso!!"
 msgstr "Issue(s) unpublished successfully!!"
 
-#: opac/webapp/admin/views.py:572 opac/webapp/admin/views.py:652
+#: build/lib/opac/webapp/admin/views.py:572
+#: build/lib/opac/webapp/admin/views.py:652 opac/webapp/admin/views.py:572
+#: opac/webapp/admin/views.py:652
 #, python-format
 msgid "Ocorreu um erro tentando despublicar o(s) número(s)!!. Erro: %(ex)s"
 msgstr "There was an error trying to unpublish the Issue(s) !!. Error: %(ex)s"
 
-#: opac/webapp/admin/views.py:608
+#: build/lib/opac/webapp/admin/views.py:608 opac/webapp/admin/views.py:608
 msgid "Id Artigo"
 msgstr "Article ID"
 
-#: opac/webapp/admin/views.py:612
+#: build/lib/opac/webapp/admin/views.py:612 opac/webapp/admin/views.py:612
 msgid "Seção"
 msgstr "Section"
 
-#: opac/webapp/admin/views.py:613
+#: build/lib/opac/webapp/admin/views.py:613 opac/webapp/admin/views.py:613
 msgid "É Ahead of Print?"
 msgstr "Ahead of Print?"
 
-#: opac/webapp/admin/views.py:616
+#: build/lib/opac/webapp/admin/views.py:616 opac/webapp/admin/views.py:616
 msgid "HTML's"
 msgstr "HTML's"
 
-#: opac/webapp/admin/views.py:617
+#: build/lib/opac/webapp/admin/views.py:617 opac/webapp/admin/views.py:617
 msgid "Chave de domínio"
 msgstr "Domain key"
 
-#: opac/webapp/admin/views.py:622
+#: build/lib/opac/webapp/admin/views.py:622 opac/webapp/admin/views.py:622
 msgid "Idioma original"
 msgstr "Original language"
 
-#: opac/webapp/admin/views.py:623
+#: build/lib/opac/webapp/admin/views.py:623 opac/webapp/admin/views.py:623
 msgid "Idiomas das traduções"
 msgstr "Translations languages"
 
-#: opac/webapp/admin/views.py:625
+#: build/lib/opac/webapp/admin/views.py:625 opac/webapp/admin/views.py:625
 msgid "Autores"
 msgstr "Authors"
 
+#: build/lib/opac/webapp/admin/views.py:626
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:29
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:72
+#: build/lib/opac/webapp/templates/issue/toc.html:176
 #: opac/webapp/admin/views.py:626
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:29
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:72
@@ -887,120 +1033,143 @@ msgstr "Authors"
 msgid "Resumo"
 msgstr "Abstract"
 
-#: opac/webapp/admin/views.py:628
+#: build/lib/opac/webapp/admin/views.py:628 opac/webapp/admin/views.py:628
 msgid "DOI"
 msgstr "DOI"
 
-#: opac/webapp/admin/views.py:629
+#: build/lib/opac/webapp/admin/views.py:629 opac/webapp/admin/views.py:629
 msgid "Idiomas"
 msgstr "Languages"
 
-#: opac/webapp/admin/views.py:630
+#: build/lib/opac/webapp/admin/views.py:630 opac/webapp/admin/views.py:630
 msgid "Idiomas dos resumos"
 msgstr "Abstracts languages"
 
-#: opac/webapp/admin/views.py:638
+#: build/lib/opac/webapp/admin/views.py:638 opac/webapp/admin/views.py:638
 msgid "Artigo(s) publicado com sucesso!!"
 msgstr "Article(s) successfully published!!"
 
-#: opac/webapp/admin/views.py:649
+#: build/lib/opac/webapp/admin/views.py:649 opac/webapp/admin/views.py:649
 msgid "Artigo(s) despublicado com sucesso!!"
 msgstr "Article(s) successfully unpublished!!"
 
-#: opac/webapp/admin/views.py:679
+#: build/lib/opac/webapp/admin/views.py:679 opac/webapp/admin/views.py:679
 msgid "Conteúdo"
 msgstr "Content"
 
-#: opac/webapp/admin/views.py:681 opac/webapp/admin/views.py:901
+#: build/lib/opac/webapp/admin/views.py:681
+#: build/lib/opac/webapp/admin/views.py:901 opac/webapp/admin/views.py:681
+#: opac/webapp/admin/views.py:901
 msgid "Descrição"
 msgstr "Description"
 
-#: opac/webapp/admin/views.py:682 opac/webapp/admin/views.py:898
+#: build/lib/opac/webapp/admin/views.py:682
+#: build/lib/opac/webapp/admin/views.py:898 opac/webapp/admin/views.py:682
+#: opac/webapp/admin/views.py:898
 msgid "Data de Criação"
 msgstr "Creation Date"
 
-#: opac/webapp/admin/views.py:683
+#: build/lib/opac/webapp/admin/views.py:683 opac/webapp/admin/views.py:683
 msgid "Data de Atualização"
 msgstr "Update Date"
 
-#: opac/webapp/admin/views.py:897
+#: build/lib/opac/webapp/admin/views.py:897 opac/webapp/admin/views.py:897
 msgid "Ação"
 msgstr "Action"
 
-#: opac/webapp/admin/views.py:899
+#: build/lib/opac/webapp/admin/views.py:899 opac/webapp/admin/views.py:899
 msgid "Modelo Auditado"
 msgstr "Audited Module"
 
-#: opac/webapp/admin/views.py:900
+#: build/lib/opac/webapp/admin/views.py:900 opac/webapp/admin/views.py:900
 msgid "Id Auditado"
 msgstr "Audited Id"
 
-#: opac/webapp/admin/views.py:902
+#: build/lib/opac/webapp/admin/views.py:902 opac/webapp/admin/views.py:902
 msgid "Dados dos campos"
 msgstr "Field data"
 
-#: opac/webapp/main/views.py:29
+#: build/lib/opac/webapp/main/views.py:34 opac/webapp/main/views.py:34
 msgid "O periódico está indisponível por motivo de: "
 msgstr "The journal is unavailable because:"
 
-#: opac/webapp/main/views.py:30
+#: build/lib/opac/webapp/main/views.py:35 opac/webapp/main/views.py:35
 msgid "O número está indisponível por motivo de: "
 msgstr "The Issue is unavailable because of:"
 
-#: opac/webapp/main/views.py:31
+#: build/lib/opac/webapp/main/views.py:36 opac/webapp/main/views.py:36
 msgid "O artigo está indisponível por motivo de: "
 msgstr "The article is unavailable because:"
 
-#: opac/webapp/main/views.py:78
+#: build/lib/opac/webapp/main/views.py:127 opac/webapp/main/views.py:127
 msgid "Código de idioma inválido"
 msgstr "Invalid language code"
 
-#: opac/webapp/main/views.py:148
+#: build/lib/opac/webapp/main/views.py:197 opac/webapp/main/views.py:197
 msgid "Últimos periódicos inseridos na coleção"
 msgstr "Latest journals added to the collection"
 
-#: opac/webapp/main/views.py:149
+#: build/lib/opac/webapp/main/views.py:198 opac/webapp/main/views.py:198
 #, python-format
 msgid "10 últimos periódicos inseridos na coleção %s"
 msgstr "10 latest journals added to the collection %s"
 
-#: opac/webapp/main/views.py:208
+#: build/lib/opac/webapp/main/views.py:257 opac/webapp/main/views.py:257
 msgid "Página não encontrada"
 msgstr ""
 
-#: opac/webapp/main/views.py:232 opac/webapp/main/views.py:322
+#: build/lib/opac/webapp/main/views.py:281
+#: build/lib/opac/webapp/main/views.py:371 opac/webapp/main/views.py:281
+#: opac/webapp/main/views.py:371
 #, python-format
 msgid "Requsição inválida ao tentar acessar o artigo com pid: %s"
 msgstr ""
 
-#: opac/webapp/main/views.py:240 opac/webapp/main/views.py:290
-#: opac/webapp/main/views.py:334 opac/webapp/main/views.py:403
-#: opac/webapp/main/views.py:450 opac/webapp/main/views.py:597
-#: opac/webapp/main/views.py:614 opac/webapp/main/views.py:1055
+#: build/lib/opac/webapp/main/views.py:289
+#: build/lib/opac/webapp/main/views.py:339
+#: build/lib/opac/webapp/main/views.py:383
+#: build/lib/opac/webapp/main/views.py:452
+#: build/lib/opac/webapp/main/views.py:500
+#: build/lib/opac/webapp/main/views.py:647
+#: build/lib/opac/webapp/main/views.py:664
+#: build/lib/opac/webapp/main/views.py:1127 opac/webapp/main/views.py:289
+#: opac/webapp/main/views.py:339 opac/webapp/main/views.py:383
+#: opac/webapp/main/views.py:452 opac/webapp/main/views.py:500
+#: opac/webapp/main/views.py:647 opac/webapp/main/views.py:664
+#: opac/webapp/main/views.py:1127
 msgid "Periódico não encontrado"
 msgstr "Journal not found"
 
-#: opac/webapp/main/views.py:252 opac/webapp/main/views.py:664
-#: opac/webapp/main/views.py:723 opac/webapp/main/views.py:1064
+#: build/lib/opac/webapp/main/views.py:301
+#: build/lib/opac/webapp/main/views.py:714
+#: build/lib/opac/webapp/main/views.py:773
+#: build/lib/opac/webapp/main/views.py:1136 opac/webapp/main/views.py:301
+#: opac/webapp/main/views.py:714 opac/webapp/main/views.py:773
+#: opac/webapp/main/views.py:1136
 msgid "Número não encontrado"
 msgstr "Issue not found"
 
-#: opac/webapp/main/views.py:270 opac/webapp/main/views.py:305
-#: opac/webapp/main/views.py:774 opac/webapp/main/views.py:805
-#: opac/webapp/main/views.py:881 opac/webapp/main/views.py:884
-#: opac/webapp/main/views.py:988
+#: build/lib/opac/webapp/main/views.py:319
+#: build/lib/opac/webapp/main/views.py:354
+#: build/lib/opac/webapp/main/views.py:825
+#: build/lib/opac/webapp/main/views.py:910
+#: build/lib/opac/webapp/main/views.py:1060 opac/webapp/main/views.py:319
+#: opac/webapp/main/views.py:354 opac/webapp/main/views.py:825
+#: opac/webapp/main/views.py:910 opac/webapp/main/views.py:1060
 msgid "Artigo não encontrado"
 msgstr "Article not found"
 
-#: opac/webapp/main/views.py:427
+#: build/lib/opac/webapp/main/views.py:476 opac/webapp/main/views.py:476
 msgid "Artigo sem título"
 msgstr "Article not found"
 
-#: opac/webapp/main/views.py:498 opac/webapp/main/views.py:515
+#: build/lib/opac/webapp/main/views.py:548
+#: build/lib/opac/webapp/main/views.py:565 opac/webapp/main/views.py:548
+#: opac/webapp/main/views.py:565
 msgid "Requisição inválida. Deve ser por ajax"
 msgstr "Invalid request. Must be made via ajax"
 
-#: opac/webapp/main/views.py:531
+#: build/lib/opac/webapp/main/views.py:581 opac/webapp/main/views.py:581
 msgid ""
 "Parámetro \"filter\" é inválido, deve ser \"areas\", \"wos\" ou "
 "\"publisher\"."
@@ -1008,11 +1177,11 @@ msgstr ""
 "Invalid parameter \"filter\". Should be \"areas\", \"wos\" or "
 "\"publisher\"."
 
-#: opac/webapp/main/views.py:540
+#: build/lib/opac/webapp/main/views.py:590 opac/webapp/main/views.py:590
 msgid "Parámetro \"extension\" é inválido, deve ser \"csv\" ou \"xls\"."
 msgstr "Invalid parameter \"extension\". Should be \"csv\" or \"xls\"."
 
-#: opac/webapp/main/views.py:542
+#: build/lib/opac/webapp/main/views.py:592 opac/webapp/main/views.py:592
 msgid ""
 "Parámetro \"list_type\" é inválido, deve ser: \"alpha\", \"areas\", "
 "\"wos\" ou \"publisher\"."
@@ -1020,69 +1189,78 @@ msgstr ""
 "Invalid parameter \"list_type\". Should be: \"alpha\", \"areas\", \"wos\""
 " or \"publisher\"."
 
-#: opac/webapp/main/views.py:563
+#: build/lib/opac/webapp/main/views.py:613 opac/webapp/main/views.py:613
 msgid "Requisição inválida, deve ser ajax."
 msgstr ""
 
-#: opac/webapp/main/views.py:572
+#: build/lib/opac/webapp/main/views.py:622 opac/webapp/main/views.py:622
 msgid "Periódico não permite envio de email."
 msgstr ""
 
-#: opac/webapp/main/views.py:590
+#: build/lib/opac/webapp/main/views.py:640 opac/webapp/main/views.py:640
 msgid "Requisição inválida, captcha inválido."
 msgstr ""
 
-#: opac/webapp/main/views.py:796 opac/webapp/main/views.py:983
+#: build/lib/opac/webapp/main/views.py:901
+#: build/lib/opac/webapp/main/views.py:1055 opac/webapp/main/views.py:901
+#: opac/webapp/main/views.py:1055
 msgid "Issue não encontrado"
 msgstr "Issue not found"
 
-#: opac/webapp/main/views.py:841 opac/webapp/main/views.py:847
-#: opac/webapp/main/views.py:1020 opac/webapp/main/views.py:1028
-#: opac/webapp/main/views.py:1030
+#: build/lib/opac/webapp/main/views.py:943
+#: build/lib/opac/webapp/main/views.py:949
+#: build/lib/opac/webapp/main/views.py:1092
+#: build/lib/opac/webapp/main/views.py:1100
+#: build/lib/opac/webapp/main/views.py:1102 opac/webapp/main/views.py:943
+#: opac/webapp/main/views.py:949 opac/webapp/main/views.py:1092
+#: opac/webapp/main/views.py:1100 opac/webapp/main/views.py:1102
 msgid "PDF do Artigo não encontrado"
 msgstr "Article's PDF not found"
 
-#: opac/webapp/main/views.py:857
-msgid "HTML do Artigo não encontrado"
-msgstr "HTML of the Article not found"
-
-#: opac/webapp/main/views.py:871
+#: build/lib/opac/webapp/main/views.py:954 opac/webapp/main/views.py:954
 msgid "HTML do Artigo não encontrado ou indisponível"
 msgstr "HTML of article not found or unavailable"
 
-#: opac/webapp/main/views.py:930
+#: build/lib/opac/webapp/main/views.py:1001 opac/webapp/main/views.py:1001
 msgid "Parâmetros insuficientes para obter o EPDF do artigo"
 msgstr "Insufficient parameters to obtain article's EPDF"
 
-#: opac/webapp/main/views.py:947
+#: build/lib/opac/webapp/main/views.py:1022 opac/webapp/main/views.py:1022
 msgid "Recruso não encontrado"
 msgstr "Resource not found"
 
-#: opac/webapp/main/views.py:952
-msgid "Recurso não encontrado"
-msgstr "Resource not found"
-
-#: opac/webapp/main/views.py:969
+#: build/lib/opac/webapp/main/views.py:1041 opac/webapp/main/views.py:1041
 msgid "Recurso do Artigo não encontrado. Caminho inválido!"
 msgstr "Article resource not found. Invalid path!"
 
-#: opac/webapp/main/views.py:1082
+#: build/lib/opac/webapp/main/views.py:1154 opac/webapp/main/views.py:1154
 msgid "PDF do artigo não foi encontrado"
 msgstr "Article's PDF not found"
 
-#: opac/webapp/main/views.py:1110 opac/webapp/main/views.py:1141
+#: build/lib/opac/webapp/main/views.py:1169
+#: build/lib/opac/webapp/main/views.py:1200 opac/webapp/main/views.py:1169
+#: opac/webapp/main/views.py:1200
 msgid "Requisição inválida."
 msgstr "Invalid request"
 
+#: build/lib/opac/webapp/templates/admin/index.html:7
 #: opac/webapp/templates/admin/index.html:7
 msgid "da coleção"
 msgstr "of collection"
 
+#: build/lib/opac/webapp/templates/admin/index.html:12
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu.html:31
 #: opac/webapp/templates/admin/index.html:12
 #: opac/webapp/templates/collection/includes/levelMenu.html:31
 msgid "Periódicos"
 msgstr "Journals"
 
+#: build/lib/opac/webapp/templates/admin/index.html:15
+#: build/lib/opac/webapp/templates/admin/index.html:22
+#: build/lib/opac/webapp/templates/admin/index.html:35
+#: build/lib/opac/webapp/templates/admin/index.html:42
+#: build/lib/opac/webapp/templates/admin/index.html:55
+#: build/lib/opac/webapp/templates/admin/index.html:62
 #: opac/webapp/templates/admin/index.html:15
 #: opac/webapp/templates/admin/index.html:22
 #: opac/webapp/templates/admin/index.html:35
@@ -1092,6 +1270,12 @@ msgstr "Journals"
 msgid "Publicados"
 msgstr "Published"
 
+#: build/lib/opac/webapp/templates/admin/index.html:16
+#: build/lib/opac/webapp/templates/admin/index.html:36
+#: build/lib/opac/webapp/templates/admin/index.html:56
+#: build/lib/opac/webapp/templates/admin/index.html:75
+#: build/lib/opac/webapp/templates/admin/index.html:85
+#: build/lib/opac/webapp/templates/admin/index.html:95
 #: opac/webapp/templates/admin/index.html:16
 #: opac/webapp/templates/admin/index.html:36
 #: opac/webapp/templates/admin/index.html:56
@@ -1101,58 +1285,78 @@ msgstr "Published"
 msgid "Total"
 msgstr "Total"
 
+#: build/lib/opac/webapp/templates/admin/index.html:32
 #: opac/webapp/templates/admin/index.html:32
 msgid "Fascícluos"
 msgstr "Issues"
 
+#: build/lib/opac/webapp/templates/admin/index.html:52
 #: opac/webapp/templates/admin/index.html:52
 msgid "Artigos"
 msgstr "Articles"
 
+#: build/lib/opac/webapp/templates/admin/index.html:72
 #: opac/webapp/templates/admin/index.html:72
 msgid "News"
 msgstr "News"
 
+#: build/lib/opac/webapp/templates/admin/index.html:82
 #: opac/webapp/templates/admin/index.html:82
 msgid "Sponsors"
 msgstr "Sponsors"
 
+#: build/lib/opac/webapp/templates/admin/index.html:92
 #: opac/webapp/templates/admin/index.html:92
 msgid "Press Releases"
 msgstr "Press Releases"
 
+#: build/lib/opac/webapp/templates/admin/auth/reset.html:9
+#: build/lib/opac/webapp/templates/admin/auth/reset_with_token.html:9
+#: build/lib/opac/webapp/templates/admin/opac_base.html:13
 #: opac/webapp/templates/admin/auth/reset.html:9
 #: opac/webapp/templates/admin/auth/reset_with_token.html:9
 #: opac/webapp/templates/admin/opac_base.html:13
 msgid "Recuperar a senha"
 msgstr "Reset password"
 
+#: build/lib/opac/webapp/templates/admin/opac_base.html:14
 #: opac/webapp/templates/admin/opac_base.html:14
 msgid "Terminar sessão"
 msgstr "Logout"
 
+#: build/lib/opac/webapp/templates/admin/auth/login.html:11
+#: build/lib/opac/webapp/templates/admin/auth/login.html:20
+#: build/lib/opac/webapp/templates/admin/opac_base.html:18
 #: opac/webapp/templates/admin/auth/login.html:11
 #: opac/webapp/templates/admin/auth/login.html:20
 #: opac/webapp/templates/admin/opac_base.html:18
 msgid "Iniciar sessão"
 msgstr "Login"
 
+#: build/lib/opac/webapp/templates/admin/audit_log/fields_data_table.html:4
 #: opac/webapp/templates/admin/audit_log/fields_data_table.html:4
 msgid "Campo: "
 msgstr "Field:"
 
+#: build/lib/opac/webapp/templates/admin/audit_log/fields_data_table.html:5
 #: opac/webapp/templates/admin/audit_log/fields_data_table.html:5
 msgid "Valor anterior: "
 msgstr "Previous value:"
 
+#: build/lib/opac/webapp/templates/admin/audit_log/fields_data_table.html:6
 #: opac/webapp/templates/admin/audit_log/fields_data_table.html:6
 msgid "Valor novo: "
 msgstr "New value:"
 
+#: build/lib/opac/webapp/templates/admin/auth/login.html:13
 #: opac/webapp/templates/admin/auth/login.html:13
 msgid "Você já iniciou sessão!"
 msgstr "You’re already logged in!"
 
+#: build/lib/opac/webapp/templates/admin/auth/login.html:24
+#: build/lib/opac/webapp/templates/admin/auth/reset.html:13
+#: build/lib/opac/webapp/templates/admin/auth/reset_with_token.html:13
+#: build/lib/opac/webapp/templates/includes/error_form.html:60
 #: opac/webapp/templates/admin/auth/login.html:24
 #: opac/webapp/templates/admin/auth/reset.html:13
 #: opac/webapp/templates/admin/auth/reset_with_token.html:13
@@ -1160,14 +1364,17 @@ msgstr "You’re already logged in!"
 msgid "Enviar"
 msgstr "Send"
 
+#: build/lib/opac/webapp/templates/admin/auth/login.html:28
 #: opac/webapp/templates/admin/auth/login.html:28
 msgid "Esqueci a senha?"
 msgstr "Forgot the password?"
 
+#: build/lib/opac/webapp/templates/admin/auth/unconfirm_email.html:7
 #: opac/webapp/templates/admin/auth/unconfirm_email.html:7
 msgid "Email não confirmado!"
 msgstr "Email not confirmed!"
 
+#: build/lib/opac/webapp/templates/admin/auth/unconfirm_email.html:9
 #: opac/webapp/templates/admin/auth/unconfirm_email.html:9
 msgid ""
 "Você <strong>deve</strong> confirmar seu email.<br>\n"
@@ -1177,6 +1384,7 @@ msgstr ""
 "You <strong>should</strong> confirm your email.<br>\n"
 "<strong>Please contact your administrator.</strong>"
 
+#: build/lib/opac/webapp/templates/admin/pages/edit.html:7
 #: opac/webapp/templates/admin/pages/edit.html:7
 msgid ""
 "<strong>Atenção:</strong> ao selecionar um <strong>periódico</strong> "
@@ -1189,6 +1397,11 @@ msgstr ""
 "otherwise the page will be a collection page, check the collection pages "
 "at <em>About SciELO</em>"
 
+#: build/lib/opac/webapp/templates/article/includes/alternative_header.html:7
+#: build/lib/opac/webapp/templates/collection/includes/header.html:7
+#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:7
+#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:7
+#: build/lib/opac/webapp/templates/journal/includes/header.html:8
 #: opac/webapp/templates/article/includes/alternative_header.html:7
 #: opac/webapp/templates/collection/includes/header.html:7
 #: opac/webapp/templates/issue/includes/alternative_header.html:7
@@ -1197,6 +1410,10 @@ msgstr ""
 msgid "Abrir menu"
 msgstr "Open menu"
 
+#: build/lib/opac/webapp/templates/article/includes/alternative_header.html:9
+#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:9
+#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:9
+#: build/lib/opac/webapp/templates/journal/includes/header.html:10
 #: opac/webapp/templates/article/includes/alternative_header.html:9
 #: opac/webapp/templates/issue/includes/alternative_header.html:9
 #: opac/webapp/templates/journal/includes/alternative_header.html:9
@@ -1204,6 +1421,11 @@ msgstr "Open menu"
 msgid "Ir para a homepage da coleção: "
 msgstr "Go to the home page of the collection:"
 
+#: build/lib/opac/webapp/templates/article/includes/alternative_header.html:42
+#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:7
+#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:121
+#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:117
+#: build/lib/opac/webapp/templates/journal/includes/header.html:118
 #: opac/webapp/templates/article/includes/alternative_header.html:42
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:7
 #: opac/webapp/templates/issue/includes/alternative_header.html:121
@@ -1212,6 +1434,11 @@ msgstr "Go to the home page of the collection:"
 msgid "Submissão de manuscritos"
 msgstr "Submission of manuscripts"
 
+#: build/lib/opac/webapp/templates/article/includes/alternative_header.html:48
+#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:16
+#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:127
+#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:123
+#: build/lib/opac/webapp/templates/journal/includes/header.html:124
 #: opac/webapp/templates/article/includes/alternative_header.html:48
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:16
 #: opac/webapp/templates/issue/includes/alternative_header.html:127
@@ -1220,6 +1447,11 @@ msgstr "Submission of manuscripts"
 msgid "Sobre o periódico"
 msgstr "About the journal"
 
+#: build/lib/opac/webapp/templates/article/includes/alternative_header.html:53
+#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:10
+#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:132
+#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:128
+#: build/lib/opac/webapp/templates/journal/includes/header.html:129
 #: opac/webapp/templates/article/includes/alternative_header.html:53
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:10
 #: opac/webapp/templates/issue/includes/alternative_header.html:132
@@ -1228,6 +1460,11 @@ msgstr "About the journal"
 msgid "Corpo Editorial"
 msgstr "Editorial Board"
 
+#: build/lib/opac/webapp/templates/article/includes/alternative_header.html:58
+#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:13
+#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:137
+#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:133
+#: build/lib/opac/webapp/templates/journal/includes/header.html:134
 #: opac/webapp/templates/article/includes/alternative_header.html:58
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:13
 #: opac/webapp/templates/issue/includes/alternative_header.html:137
@@ -1236,6 +1473,11 @@ msgstr "Editorial Board"
 msgid "Instruções aos autores"
 msgstr "Instructions to authors"
 
+#: build/lib/opac/webapp/templates/article/includes/alternative_header.html:63
+#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:19
+#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:142
+#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:138
+#: build/lib/opac/webapp/templates/journal/includes/header.html:140
 #: opac/webapp/templates/article/includes/alternative_header.html:63
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:19
 #: opac/webapp/templates/issue/includes/alternative_header.html:142
@@ -1244,56 +1486,81 @@ msgstr "Instructions to authors"
 msgid "Contato"
 msgstr "Contact"
 
+#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:2
+#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:60
 #: opac/webapp/templates/article/includes/floating_menu.html:2
 #: opac/webapp/templates/article/includes/floating_menu.html:60
 msgid "Ir para o topo"
 msgstr "Go to top"
 
+#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:6
+#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:65
 #: opac/webapp/templates/article/includes/floating_menu.html:6
 #: opac/webapp/templates/article/includes/floating_menu.html:65
 msgid "PDFs"
 msgstr "PDFs"
 
+#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:26
+#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:77
 #: opac/webapp/templates/article/includes/floating_menu.html:26
 #: opac/webapp/templates/article/includes/floating_menu.html:77
 msgid "Figuras e tabelas"
 msgstr "Figures and tables"
 
+#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:32
+#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:83
 #: opac/webapp/templates/article/includes/floating_menu.html:32
 #: opac/webapp/templates/article/includes/floating_menu.html:83
 msgid "Versões e traduções"
 msgstr "Versions and translations"
 
+#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:37
+#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:88
 #: opac/webapp/templates/article/includes/floating_menu.html:37
 #: opac/webapp/templates/article/includes/floating_menu.html:88
 msgid "Como citar este artigo"
 msgstr "How to cite this article"
 
+#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:42
+#: build/lib/opac/webapp/templates/article/includes/modal/related_article.html:9
 #: opac/webapp/templates/article/includes/floating_menu.html:42
 #: opac/webapp/templates/article/includes/modal/related_article.html:9
 msgid "Artigos relacionados"
 msgstr "Related articles"
 
+#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:93
 #: opac/webapp/templates/article/includes/floating_menu.html:93
 msgid "Artigos e similares"
 msgstr "Articles and alike"
 
+#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:9
 #: opac/webapp/templates/article/includes/levelMenu.html:9
 msgid "home do periodico"
 msgstr "Home of journal"
 
+#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:17
+#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:70
+#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:123
 #: opac/webapp/templates/article/includes/levelMenu.html:17
 #: opac/webapp/templates/article/includes/levelMenu.html:70
 #: opac/webapp/templates/article/includes/levelMenu.html:123
 msgid "sumário"
 msgstr "summary"
 
+#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:30
+#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:75
+#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:71
 #: opac/webapp/templates/article/includes/levelMenu.html:30
 #: opac/webapp/templates/issue/includes/alternative_header.html:75
 #: opac/webapp/templates/journal/includes/alternative_header.html:71
 msgid "anterior"
 msgstr "previous"
 
+#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:35
+#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:88
+#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:141
+#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:82
+#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:78
 #: opac/webapp/templates/article/includes/levelMenu.html:35
 #: opac/webapp/templates/article/includes/levelMenu.html:88
 #: opac/webapp/templates/article/includes/levelMenu.html:141
@@ -1302,10 +1569,15 @@ msgstr "previous"
 msgid "atual"
 msgstr "current"
 
+#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:48
 #: opac/webapp/templates/article/includes/levelMenu.html:48
 msgid "seguinte"
 msgstr "next"
 
+#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:193
+#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:219
+#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:264
+#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:290
 #: opac/webapp/templates/article/includes/levelMenu.html:193
 #: opac/webapp/templates/article/includes/levelMenu.html:219
 #: opac/webapp/templates/article/includes/levelMenu.html:264
@@ -1313,6 +1585,10 @@ msgstr "next"
 msgid "Download PDF (Espanhol)"
 msgstr "Download PDF (Spanish)"
 
+#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:195
+#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:221
+#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:266
+#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:292
 #: opac/webapp/templates/article/includes/levelMenu.html:195
 #: opac/webapp/templates/article/includes/levelMenu.html:221
 #: opac/webapp/templates/article/includes/levelMenu.html:266
@@ -1320,6 +1596,10 @@ msgstr "Download PDF (Spanish)"
 msgid "Download PDF (Inglês)"
 msgstr "Download PDF (English)"
 
+#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:197
+#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:223
+#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:268
+#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:294
 #: opac/webapp/templates/article/includes/levelMenu.html:197
 #: opac/webapp/templates/article/includes/levelMenu.html:223
 #: opac/webapp/templates/article/includes/levelMenu.html:268
@@ -1327,6 +1607,13 @@ msgstr "Download PDF (English)"
 msgid "Download PDF (Português)"
 msgstr "Download PDF (Portuguese)"
 
+#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:310
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu.html:38
+#: build/lib/opac/webapp/templates/collection/includes/list_journals_section_title.html:14
+#: build/lib/opac/webapp/templates/issue/grid.html:14
+#: build/lib/opac/webapp/templates/issue/toc.html:13
+#: build/lib/opac/webapp/templates/journal/about.html:16
+#: build/lib/opac/webapp/templates/journal/detail.html:11
 #: opac/webapp/templates/article/includes/levelMenu.html:310
 #: opac/webapp/templates/collection/includes/levelMenu.html:38
 #: opac/webapp/templates/collection/includes/list_journals_section_title.html:14
@@ -1337,6 +1624,11 @@ msgstr "Download PDF (Portuguese)"
 msgid "Compartilhe"
 msgstr "Share"
 
+#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:311
+#: build/lib/opac/webapp/templates/collection/includes/list_journals_section_title.html:16
+#: build/lib/opac/webapp/templates/issue/toc.html:14
+#: build/lib/opac/webapp/templates/journal/about.html:17
+#: build/lib/opac/webapp/templates/journal/detail.html:12
 #: opac/webapp/templates/article/includes/levelMenu.html:311
 #: opac/webapp/templates/collection/includes/list_journals_section_title.html:16
 #: opac/webapp/templates/issue/toc.html:14
@@ -1345,6 +1637,11 @@ msgstr "Share"
 msgid "Enviar link por e-mail"
 msgstr "Send link by email"
 
+#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:314
+#: build/lib/opac/webapp/templates/collection/includes/list_journals_section_title.html:19
+#: build/lib/opac/webapp/templates/issue/toc.html:15
+#: build/lib/opac/webapp/templates/journal/about.html:18
+#: build/lib/opac/webapp/templates/journal/detail.html:13
 #: opac/webapp/templates/article/includes/levelMenu.html:314
 #: opac/webapp/templates/collection/includes/list_journals_section_title.html:19
 #: opac/webapp/templates/issue/toc.html:15
@@ -1353,6 +1650,11 @@ msgstr "Send link by email"
 msgid "Compartilhar no Facebook"
 msgstr "Share in Facebook"
 
+#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:317
+#: build/lib/opac/webapp/templates/collection/includes/list_journals_section_title.html:22
+#: build/lib/opac/webapp/templates/issue/toc.html:16
+#: build/lib/opac/webapp/templates/journal/about.html:19
+#: build/lib/opac/webapp/templates/journal/detail.html:14
 #: opac/webapp/templates/article/includes/levelMenu.html:317
 #: opac/webapp/templates/collection/includes/list_journals_section_title.html:22
 #: opac/webapp/templates/issue/toc.html:16
@@ -1361,6 +1663,18 @@ msgstr "Share in Facebook"
 msgid "Compartilhar no Twitter"
 msgstr "Share in Twitter"
 
+#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:320
+#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:325
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu.html:46
+#: build/lib/opac/webapp/templates/collection/includes/list_journals_section_title.html:25
+#: build/lib/opac/webapp/templates/collection/includes/list_journals_section_title.html:30
+#: build/lib/opac/webapp/templates/issue/grid.html:20
+#: build/lib/opac/webapp/templates/issue/toc.html:17
+#: build/lib/opac/webapp/templates/issue/toc.html:19
+#: build/lib/opac/webapp/templates/journal/about.html:20
+#: build/lib/opac/webapp/templates/journal/about.html:22
+#: build/lib/opac/webapp/templates/journal/detail.html:15
+#: build/lib/opac/webapp/templates/journal/detail.html:17
 #: opac/webapp/templates/article/includes/levelMenu.html:320
 #: opac/webapp/templates/article/includes/levelMenu.html:325
 #: opac/webapp/templates/collection/includes/levelMenu.html:46
@@ -1376,16 +1690,24 @@ msgstr "Share in Twitter"
 msgid "Outras redes sociais"
 msgstr "Other social networks"
 
+#: build/lib/opac/webapp/templates/article/includes/recent_articles_row.html:6
+#: build/lib/opac/webapp/templates/issue/toc.html:149
 #: opac/webapp/templates/article/includes/recent_articles_row.html:6
 #: opac/webapp/templates/issue/toc.html:149
 msgid "Documento sem título"
 msgstr "Untitled document"
 
+#: build/lib/opac/webapp/templates/article/includes/recent_articles_row.html:13
+#: build/lib/opac/webapp/templates/news/includes/journal_news_row.html:14
 #: opac/webapp/templates/article/includes/recent_articles_row.html:13
-#: opac/webapp/templates/news/includes/journal_news_row.html:9
+#: opac/webapp/templates/news/includes/journal_news_row.html:14
 msgid "Continue lendo"
 msgstr "Continue reading"
 
+#: build/lib/opac/webapp/templates/article/includes/modal/download.html:6
+#: build/lib/opac/webapp/templates/article/includes/modal/related_article.html:7
+#: build/lib/opac/webapp/templates/email/email_form.html:7
+#: build/lib/opac/webapp/templates/includes/metric_modal.html:6
 #: opac/webapp/templates/article/includes/modal/download.html:6
 #: opac/webapp/templates/article/includes/modal/related_article.html:7
 #: opac/webapp/templates/email/email_form.html:7
@@ -1393,317 +1715,416 @@ msgstr "Continue reading"
 msgid "Fechar"
 msgstr "Close"
 
+#: build/lib/opac/webapp/templates/article/includes/modal/download.html:8
 #: opac/webapp/templates/article/includes/modal/download.html:8
 msgid "Versão para download de PDF"
 msgstr "PDF version for download"
 
+#: build/lib/opac/webapp/templates/article/includes/modal/translate_version.html:6
 #: opac/webapp/templates/article/includes/modal/translate_version.html:6
 msgid "Versões e tradução automática"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/article/includes/modal/translate_version.html:11
 #: opac/webapp/templates/article/includes/modal/translate_version.html:11
 msgid "Versão original do texto"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/about.html:23
+#: build/lib/opac/webapp/templates/collection/pages.html:21
 #: opac/webapp/templates/collection/about.html:23
+#: opac/webapp/templates/collection/pages.html:21
 #, python-format
 msgid " %(page)s "
 msgstr " %(page)s "
 
+#: build/lib/opac/webapp/templates/collection/about.html:38
+#: build/lib/opac/webapp/templates/collection/pages.html:36
 #: opac/webapp/templates/collection/about.html:38
+#: opac/webapp/templates/collection/pages.html:36
 msgid " Conteúdo não cadastrado "
 msgstr "No journal information has been submitted"
 
+#: build/lib/opac/webapp/templates/collection/index.html:17
 #: opac/webapp/templates/collection/index.html:17
 msgid "em números | Métricas"
 msgstr "in numbers | Metrics"
 
+#: build/lib/opac/webapp/templates/collection/index.html:27
 #: opac/webapp/templates/collection/index.html:27
 msgid "períodicos"
 msgstr "journals"
 
+#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:31
+#: build/lib/opac/webapp/templates/collection/index.html:31
+#: build/lib/opac/webapp/templates/collection/list_feed_content.html:7
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:31
 #: opac/webapp/templates/collection/index.html:31
 #: opac/webapp/templates/collection/list_feed_content.html:7
 msgid "números"
 msgstr "issues"
 
+#: build/lib/opac/webapp/templates/collection/index.html:35
+#: build/lib/opac/webapp/templates/issue/grid.html:68
 #: opac/webapp/templates/collection/index.html:35
 #: opac/webapp/templates/issue/grid.html:68
 msgid "artigos"
 msgstr "articles"
 
+#: build/lib/opac/webapp/templates/collection/index.html:39
 #: opac/webapp/templates/collection/index.html:39
 msgid "referências"
 msgstr "references"
 
+#: build/lib/opac/webapp/templates/collection/index.html:45
 #: opac/webapp/templates/collection/index.html:45
 msgid "Downloads"
 msgstr "Downloads"
 
+#: build/lib/opac/webapp/templates/collection/index.html:48
 #: opac/webapp/templates/collection/index.html:48
 msgid "Citações"
 msgstr "Citations"
 
+#: build/lib/opac/webapp/templates/collection/index.html:51
 #: opac/webapp/templates/collection/index.html:51
 msgid "Outros indicadores"
 msgstr "Other indicators"
 
+#: build/lib/opac/webapp/templates/collection/index.html:62
+#: build/lib/opac/webapp/templates/collection/list_journal.html:3
 #: opac/webapp/templates/collection/index.html:62
 #: opac/webapp/templates/collection/list_journal.html:3
 msgid "Lista de periódicos"
 msgstr "Journal list"
 
+#: build/lib/opac/webapp/templates/collection/index.html:66
+#: build/lib/opac/webapp/templates/collection/list_journal.html:21
 #: opac/webapp/templates/collection/index.html:66
 #: opac/webapp/templates/collection/list_journal.html:21
 msgid "Alfabética"
 msgstr "Alphabetic"
 
+#: build/lib/opac/webapp/templates/collection/index.html:69
+#: build/lib/opac/webapp/templates/collection/list_journal.html:24
 #: opac/webapp/templates/collection/index.html:69
 #: opac/webapp/templates/collection/list_journal.html:24
 msgid "Temática"
 msgstr "Thematic"
 
+#: build/lib/opac/webapp/templates/collection/index.html:77
 #: opac/webapp/templates/collection/index.html:77
 msgid "Busca por periódicos"
 msgstr "Search by journals"
 
+#: build/lib/opac/webapp/templates/collection/index.html:105
 #: opac/webapp/templates/collection/index.html:105
 msgid "Números <span>mais recentes</span>"
 msgstr "<span>Latest</span> issues"
 
+#: build/lib/opac/webapp/templates/collection/index.html:149
 #: opac/webapp/templates/collection/index.html:149
 msgid "em perspectiva"
 msgstr "in perspective"
 
+#: build/lib/opac/webapp/templates/collection/list_feed_content.html:1
 #: opac/webapp/templates/collection/list_feed_content.html:1
 msgid "Último número"
 msgstr "Last issue"
 
+#: build/lib/opac/webapp/templates/collection/list_feed_content.html:4
 #: opac/webapp/templates/collection/list_feed_content.html:4
 msgid "Nº"
 msgstr "Nº"
 
+#: build/lib/opac/webapp/templates/collection/list_feed_content.html:6
 #: opac/webapp/templates/collection/list_feed_content.html:6
 msgid "descontinuado"
 msgstr "non-current"
 
+#: build/lib/opac/webapp/templates/collection/list_feed_content.html:7
 #: opac/webapp/templates/collection/list_feed_content.html:7
 msgid "de"
 msgstr "of"
 
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu.html:11
+#: build/lib/opac/webapp/templates/collection/list_journal.html:16
 #: opac/webapp/templates/collection/includes/levelMenu.html:11
 #: opac/webapp/templates/collection/list_journal.html:16
 msgid "Home"
 msgstr "Home"
 
+#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_grouper_table_container.html:14
+#: build/lib/opac/webapp/templates/collection/list_journal.html:52
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_grouper_table_container.html:14
 #: opac/webapp/templates/collection/list_journal.html:52
 msgid "download da lista"
 msgstr "list download"
 
+#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_grouper_table_container.html:15
+#: build/lib/opac/webapp/templates/collection/list_journal.html:53
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_grouper_table_container.html:15
 #: opac/webapp/templates/collection/list_journal.html:53
 msgid "Lista em arquivo para Excel"
 msgstr "List downloaded as an Excel file"
 
+#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_grouper_table_container.html:18
+#: build/lib/opac/webapp/templates/collection/list_journal.html:56
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_grouper_table_container.html:18
 #: opac/webapp/templates/collection/list_journal.html:56
 msgid "Lista em arquivo CSV"
 msgstr "List downloaded as a CSV file"
 
+#: build/lib/opac/webapp/templates/collection/list_journal.html:80
+#: build/lib/opac/webapp/templates/collection/list_journal.html:84
 #: opac/webapp/templates/collection/list_journal.html:80
 #: opac/webapp/templates/collection/list_journal.html:84
 msgid "Grandes áreas do conhecimento"
 msgstr "Major areas of knowledge"
 
+#: build/lib/opac/webapp/templates/collection/list_journal.html:85
 #: opac/webapp/templates/collection/list_journal.html:85
 msgid "Áreas temáticas do Web of Science"
 msgstr "Web of Science Thematic Areas"
 
+#: build/lib/opac/webapp/templates/collection/list_journal.html:222
 #: opac/webapp/templates/collection/list_journal.html:222
 msgid "grandes áreas"
 msgstr "broad areas"
 
+#: build/lib/opac/webapp/templates/collection/list_journal.html:236
 #: opac/webapp/templates/collection/list_journal.html:236
 msgid "áreas WOS"
 msgstr "WOS subject areas"
 
+#: build/lib/opac/webapp/templates/collection/list_journal.html:248
 #: opac/webapp/templates/collection/list_journal.html:248
 msgid "Editoras"
 msgstr "Publishers"
 
+#: build/lib/opac/webapp/templates/collection/list_journal.html:249
 #: opac/webapp/templates/collection/list_journal.html:249
 msgid "editoras"
 msgstr "publishers"
 
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:7
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:7
 msgid "Sobre o"
 msgstr "About"
 
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:19
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:62
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:19
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:62
 msgid "Entre uma ou mais palavras"
 msgstr "Enter one or more words"
 
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:24
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:67
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:24
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:67
 msgid "Todos os índices"
 msgstr "All indexes"
 
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:26
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:69
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:26
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:69
 msgid "Autor"
 msgstr "Author"
 
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:38
+#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:95
+#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:91
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:38
 #: opac/webapp/templates/issue/includes/alternative_header.html:95
 #: opac/webapp/templates/journal/includes/alternative_header.html:91
 msgid "Buscar"
 msgstr "Search"
 
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:44
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:44
 msgid "Adicionar outro campo"
 msgstr "Add another field"
 
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:49
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:49
 msgid "Apagar campo"
 msgstr "Delete field"
 
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:63
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:63
 msgid "Limpar expressão"
 msgstr "Reset"
 
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:92
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:92
 msgid "Sem resultados"
 msgstr "No results"
 
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:96
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:96
 msgid "Não foram encontrados documentos para sua pesquisa"
 msgstr "No documents found which meet your search criteria"
 
+#: build/lib/opac/webapp/templates/collection/includes/list_journals_search_input.html:5
 #: opac/webapp/templates/collection/includes/list_journals_search_input.html:5
 msgid "Todos"
 msgstr "All"
 
+#: build/lib/opac/webapp/templates/collection/includes/list_journals_search_input.html:9
 #: opac/webapp/templates/collection/includes/list_journals_search_input.html:9
 msgid "Periódicos ativos"
 msgstr "Current journals"
 
+#: build/lib/opac/webapp/templates/collection/includes/list_journals_search_input.html:13
 #: opac/webapp/templates/collection/includes/list_journals_search_input.html:13
 msgid "Periódicos descontinuados"
 msgstr "Non-current journals"
 
+#: build/lib/opac/webapp/templates/collection/includes/list_journals_search_input.html:24
 #: opac/webapp/templates/collection/includes/list_journals_search_input.html:24
 msgid "Digite uma ou mais palavras para filtrar a lista"
 msgstr "Enter one or more words to filter the list"
 
+#: build/lib/opac/webapp/templates/collection/includes/nav.html:22
+#: build/lib/opac/webapp/templates/collection/includes/nav.html:64
 #: opac/webapp/templates/collection/includes/nav.html:22
 #: opac/webapp/templates/collection/includes/nav.html:64
 msgid "Busca"
 msgstr "Search"
 
+#: build/lib/opac/webapp/templates/collection/includes/nav.html:32
 #: opac/webapp/templates/collection/includes/nav.html:32
 msgid "Sobre:"
 msgstr "About:"
 
+#: build/lib/opac/webapp/templates/collection/includes/nav.html:44
 #: opac/webapp/templates/collection/includes/nav.html:44
 msgid "SciELO.org - Rede SciELO"
 msgstr "SciELO.org - The SciELO Network"
 
+#: build/lib/opac/webapp/templates/collection/includes/nav.html:95
 #: opac/webapp/templates/collection/includes/nav.html:95
 msgid "Blog SciELO em Perspectiva"
 msgstr "Blog SciELO in Perspective"
 
+#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_empty.html:3
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_empty.html:3
 msgid "Nenhum periódico encontrado."
 msgstr "No journals found."
 
+#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_error.html:3
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_error.html:3
 msgid "Ocorreu um erro obtendo a lista de periódicos."
 msgstr "An error occurred in getting the list of journals."
 
+#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_grouper_table_container.html:10
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_grouper_table_container.html:10
 msgid "periódicos"
 msgstr "journals"
 
+#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:3
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:3
 msgid "Homepage"
 msgstr "Home page"
 
+#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:25
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:25
 msgid "Título do periódico"
 msgstr "Journal title"
 
+#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:29
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:29
 msgid "Grade de número"
 msgstr "Issue grid"
 
+#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:36
+#: build/lib/opac/webapp/templates/journal/detail.html:89
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:36
 #: opac/webapp/templates/journal/detail.html:89
 msgid "Número mais recente"
 msgstr "Most recent issue"
 
+#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:37
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:37
 msgid "Último"
 msgstr "Latest"
 
+#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:45
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:45
 msgid "Continua como "
 msgstr "Continues as"
 
+#: build/lib/opac/webapp/templates/email/email_form.html:10
 #: opac/webapp/templates/email/email_form.html:10
 msgid "Enviar página por e-mail"
 msgstr "Send page by e-mail "
 
+#: build/lib/opac/webapp/templates/email/email_form.html:18
+#: build/lib/opac/webapp/templates/includes/error_form.html:26
+#: build/lib/opac/webapp/templates/journal/includes/contact_form.html:20
 #: opac/webapp/templates/email/email_form.html:18
 #: opac/webapp/templates/includes/error_form.html:26
 #: opac/webapp/templates/journal/includes/contact_form.html:20
 msgid "Seu e-mail"
 msgstr "Your e-mail"
 
+#: build/lib/opac/webapp/templates/email/email_form.html:23
 #: opac/webapp/templates/email/email_form.html:23
 msgid "Para"
 msgstr "For"
 
+#: build/lib/opac/webapp/templates/email/email_form.html:27
 #: opac/webapp/templates/email/email_form.html:27
 msgid "Utilize ; (ponto e vírgula) para inserir mais emails."
 msgstr "Use ; (point and comma)  for insert more emails"
 
+#: build/lib/opac/webapp/templates/email/email_form.html:36
 #: opac/webapp/templates/email/email_form.html:36
 msgid "Alterar assunto e comentários"
 msgstr "Change subject e comments"
 
+#: build/lib/opac/webapp/templates/email/email_form.html:41
 #: opac/webapp/templates/email/email_form.html:41
 msgid "Assunto"
 msgstr "Subject"
 
+#: build/lib/opac/webapp/templates/email/email_form.html:45
 #: opac/webapp/templates/email/email_form.html:45
 msgid "Comentário"
 msgstr "Comments"
 
+#: build/lib/opac/webapp/templates/email/email_form.html:49
 #: opac/webapp/templates/email/email_form.html:49
 msgid "Remover remetente, assunto e comentários"
 msgstr "Remove sender, subject and comments"
 
+#: build/lib/opac/webapp/templates/email/email_form.html:75
 #: opac/webapp/templates/email/email_form.html:75
 msgid "Email enviado com sucesso."
 msgstr "Email sent with success."
 
+#: build/lib/opac/webapp/templates/email/email_form.html:76
+#: build/lib/opac/webapp/templates/includes/error_form.html:86
+#: build/lib/opac/webapp/templates/journal/includes/contact_form.html:77
 #: opac/webapp/templates/email/email_form.html:76
 #: opac/webapp/templates/includes/error_form.html:86
 #: opac/webapp/templates/journal/includes/contact_form.html:77
 msgid "Erro ao tentar enviar e-mail, por favor tente mais tarde."
 msgstr "Error trying send e-mail, please, try again later."
 
+#: build/lib/opac/webapp/templates/errors/400.html:7
 #: opac/webapp/templates/errors/400.html:7
 msgid "Ação inválida"
 msgstr "Invalid action"
 
+#: build/lib/opac/webapp/templates/errors/403.html:7
 #: opac/webapp/templates/errors/403.html:7
 msgid "Acesso não autorizado!"
 msgstr "Access not authorized"
 
+#: build/lib/opac/webapp/templates/errors/404.html:7
 #: opac/webapp/templates/errors/404.html:7
 msgid ""
 "A URL solicitada não foi encontrada no servidor. Se você digitou a URL "
@@ -1712,6 +2133,7 @@ msgstr ""
 "The requested URL was not found on the server. If you typed in the URL, "
 "please check it and try again."
 
+#: build/lib/opac/webapp/templates/errors/500.html:5
 #: opac/webapp/templates/errors/500.html:5
 msgid ""
 "Erro interno do servidor. Tente novamente mais tarde. Nossos engenheiros "
@@ -1720,286 +2142,370 @@ msgstr ""
 "Internal server error. Please try again later. Our technical staff has "
 "been notified."
 
+#: build/lib/opac/webapp/templates/errors/500.html:9
 #: opac/webapp/templates/errors/500.html:9
 msgid "Id. do erro"
 msgstr "Error id."
 
+#: build/lib/opac/webapp/templates/errors/base.html:24
 #: opac/webapp/templates/errors/base.html:24
 msgid "Erro"
 msgstr "Error"
 
+#: build/lib/opac/webapp/templates/errors/base.html:27
 #: opac/webapp/templates/errors/base.html:27
 msgid "Qualquer dúvida, por favor entre em contato com o administrador"
 msgstr ""
 "Please contact the administrator if you have any questions, doubts or "
 "concerns"
 
+#: build/lib/opac/webapp/templates/includes/error_form.html:5
 #: opac/webapp/templates/includes/error_form.html:5
 msgid " Reportar erro "
 msgstr ""
 
+#: build/lib/opac/webapp/templates/includes/error_form.html:20
+#: build/lib/opac/webapp/templates/journal/includes/contact_form.html:14
 #: opac/webapp/templates/includes/error_form.html:20
 #: opac/webapp/templates/journal/includes/contact_form.html:14
 msgid "Seu Nome"
 msgstr "Your Name"
 
+#: build/lib/opac/webapp/templates/includes/error_form.html:21
 #: opac/webapp/templates/includes/error_form.html:21
 msgid "Digite seu Nome"
 msgstr "Type your Name"
 
+#: build/lib/opac/webapp/templates/includes/error_form.html:32
 #: opac/webapp/templates/includes/error_form.html:32
 msgid "Erro referente"
 msgstr "Referring error"
 
+#: build/lib/opac/webapp/templates/includes/error_form.html:35
 #: opac/webapp/templates/includes/error_form.html:35
 msgid "ao conteúdo"
 msgstr "to content"
 
+#: build/lib/opac/webapp/templates/includes/error_form.html:39
 #: opac/webapp/templates/includes/error_form.html:39
 msgid "à aplicação"
 msgstr "the app"
 
+#: build/lib/opac/webapp/templates/includes/error_form.html:46
 #: opac/webapp/templates/includes/error_form.html:46
 msgid "Descrição do erro"
 msgstr "Erro description"
 
+#: build/lib/opac/webapp/templates/includes/error_form.html:47
 #: opac/webapp/templates/includes/error_form.html:47
 msgid "Digite sua mensagem"
 msgstr "Enter your message"
 
+#: build/lib/opac/webapp/templates/includes/error_form.html:49
 #: opac/webapp/templates/includes/error_form.html:49
 msgid "Obs.: Link e título da página são enviados automaticamente"
 msgstr "Note: Link and page title are sent automatically"
 
+#: build/lib/opac/webapp/templates/includes/error_form.html:85
 #: opac/webapp/templates/includes/error_form.html:85
 msgid "Email de erro enviado com sucesso."
 msgstr "Error email sent successfully."
 
+#: build/lib/opac/webapp/templates/includes/footer.html:36
 #: opac/webapp/templates/includes/footer.html:36
 msgid "Open Access"
 msgstr "Open Access"
 
+#: build/lib/opac/webapp/templates/includes/footer.html:38
 #: opac/webapp/templates/includes/footer.html:38
 msgid "Leia"
 msgstr "Read"
 
+#: build/lib/opac/webapp/templates/includes/footer.html:38
 #: opac/webapp/templates/includes/footer.html:38
 msgid "a Declaração de Acesso Aberto"
 msgstr "our Open Access Statement"
 
+#: build/lib/opac/webapp/templates/issue/grid.html:4
 #: opac/webapp/templates/issue/grid.html:4
 msgid "Fascículos"
 msgstr "Issues"
 
+#: build/lib/opac/webapp/templates/issue/grid.html:33
 #: opac/webapp/templates/issue/grid.html:33
 msgid "Todos os números"
 msgstr "All issues"
 
+#: build/lib/opac/webapp/templates/issue/grid.html:79
 #: opac/webapp/templates/issue/grid.html:79
 msgid "supl."
 msgstr "suppl."
 
+#: build/lib/opac/webapp/templates/issue/grid.html:98
 #: opac/webapp/templates/issue/grid.html:98
 msgid "Nenhum número encontrado para esse periódico"
 msgstr "No Issue was found for this Journal"
 
+#: build/lib/opac/webapp/templates/issue/grid.html:101
 #: opac/webapp/templates/issue/grid.html:101
 msgid "Histórico deste periódico na coleção"
 msgstr "History of the journal in the collection"
 
+#: build/lib/opac/webapp/templates/issue/grid.html:105
 #: opac/webapp/templates/issue/grid.html:105
 msgid " admitido na coleção da SciELO"
 msgstr "admitted to the SciELO collection"
 
+#: build/lib/opac/webapp/templates/issue/toc.html:10
+#: build/lib/opac/webapp/templates/journal/detail.html:8
 #: opac/webapp/templates/issue/toc.html:10
 #: opac/webapp/templates/journal/detail.html:8
 msgid "Imprimir"
 msgstr "Print"
 
+#: build/lib/opac/webapp/templates/issue/toc.html:41
 #: opac/webapp/templates/issue/toc.html:41
 msgid "Editor científico"
 msgstr "Scientific editor"
 
+#: build/lib/opac/webapp/templates/issue/toc.html:45
 #: opac/webapp/templates/issue/toc.html:45
 msgid "Editores associados"
 msgstr "Associate editors"
 
+#: build/lib/opac/webapp/templates/issue/toc.html:52
 #: opac/webapp/templates/issue/toc.html:52
 msgid "Veja toda a equipe editorial"
 msgstr "View the editorial team"
 
+#: build/lib/opac/webapp/templates/issue/toc.html:63
 #: opac/webapp/templates/issue/toc.html:63
 msgid "Expandir/recolher conteúdo"
 msgstr "Expand/collapse content"
 
+#: build/lib/opac/webapp/templates/issue/toc.html:72
+#: build/lib/opac/webapp/templates/journal/detail.html:96
 #: opac/webapp/templates/issue/toc.html:72
 #: opac/webapp/templates/journal/detail.html:96
 msgid "Sumário"
 msgstr "Summary"
 
+#: build/lib/opac/webapp/templates/issue/toc.html:79
 #: opac/webapp/templates/issue/toc.html:79
 msgid "Ordenar publicações por"
 msgstr "Sort publications by"
 
+#: build/lib/opac/webapp/templates/issue/toc.html:82
 #: opac/webapp/templates/issue/toc.html:82
 msgid "Ordem do fascículo"
 msgstr "Order issues by"
 
+#: build/lib/opac/webapp/templates/issue/toc.html:83
 #: opac/webapp/templates/issue/toc.html:83
 msgid "Mais novos primeiro"
 msgstr "Newest first"
 
+#: build/lib/opac/webapp/templates/issue/toc.html:84
 #: opac/webapp/templates/issue/toc.html:84
 msgid "Mais antigos primeiro"
 msgstr "Oldest first"
 
+#: build/lib/opac/webapp/templates/issue/toc.html:102
+#: build/lib/opac/webapp/templates/issue/toc.html:104
 #: opac/webapp/templates/issue/toc.html:102
 #: opac/webapp/templates/issue/toc.html:104
 msgid "Todas as seções"
 msgstr "All the sections"
 
+#: build/lib/opac/webapp/templates/issue/toc.html:187
 #: opac/webapp/templates/issue/toc.html:187
 msgid "Texto"
 msgstr "Text"
 
+#: build/lib/opac/webapp/templates/issue/toc.html:214
 #: opac/webapp/templates/issue/toc.html:214
 msgid "Resumo em"
 msgstr "Abstract in"
 
+#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:31
+#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:31
 #: opac/webapp/templates/issue/includes/alternative_header.html:31
 #: opac/webapp/templates/journal/includes/alternative_header.html:31
 msgid "Número atual"
 msgstr "Current issue"
 
+#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:51
+#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:47
 #: opac/webapp/templates/issue/includes/alternative_header.html:51
 #: opac/webapp/templates/journal/includes/alternative_header.html:47
 msgid "Homepage do periódico"
 msgstr "Journal home page"
 
+#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:62
+#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:58
 #: opac/webapp/templates/issue/includes/alternative_header.html:62
 #: opac/webapp/templates/journal/includes/alternative_header.html:58
 msgid "Números"
 msgstr "Issues"
 
+#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:68
+#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:64
+#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:90
 #: opac/webapp/templates/issue/includes/alternative_header.html:68
 #: opac/webapp/templates/journal/includes/alternative_header.html:64
 #: opac/webapp/templates/journal/includes/levelMenu.html:90
 msgid "todos"
 msgstr "all"
 
+#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:89
+#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:85
 #: opac/webapp/templates/issue/includes/alternative_header.html:89
 #: opac/webapp/templates/journal/includes/alternative_header.html:85
 msgid "próximo"
 msgstr "next"
 
+#: build/lib/opac/webapp/templates/journal/about.html:39
 #: opac/webapp/templates/journal/about.html:39
 msgid "Conteúdo não cadastrado"
 msgstr "Content not submitted"
 
+#: build/lib/opac/webapp/templates/journal/about.html:55
+#: build/lib/opac/webapp/templates/journal/includes/contact_footer.html:48
 #: opac/webapp/templates/journal/about.html:55
 #: opac/webapp/templates/journal/includes/contact_footer.html:48
 msgid "Siga este periódico nas redes sociais"
 msgstr "Follow this journal in the social networks"
 
+#: build/lib/opac/webapp/templates/journal/detail.html:32
 #: opac/webapp/templates/journal/detail.html:32
 msgid "Nossa Missão"
 msgstr "Our Mission"
 
+#: build/lib/opac/webapp/templates/journal/detail.html:34
 #: opac/webapp/templates/journal/detail.html:34
 msgid "Periódico sem missão cadastrada"
 msgstr "Journal without mission"
 
+#: build/lib/opac/webapp/templates/journal/detail.html:42
 #: opac/webapp/templates/journal/detail.html:42
 msgid "Métricas deste periódico"
 msgstr "Metrics for this journal"
 
+#: build/lib/opac/webapp/templates/journal/detail.html:52
 #: opac/webapp/templates/journal/detail.html:52
 msgid "Índice h5"
 msgstr "h5 index"
 
+#: build/lib/opac/webapp/templates/journal/detail.html:54
+#: build/lib/opac/webapp/templates/journal/detail.html:66
 #: opac/webapp/templates/journal/detail.html:54
 #: opac/webapp/templates/journal/detail.html:66
 msgid "ano"
 msgstr "year"
 
+#: build/lib/opac/webapp/templates/journal/detail.html:58
+#: build/lib/opac/webapp/templates/journal/detail.html:70
 #: opac/webapp/templates/journal/detail.html:58
 #: opac/webapp/templates/journal/detail.html:70
 msgid "Não possui"
 msgstr "Does not have"
 
+#: build/lib/opac/webapp/templates/journal/detail.html:63
 #: opac/webapp/templates/journal/detail.html:63
 msgid "Mediana h5"
 msgstr "Median h5"
 
+#: build/lib/opac/webapp/templates/journal/detail.html:86
 #: opac/webapp/templates/journal/detail.html:86
 msgid "Capa do número mais recente"
 msgstr "Cover of most recent issue"
 
+#: build/lib/opac/webapp/templates/journal/detail.html:138
 #: opac/webapp/templates/journal/detail.html:138
 msgid "Artigos mais recentes"
 msgstr "Latest articles"
 
+#: build/lib/opac/webapp/templates/journal/includes/contact_footer.html:57
 #: opac/webapp/templates/journal/includes/contact_footer.html:57
 msgid "Acompanhe os números deste periódico no seu leitor de RSS"
 msgstr "Stay informed of issues for this journal through your RSS reader"
 
+#: build/lib/opac/webapp/templates/journal/includes/contact_form.html:26
 #: opac/webapp/templates/journal/includes/contact_form.html:26
 msgid "Mensagem"
 msgstr "Message"
 
+#: build/lib/opac/webapp/templates/journal/includes/contact_form.html:76
 #: opac/webapp/templates/journal/includes/contact_form.html:76
 msgid "Email enviado para "
 msgstr "Email sent to "
 
+#: build/lib/opac/webapp/templates/journal/includes/contact_form.html:76
 #: opac/webapp/templates/journal/includes/contact_form.html:76
 msgid "com sucesso."
 msgstr "successfully."
 
+#: build/lib/opac/webapp/templates/journal/includes/header.html:42
 #: opac/webapp/templates/journal/includes/header.html:42
 msgid "Publicação de:"
 msgstr "Publication of:"
 
+#: build/lib/opac/webapp/templates/journal/includes/header.html:47
 #: opac/webapp/templates/journal/includes/header.html:47
 msgid "Área:"
 msgstr "Area:"
 
+#: build/lib/opac/webapp/templates/journal/includes/header.html:51
 #: opac/webapp/templates/journal/includes/header.html:51
-msgid "Multidiciplinar"
+msgid "Multidisciplinar"
 msgstr "Multidisciplinary"
 
+#: build/lib/opac/webapp/templates/journal/includes/header.html:60
 #: opac/webapp/templates/journal/includes/header.html:60
 msgid "Versão impressa ISSN:"
 msgstr "ISSN printed version:"
 
+#: build/lib/opac/webapp/templates/journal/includes/header.html:67
 #: opac/webapp/templates/journal/includes/header.html:67
 msgid "Versão on-line ISSN:"
 msgstr "ISSN online version:"
 
+#: build/lib/opac/webapp/templates/journal/includes/header.html:76
 #: opac/webapp/templates/journal/includes/header.html:76
 msgid "Novo título:"
 msgstr "New title:"
 
+#: build/lib/opac/webapp/templates/journal/includes/header.html:93
 #: opac/webapp/templates/journal/includes/header.html:93
 msgid "Título anterior:"
 msgstr "Previous title"
 
+#: build/lib/opac/webapp/templates/journal/includes/header.html:148
 #: opac/webapp/templates/journal/includes/header.html:148
 msgid "Siga-nos"
 msgstr "Follow us"
 
+#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:10
 #: opac/webapp/templates/journal/includes/levelMenu.html:10
 msgid "home do periódico"
 msgstr "Journal homepage"
 
+#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:19
 #: opac/webapp/templates/journal/includes/levelMenu.html:19
 msgid "todos os números"
 msgstr "all issues"
 
+#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:25
+#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:29
 #: opac/webapp/templates/journal/includes/levelMenu.html:25
 #: opac/webapp/templates/journal/includes/levelMenu.html:29
 msgid "número anterior"
 msgstr "previous issue"
 
+#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:36
+#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:40
+#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:107
+#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:111
 #: opac/webapp/templates/journal/includes/levelMenu.html:36
 #: opac/webapp/templates/journal/includes/levelMenu.html:40
 #: opac/webapp/templates/journal/includes/levelMenu.html:107
@@ -2007,16 +2513,24 @@ msgstr "previous issue"
 msgid "número atual"
 msgstr "current issue"
 
+#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:47
+#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:51
 #: opac/webapp/templates/journal/includes/levelMenu.html:47
 #: opac/webapp/templates/journal/includes/levelMenu.html:51
 msgid "número seguinte"
 msgstr "next issue"
 
+#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:59
+#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:130
 #: opac/webapp/templates/journal/includes/levelMenu.html:59
 #: opac/webapp/templates/journal/includes/levelMenu.html:130
 msgid "buscar"
 msgstr "search"
 
+#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:65
+#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:69
+#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:136
+#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:140
 #: opac/webapp/templates/journal/includes/levelMenu.html:65
 #: opac/webapp/templates/journal/includes/levelMenu.html:69
 #: opac/webapp/templates/journal/includes/levelMenu.html:136
@@ -2024,22 +2538,27 @@ msgstr "search"
 msgid "métricas"
 msgstr "metrics"
 
+#: build/lib/opac/webapp/templates/macros/issue.html:5
 #: opac/webapp/templates/macros/issue.html:5
 msgid " número especial "
 msgstr " special issue "
 
+#: build/lib/opac/webapp/templates/macros/issue.html:10
 #: opac/webapp/templates/macros/issue.html:10
 msgid "número especial"
 msgstr "special issue"
 
-#: opac/webapp/templates/news/includes/collection_news_row.html:11
+#: build/lib/opac/webapp/templates/news/includes/collection_news_row.html:16
+#: opac/webapp/templates/news/includes/collection_news_row.html:16
 msgid "continue lendo"
 msgstr "continue reading"
 
+#: build/lib/opac/webapp/templates/news/includes/issue_last_row.html:15
 #: opac/webapp/templates/news/includes/issue_last_row.html:15
 msgid "Suplemento"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/news/includes/issue_last_row.html:20
 #: opac/webapp/templates/news/includes/issue_last_row.html:20
 msgid "Ver"
 msgstr "Open"
@@ -2082,4 +2601,10 @@ msgstr "Open"
 
 #~ msgid "LINGUISTICS, LITERATURE AND ARTS"
 #~ msgstr ""
+
+#~ msgid "HTML do Artigo não encontrado"
+#~ msgstr "HTML of the Article not found"
+
+#~ msgid "Recurso não encontrado"
+#~ msgstr "Resource not found"
 

--- a/opac/webapp/translations/es/LC_MESSAGES/messages.po
+++ b/opac/webapp/translations/es/LC_MESSAGES/messages.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version:  OPAC\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-03-15 11:46+0000\n"
+"POT-Creation-Date: 2019-05-09 17:02-0300\n"
 "PO-Revision-Date: 2018-03-07 00:47+0000\n"
 "Last-Translator: jamil Atta <atta.jamil@gmail.com>\n"
 "Language: es\n"
@@ -24,6 +24,23 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.6.0\n"
 
+#: build/lib/opac/tests/test_admin_custom_filters.py:100
+#: build/lib/opac/tests/test_admin_custom_filters.py:114
+#: build/lib/opac/tests/test_admin_custom_filters.py:129
+#: build/lib/opac/tests/test_admin_custom_filters.py:144
+#: build/lib/opac/tests/test_admin_custom_filters.py:158
+#: build/lib/opac/webapp/__init__.py:119
+#: build/lib/opac/webapp/admin/views.py:533
+#: build/lib/opac/webapp/admin/views.py:610
+#: build/lib/opac/webapp/admin/views.py:680
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:28
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:71
+#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_grouper_table_row.html:15
+#: build/lib/opac/webapp/templates/collection/list_journal.html:49
+#: build/lib/opac/webapp/templates/collection/list_journal.html:221
+#: build/lib/opac/webapp/templates/collection/list_journal.html:235
+#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:116
+#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:112
 #: opac/tests/test_admin_custom_filters.py:100
 #: opac/tests/test_admin_custom_filters.py:114
 #: opac/tests/test_admin_custom_filters.py:129
@@ -42,21 +59,38 @@ msgstr ""
 msgid "Periódico"
 msgstr "Revista"
 
+#: build/lib/opac/tests/test_interface_menu.py:51
 #: opac/tests/test_interface_menu.py:51
 msgid "NOME DA COLEÇÃO!!"
 msgstr "NOMBRE DE LA COLECCIÓN!!"
 
-#: opac/tests/test_interface_menu.py:53 opac/tests/test_interface_menu.py:72
+#: build/lib/opac/tests/test_interface_menu.py:53
+#: build/lib/opac/tests/test_interface_menu.py:75
+#: build/lib/opac/webapp/templates/collection/includes/nav.html:12
+#: build/lib/opac/webapp/templates/collection/includes/nav.html:54
+#: opac/tests/test_interface_menu.py:53 opac/tests/test_interface_menu.py:75
 #: opac/webapp/templates/collection/includes/nav.html:12
 #: opac/webapp/templates/collection/includes/nav.html:54
 msgid "Lista alfabética de periódicos"
 msgstr "Lista alfabética de revistas"
 
+#: build/lib/opac/tests/test_interface_menu.py:55
+#: build/lib/opac/webapp/templates/collection/includes/nav.html:17
 #: opac/tests/test_interface_menu.py:55
 #: opac/webapp/templates/collection/includes/nav.html:17
 msgid "Lista temática de periódicos"
 msgstr "Lista temática de revistas"
 
+#: build/lib/opac/tests/test_interface_menu.py:61
+#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:11
+#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:70
+#: build/lib/opac/webapp/templates/collection/includes/nav.html:27
+#: build/lib/opac/webapp/templates/collection/includes/nav.html:69
+#: build/lib/opac/webapp/templates/includes/metric_modal.html:7
+#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:101
+#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:105
+#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:97
+#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:101
 #: opac/tests/test_interface_menu.py:61
 #: opac/webapp/templates/article/includes/floating_menu.html:11
 #: opac/webapp/templates/article/includes/floating_menu.html:70
@@ -70,332 +104,383 @@ msgstr "Lista temática de revistas"
 msgid "Métricas"
 msgstr "Métricas"
 
+#: build/lib/opac/tests/test_interface_menu.py:63
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu.html:12
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu.html:29
 #: opac/tests/test_interface_menu.py:63
 #: opac/webapp/templates/collection/includes/levelMenu.html:12
 #: opac/webapp/templates/collection/includes/levelMenu.html:29
 msgid "Sobre o SciELO"
 msgstr "Acerca de SciELO"
 
-#: opac/tests/test_interface_menu.py:65 opac/tests/test_interface_menu.py:84
+#: build/lib/opac/tests/test_interface_menu.py:65
+#: build/lib/opac/tests/test_interface_menu.py:99
+#: build/lib/opac/webapp/templates/collection/includes/nav.html:37
+#: build/lib/opac/webapp/templates/collection/includes/nav.html:84
+#: opac/tests/test_interface_menu.py:65 opac/tests/test_interface_menu.py:99
 #: opac/webapp/templates/collection/includes/nav.html:37
 #: opac/webapp/templates/collection/includes/nav.html:84
 msgid "Contatos"
 msgstr "Contactos"
 
+#: build/lib/opac/tests/test_interface_menu.py:67
 #: opac/tests/test_interface_menu.py:67
 msgid "Rede SciELO"
 msgstr "Red SciELO"
 
-#: opac/tests/test_interface_menu.py:70
+#: build/lib/opac/tests/test_interface_menu.py:71
+#: build/lib/opac/webapp/templates/collection/includes/nav.html:49
+#: opac/tests/test_interface_menu.py:71
 #: opac/webapp/templates/collection/includes/nav.html:49
 msgid "Coleções nacionais e temáticas"
 msgstr "Colecciones nacionales y temáticas"
 
-#: opac/tests/test_interface_menu.py:74
+#: build/lib/opac/tests/test_interface_menu.py:79
+#: build/lib/opac/webapp/templates/collection/includes/nav.html:59
+#: opac/tests/test_interface_menu.py:79
 #: opac/webapp/templates/collection/includes/nav.html:59
 msgid "Lista de periódicos por assunto"
 msgstr "Lista de revistas por asunto"
 
-#: opac/tests/test_interface_menu.py:80
+#: build/lib/opac/tests/test_interface_menu.py:91
+#: build/lib/opac/webapp/templates/collection/includes/nav.html:74
+#: opac/tests/test_interface_menu.py:91
 #: opac/webapp/templates/collection/includes/nav.html:74
 msgid "Acesso OAI e RSS"
 msgstr "Acceso OAI y RSS"
 
-#: opac/tests/test_interface_menu.py:82
+#: build/lib/opac/tests/test_interface_menu.py:95
+#: build/lib/opac/webapp/templates/collection/includes/nav.html:79
+#: opac/tests/test_interface_menu.py:95
 #: opac/webapp/templates/collection/includes/nav.html:79
 msgid "Sobre a Rede SciELO"
 msgstr "Acerca de la Red SciELO"
 
-#: opac/tests/test_main_errors.py:8
+#: build/lib/opac/tests/test_main_errors.py:8 opac/tests/test_main_errors.py:8
 msgid "Mensagem de erro explicativo para o usuário"
 msgstr "Mensaje de error explicativo para el usuario"
 
+#: build/lib/opac/webapp/__init__.py:118 build/lib/opac/webapp/__init__.py:119
+#: build/lib/opac/webapp/__init__.py:120 build/lib/opac/webapp/__init__.py:121
+#: build/lib/opac/webapp/__init__.py:122 build/lib/opac/webapp/__init__.py:123
 #: opac/webapp/__init__.py:118 opac/webapp/__init__.py:119
 #: opac/webapp/__init__.py:120 opac/webapp/__init__.py:121
 #: opac/webapp/__init__.py:122 opac/webapp/__init__.py:123
 msgid "Catálogo"
 msgstr "Catálogo"
 
-#: opac/webapp/__init__.py:118 opac/webapp/admin/views.py:452
+#: build/lib/opac/webapp/__init__.py:118
+#: build/lib/opac/webapp/admin/views.py:452 opac/webapp/__init__.py:118
+#: opac/webapp/admin/views.py:452
 msgid "Coleção"
 msgstr "Colección"
 
+#: build/lib/opac/webapp/__init__.py:120
+#: build/lib/opac/webapp/admin/views.py:537
+#: build/lib/opac/webapp/admin/views.py:609
+#: build/lib/opac/webapp/templates/issue/grid.html:41
+#: build/lib/opac/webapp/templates/news/includes/issue_last_row.html:11
 #: opac/webapp/__init__.py:120 opac/webapp/admin/views.py:537
 #: opac/webapp/admin/views.py:609 opac/webapp/templates/issue/grid.html:41
 #: opac/webapp/templates/news/includes/issue_last_row.html:11
 msgid "Número"
 msgstr "Número"
 
-#: opac/webapp/__init__.py:121
+#: build/lib/opac/webapp/__init__.py:121 opac/webapp/__init__.py:121
 msgid "Artigo"
 msgstr "Artículo"
 
+#: build/lib/opac/webapp/__init__.py:122
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:27
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:70
 #: opac/webapp/__init__.py:122
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:27
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:70
 msgid "Financiador"
 msgstr "Financiador"
 
-#: opac/webapp/__init__.py:123
+#: build/lib/opac/webapp/__init__.py:123 opac/webapp/__init__.py:123
 msgid "Press Release"
 msgstr "Comunicado de prensa"
 
+#: build/lib/opac/webapp/__init__.py:124
+#: build/lib/opac/webapp/templates/journal/detail.html:160
 #: opac/webapp/__init__.py:124 opac/webapp/templates/journal/detail.html:160
 msgid "Notícias"
 msgstr "Noticias"
 
+#: build/lib/opac/webapp/__init__.py:125 build/lib/opac/webapp/__init__.py:126
 #: opac/webapp/__init__.py:125 opac/webapp/__init__.py:126
 msgid "Ativos"
 msgstr "Activos"
 
-#: opac/webapp/__init__.py:127
+#: build/lib/opac/webapp/__init__.py:127 opac/webapp/__init__.py:127
 msgid "Páginas"
 msgstr "Páginas"
 
+#: build/lib/opac/webapp/__init__.py:128 build/lib/opac/webapp/__init__.py:129
 #: opac/webapp/__init__.py:128 opac/webapp/__init__.py:129
 msgid "Gestão"
 msgstr "Gestión"
 
-#: opac/webapp/__init__.py:128
+#: build/lib/opac/webapp/__init__.py:128 opac/webapp/__init__.py:128
 msgid "Auditoria: Páginas"
 msgstr ""
 
-#: opac/webapp/__init__.py:129 opac/webapp/admin/views.py:896
+#: build/lib/opac/webapp/__init__.py:129
+#: build/lib/opac/webapp/admin/views.py:896 opac/webapp/__init__.py:129
+#: opac/webapp/admin/views.py:896
 msgid "Usuário"
 msgstr "Usuario"
 
-#: opac/webapp/choices.py:7
+#: build/lib/opac/webapp/choices.py:7 opac/webapp/choices.py:7
 msgid "Conteúdo temporariamente indisponível"
 msgstr "Contenido indisponible temporalmente"
 
+#: build/lib/opac/webapp/choices.py:11 build/lib/opac/webapp/choices.py:23
+#: build/lib/opac/webapp/templates/article/includes/modal/download.html:26
 #: opac/webapp/choices.py:11 opac/webapp/choices.py:23
 #: opac/webapp/templates/article/includes/modal/download.html:26
 msgid "Português"
 msgstr "Portugués"
 
+#: build/lib/opac/webapp/choices.py:12 build/lib/opac/webapp/choices.py:24
+#: build/lib/opac/webapp/templates/article/includes/modal/download.html:24
 #: opac/webapp/choices.py:12 opac/webapp/choices.py:24
 #: opac/webapp/templates/article/includes/modal/download.html:24
 msgid "Inglês"
 msgstr "Inglés"
 
+#: build/lib/opac/webapp/choices.py:13 build/lib/opac/webapp/choices.py:25
+#: build/lib/opac/webapp/templates/article/includes/modal/download.html:22
 #: opac/webapp/choices.py:13 opac/webapp/choices.py:25
 #: opac/webapp/templates/article/includes/modal/download.html:22
 msgid "Espanhol"
 msgstr "Español"
 
-#: opac/webapp/choices.py:26
+#: build/lib/opac/webapp/choices.py:26 opac/webapp/choices.py:26
 msgid "Albanês"
 msgstr "Albanés"
 
+#: build/lib/opac/webapp/choices.py:27 build/lib/opac/webapp/choices.py:33
 #: opac/webapp/choices.py:27 opac/webapp/choices.py:33
 msgid "Chinês"
 msgstr "Chino"
 
-#: opac/webapp/choices.py:28
+#: build/lib/opac/webapp/choices.py:28 opac/webapp/choices.py:28
 msgid "Romeno"
 msgstr "Rumano"
 
-#: opac/webapp/choices.py:29
+#: build/lib/opac/webapp/choices.py:29 opac/webapp/choices.py:29
 msgid "Francês"
 msgstr "Francés"
 
-#: opac/webapp/choices.py:30
+#: build/lib/opac/webapp/choices.py:30 opac/webapp/choices.py:30
 msgid "Italiano"
 msgstr "Italiano"
 
-#: opac/webapp/choices.py:31
+#: build/lib/opac/webapp/choices.py:31 opac/webapp/choices.py:31
 msgid "Russo"
 msgstr "Ruso"
 
-#: opac/webapp/choices.py:32
+#: build/lib/opac/webapp/choices.py:32 opac/webapp/choices.py:32
 msgid "Árabe"
 msgstr "Árabe"
 
-#: opac/webapp/choices.py:37
+#: build/lib/opac/webapp/choices.py:37 opac/webapp/choices.py:37
 msgid "corrente"
 msgstr "vigente"
 
-#: opac/webapp/choices.py:38
+#: build/lib/opac/webapp/choices.py:38 opac/webapp/choices.py:38
 msgid "terminado"
 msgstr "terminado"
 
-#: opac/webapp/choices.py:39
+#: build/lib/opac/webapp/choices.py:39 opac/webapp/choices.py:39
 msgid "indexação interrompida"
 msgstr "indización interrumpida"
 
-#: opac/webapp/choices.py:40
+#: build/lib/opac/webapp/choices.py:40 opac/webapp/choices.py:40
 msgid "indexação interrompida pelo Comitê"
 msgstr "indización interrumpida por el comité"
 
-#: opac/webapp/choices.py:41
+#: build/lib/opac/webapp/choices.py:41 opac/webapp/choices.py:41
 msgid "publicação finalizada"
 msgstr "publicación finalizada"
 
-#: opac/webapp/choices.py:45
+#: build/lib/opac/webapp/choices.py:45 opac/webapp/choices.py:45
 msgid "Ciências Agrárias"
 msgstr "Ciencias Agrícolas"
 
-#: opac/webapp/choices.py:46
+#: build/lib/opac/webapp/choices.py:46 opac/webapp/choices.py:46
 msgid "Ciências Sociais Aplicadas"
 msgstr "Ciencias Sociales Aplicadas"
 
-#: opac/webapp/choices.py:47
+#: build/lib/opac/webapp/choices.py:47 opac/webapp/choices.py:47
 msgid "Ciências Biológicas"
 msgstr "Ciencias Biológicas"
 
-#: opac/webapp/choices.py:48
+#: build/lib/opac/webapp/choices.py:48 opac/webapp/choices.py:48
 msgid "Engenharias"
 msgstr "Ingeniería"
 
-#: opac/webapp/choices.py:49
+#: build/lib/opac/webapp/choices.py:49 opac/webapp/choices.py:49
 msgid "Ciências Exatas e da Terra"
 msgstr "Ciencias Exactas y de la Tierra"
 
-#: opac/webapp/choices.py:50
+#: build/lib/opac/webapp/choices.py:50 opac/webapp/choices.py:50
 msgid "Ciências da Saúde"
 msgstr "Ciencias de la Salud"
 
-#: opac/webapp/choices.py:51
+#: build/lib/opac/webapp/choices.py:51 opac/webapp/choices.py:51
 msgid "Ciências Humanas"
 msgstr "Humanidades"
 
+#: build/lib/opac/webapp/choices.py:52 build/lib/opac/webapp/choices.py:53
 #: opac/webapp/choices.py:52 opac/webapp/choices.py:53
 msgid "Lingüística, Letras e Artes"
 msgstr "Linguística, Letras y Artes"
 
-#: opac/webapp/controllers.py:353
+#: build/lib/opac/webapp/controllers.py:353 opac/webapp/controllers.py:353
 msgid "Lista Alfabética"
 msgstr "Lista Alfabética"
 
-#: opac/webapp/controllers.py:357
+#: build/lib/opac/webapp/controllers.py:357 opac/webapp/controllers.py:357
 msgid "Lista Temática"
 msgstr "Lista Temática"
 
-#: opac/webapp/controllers.py:361
+#: build/lib/opac/webapp/controllers.py:361 opac/webapp/controllers.py:361
 msgid "Lista Web of Science"
 msgstr "Lista Web of Science"
 
-#: opac/webapp/controllers.py:365
+#: build/lib/opac/webapp/controllers.py:365 opac/webapp/controllers.py:365
 msgid "Lista by Institution"
 msgstr "Lista por Institución"
 
-#: opac/webapp/controllers.py:424
+#: build/lib/opac/webapp/controllers.py:424 opac/webapp/controllers.py:424
 msgid "Obrigatório um jid."
 msgstr "Obligatorio un jid."
 
-#: opac/webapp/controllers.py:440
+#: build/lib/opac/webapp/controllers.py:440 opac/webapp/controllers.py:440
 msgid "Obrigatório um acronym."
 msgstr "Obligatorio un acronym."
 
-#: opac/webapp/controllers.py:456
+#: build/lib/opac/webapp/controllers.py:456 opac/webapp/controllers.py:456
 msgid "Obrigatório um url_seg."
 msgstr "Obligatorio un url_seg."
 
-#: opac/webapp/controllers.py:472
+#: build/lib/opac/webapp/controllers.py:472 opac/webapp/controllers.py:472
 msgid "Obrigatório um issn."
 msgstr "ISSN obligatorio."
 
-#: opac/webapp/controllers.py:487
+#: build/lib/opac/webapp/controllers.py:487 opac/webapp/controllers.py:487
 msgid "Obrigatório um title."
 msgstr ""
 
-#: opac/webapp/controllers.py:525 opac/webapp/controllers.py:669
-#: opac/webapp/controllers.py:830
+#: build/lib/opac/webapp/controllers.py:525
+#: build/lib/opac/webapp/controllers.py:669
+#: build/lib/opac/webapp/controllers.py:830 opac/webapp/controllers.py:525
+#: opac/webapp/controllers.py:669 opac/webapp/controllers.py:830
 msgid "Obrigatório uma lista de ids."
 msgstr "Obligatorio un listado de ids."
 
-#: opac/webapp/controllers.py:631 opac/webapp/controllers.py:851
+#: build/lib/opac/webapp/controllers.py:631
+#: build/lib/opac/webapp/controllers.py:851 opac/webapp/controllers.py:631
+#: opac/webapp/controllers.py:851
 msgid "Obrigatório um iid."
 msgstr "Obligatorio un iid."
 
-#: opac/webapp/controllers.py:688
+#: build/lib/opac/webapp/controllers.py:688 opac/webapp/controllers.py:688
 msgid "Obrigatório um jacron e issue_label."
 msgstr "Obligatorio un jacron e issue_label."
 
-#: opac/webapp/controllers.py:701
+#: build/lib/opac/webapp/controllers.py:701 opac/webapp/controllers.py:701
 msgid "Obrigatório um PID."
 msgstr "PID obligatorio."
 
-#: opac/webapp/controllers.py:717
+#: build/lib/opac/webapp/controllers.py:717 opac/webapp/controllers.py:717
 msgid "Obrigatório um url_seg e url_seg_issue."
 msgstr "Obligatorio un url_seg y url_seg_issue."
 
-#: opac/webapp/controllers.py:724
+#: build/lib/opac/webapp/controllers.py:724 opac/webapp/controllers.py:724
 msgid "Obrigatório um assets_code."
 msgstr "assets_code es obligatório."
 
-#: opac/webapp/controllers.py:727
+#: build/lib/opac/webapp/controllers.py:727 opac/webapp/controllers.py:727
 msgid "Obrigatório um journal."
 msgstr "journal es obligatorio."
 
-#: opac/webapp/controllers.py:743
+#: build/lib/opac/webapp/controllers.py:743 opac/webapp/controllers.py:743
 msgid "Obrigatório um aid."
 msgstr "Obligatorio un aid."
 
-#: opac/webapp/controllers.py:757
+#: build/lib/opac/webapp/controllers.py:757 opac/webapp/controllers.py:757
 msgid "Obrigatório um url_seg_article."
 msgstr "Obligatorio un url_seg_article."
 
-#: opac/webapp/controllers.py:772
+#: build/lib/opac/webapp/controllers.py:772 opac/webapp/controllers.py:772
 msgid "Obrigatório um iid and url_seg_article."
 msgstr "Obligatorio un iid and url_seg_article."
 
-#: opac/webapp/controllers.py:788
+#: build/lib/opac/webapp/controllers.py:788 opac/webapp/controllers.py:788
 msgid "Obrigatório um jid, url_seg_issue and url_seg_article."
 msgstr ""
 
-#: opac/webapp/controllers.py:889
+#: build/lib/opac/webapp/controllers.py:889 opac/webapp/controllers.py:889
 msgid "Obrigatório um pid."
 msgstr "PID obligatorio."
 
-#: opac/webapp/controllers.py:902
+#: build/lib/opac/webapp/controllers.py:902 opac/webapp/controllers.py:902
 msgid "Obrigatório um aop_pid."
 msgstr "Obligatorio un aop_pid."
 
-#: opac/webapp/controllers.py:913
+#: build/lib/opac/webapp/controllers.py:913 opac/webapp/controllers.py:913
 msgid "Parámetro obrigatório: issue_iid."
 msgstr "Parámetro obligatorio: issue_iid."
 
-#: opac/webapp/controllers.py:961
+#: build/lib/opac/webapp/controllers.py:961 opac/webapp/controllers.py:961
 msgid "Parâmetro email deve ser uma string"
 msgstr "Parámetro email debe ser un string"
 
-#: opac/webapp/controllers.py:972
+#: build/lib/opac/webapp/controllers.py:972 opac/webapp/controllers.py:972
 msgid "Parâmetro email deve ser uma inteiro"
 msgstr "Parámetro email debe ser un entero"
 
-#: opac/webapp/controllers.py:984 opac/webapp/controllers.py:998
+#: build/lib/opac/webapp/controllers.py:984
+#: build/lib/opac/webapp/controllers.py:998 opac/webapp/controllers.py:984
+#: opac/webapp/controllers.py:998
 #, python-format
 msgid "Usuário deve ser do tipo %s"
 msgstr "Usuario debe ser del tipo %s"
 
-#: opac/webapp/controllers.py:1054
+#: build/lib/opac/webapp/controllers.py:1054 opac/webapp/controllers.py:1054
 msgid "Compartilhamento de link SciELO"
 msgstr "Compartir enlace SciELO"
 
-#: opac/webapp/controllers.py:1055
+#: build/lib/opac/webapp/controllers.py:1055 opac/webapp/controllers.py:1055
 #, python-format
 msgid "O usuário %s compartilha este link: %s, da SciELO"
 msgstr "El usuario %s comparte este enlace: %s, de SciELO"
 
-#: opac/webapp/controllers.py:1063 opac/webapp/controllers.py:1099
-#: opac/webapp/controllers.py:1121
+#: build/lib/opac/webapp/controllers.py:1063
+#: build/lib/opac/webapp/controllers.py:1099
+#: build/lib/opac/webapp/controllers.py:1121 opac/webapp/controllers.py:1063
+#: opac/webapp/controllers.py:1099 opac/webapp/controllers.py:1121
 msgid "Mensagem enviada!"
 msgstr "Mensaje enviado!"
 
-#: opac/webapp/controllers.py:1080
+#: build/lib/opac/webapp/controllers.py:1080 opac/webapp/controllers.py:1080
 msgid "[Erro] Erro informado pelo usuário no site SciELO"
 msgstr ""
 
-#: opac/webapp/controllers.py:1083
+#: build/lib/opac/webapp/controllers.py:1083 opac/webapp/controllers.py:1083
 msgid "aplicação"
 msgstr ""
 
-#: opac/webapp/controllers.py:1085
+#: build/lib/opac/webapp/controllers.py:1085 opac/webapp/controllers.py:1085
 msgid "conteúdo"
 msgstr ""
 
-#: opac/webapp/controllers.py:1090
+#: build/lib/opac/webapp/controllers.py:1090 opac/webapp/controllers.py:1090
 #, python-format
 msgid ""
 "O usuário <b>%s</b> com e-mail: <b>%s</b>, informa que existe um erro na "
@@ -406,52 +491,56 @@ msgstr ""
 " en la% s en el sitio SciELO. <br> <br> <b> Título de la página: </ b>% s"
 " <br> <br> <b> Link: </ b% s"
 
-#: opac/webapp/controllers.py:1111
+#: build/lib/opac/webapp/controllers.py:1111 opac/webapp/controllers.py:1111
 msgid "Contato de usuário via site SciELO"
 msgstr "Contacto de usuário por sitio SciELO"
 
-#: opac/webapp/controllers.py:1113
+#: build/lib/opac/webapp/controllers.py:1113 opac/webapp/controllers.py:1113
 #, python-format
 msgid "O usuário %s, com e-mail: %s, entra em contato com a seguinte mensagem:"
 msgstr "El usuario %s, con e-mail: %s, entra en contacto com la siguiente mensaje:"
 
-#: opac/webapp/controllers.py:1145
+#: build/lib/opac/webapp/controllers.py:1145 opac/webapp/controllers.py:1145
 msgid "Obrigatório um slug_name."
 msgstr ""
 
-#: opac/webapp/forms.py:29
+#: build/lib/opac/webapp/forms.py:29 opac/webapp/forms.py:29
 msgid "Endereço de e-mail inválido."
 msgstr "Dirección de e-mail inválida."
 
-#: opac/webapp/admin/forms.py:9 opac/webapp/admin/forms.py:21
+#: build/lib/opac/webapp/admin/forms.py:9
+#: build/lib/opac/webapp/admin/forms.py:21 opac/webapp/admin/forms.py:9
+#: opac/webapp/admin/forms.py:21
 msgid "Email"
 msgstr "Email"
 
-#: opac/webapp/admin/forms.py:10 opac/webapp/admin/forms.py:25
+#: build/lib/opac/webapp/admin/forms.py:10
+#: build/lib/opac/webapp/admin/forms.py:25 opac/webapp/admin/forms.py:10
+#: opac/webapp/admin/forms.py:25
 msgid "Senha"
 msgstr "Contraseña"
 
-#: opac/webapp/admin/forms.py:15
+#: build/lib/opac/webapp/admin/forms.py:15 opac/webapp/admin/forms.py:15
 msgid "Usuário inválido"
 msgstr "Usuario inválido"
 
-#: opac/webapp/admin/forms.py:17
+#: build/lib/opac/webapp/admin/forms.py:17 opac/webapp/admin/forms.py:17
 msgid "Senha inválida"
 msgstr "Contraseña inválida"
 
-#: opac/webapp/admin/views.py:28
+#: build/lib/opac/webapp/admin/views.py:28 opac/webapp/admin/views.py:28
 msgid "Tem certeza que quer publicar os itens selecionados?"
 msgstr "¿Está seguro que desea publicar los ítems seleccionados?"
 
-#: opac/webapp/admin/views.py:29
+#: build/lib/opac/webapp/admin/views.py:29 opac/webapp/admin/views.py:29
 msgid "Tem certeza que quer despublicar os itens selecionados?"
 msgstr "¿Está seguro que desea despublicar los ítems seleccionados?"
 
-#: opac/webapp/admin/views.py:30
+#: build/lib/opac/webapp/admin/views.py:30 opac/webapp/admin/views.py:30
 msgid "Tem certeza que quer reconstruir os artigos selecionados?"
 msgstr "¿Está seguro que desea reconstruir los artículos seleccionados?"
 
-#: opac/webapp/admin/views.py:31
+#: build/lib/opac/webapp/admin/views.py:31 opac/webapp/admin/views.py:31
 msgid ""
 "Tem certeza que quer enviar email de confirmação aos usuários "
 "selecionados?"
@@ -459,21 +548,23 @@ msgstr ""
 "¿Está seguro que desea enviar email de confirmación a los usuarios "
 "seleccionados?"
 
-#: opac/webapp/admin/views.py:91 opac/webapp/admin/views.py:104
+#: build/lib/opac/webapp/admin/views.py:91
+#: build/lib/opac/webapp/admin/views.py:104 opac/webapp/admin/views.py:91
+#: opac/webapp/admin/views.py:104
 msgid "Usuário não encontrado"
 msgstr "Usuario no encontrado"
 
-#: opac/webapp/admin/views.py:94
+#: build/lib/opac/webapp/admin/views.py:94 opac/webapp/admin/views.py:94
 #, python-format
 msgid "Email: %(email)s confirmado com sucesso!"
 msgstr "Email: %(email)s confirmado com éxito!"
 
-#: opac/webapp/admin/views.py:110
+#: build/lib/opac/webapp/admin/views.py:110 opac/webapp/admin/views.py:110
 #, python-format
 msgid "Enviamos as instruções para recuperar a senha para: %(email)s"
 msgstr "Enviamos las instrucciones para recuperar la contraseña para: %(email)s"
 
-#: opac/webapp/admin/views.py:113
+#: build/lib/opac/webapp/admin/views.py:113 opac/webapp/admin/views.py:113
 #, python-format
 msgid ""
 "Ocorreu um erro no envio das instruções por email para: %(email)s. Erro: "
@@ -482,16 +573,18 @@ msgstr ""
 "Ocurrió un error en el envío de las instrucciones por email para "
 "%(email)s. Error: %(error)s"
 
-#: opac/webapp/admin/views.py:139
+#: build/lib/opac/webapp/admin/views.py:139 opac/webapp/admin/views.py:139
 msgid "Nova senha salva com sucesso!!"
 msgstr "Nueva contraseña guardada con éxito!!"
 
-#: opac/webapp/admin/views.py:167 opac/webapp/admin/views.py:186
+#: build/lib/opac/webapp/admin/views.py:167
+#: build/lib/opac/webapp/admin/views.py:186 opac/webapp/admin/views.py:167
+#: opac/webapp/admin/views.py:186
 #, python-format
 msgid "Enviamos o email de confirmação para: %(email)s"
 msgstr "Enviamos el email de confirmación para: %(email)s"
 
-#: opac/webapp/admin/views.py:170
+#: build/lib/opac/webapp/admin/views.py:170 opac/webapp/admin/views.py:170
 #, python-format
 msgid ""
 "Ocorreu um erro no envio do email de confirmação para: %(email)s "
@@ -500,296 +593,334 @@ msgstr ""
 "Ocurrió un error en el envío de e-mail de confirmación "
 "para:%(email)s%(error_msg)s"
 
-#: opac/webapp/admin/views.py:177
+#: build/lib/opac/webapp/admin/views.py:177 opac/webapp/admin/views.py:177
 msgid "Enviar email de confirmação"
 msgstr "Enviar email de confirmación"
 
-#: opac/webapp/admin/views.py:189
+#: build/lib/opac/webapp/admin/views.py:189 opac/webapp/admin/views.py:189
 #, python-format
 msgid "Ocorreu um erro no envio do email de confirmação para: %(email)s"
 msgstr "Ocurrió un error en el envío de email de confirmación para: %(email)s"
 
-#: opac/webapp/admin/views.py:193
+#: build/lib/opac/webapp/admin/views.py:193 opac/webapp/admin/views.py:193
 #, python-format
 msgid "%(count)s usuários foram notificados com sucesso!"
 msgstr "%(count)s usuarios fueron notificados con éxito!"
 
-#: opac/webapp/admin/views.py:196
+#: build/lib/opac/webapp/admin/views.py:196 opac/webapp/admin/views.py:196
 #, python-format
 msgid "Ocorreu um erro no envio do emails de confirmação. Erro: %(ex)s"
 msgstr "Ocurrió un error en el envío de emails de confirmación. Error: %(ex)s"
 
-#: opac/webapp/admin/views.py:231 opac/webapp/admin/views.py:265
-#: opac/webapp/admin/views.py:363 opac/webapp/admin/views.py:393
-#: opac/webapp/admin/views.py:677
+#: build/lib/opac/webapp/admin/views.py:231
+#: build/lib/opac/webapp/admin/views.py:265
+#: build/lib/opac/webapp/admin/views.py:363
+#: build/lib/opac/webapp/admin/views.py:393
+#: build/lib/opac/webapp/admin/views.py:677 opac/webapp/admin/views.py:231
+#: opac/webapp/admin/views.py:265 opac/webapp/admin/views.py:363
+#: opac/webapp/admin/views.py:393 opac/webapp/admin/views.py:677
 msgid "Nome"
 msgstr "Nombre"
 
-#: opac/webapp/admin/views.py:232 opac/webapp/admin/views.py:267
+#: build/lib/opac/webapp/admin/views.py:232
+#: build/lib/opac/webapp/admin/views.py:267 opac/webapp/admin/views.py:232
+#: opac/webapp/admin/views.py:267
 msgid "Link"
 msgstr "Enlace"
 
-#: opac/webapp/admin/views.py:233 opac/webapp/admin/views.py:268
-#: opac/webapp/admin/views.py:678
+#: build/lib/opac/webapp/admin/views.py:233
+#: build/lib/opac/webapp/admin/views.py:268
+#: build/lib/opac/webapp/admin/views.py:678 opac/webapp/admin/views.py:233
+#: opac/webapp/admin/views.py:268 opac/webapp/admin/views.py:678
 msgid "Idioma"
 msgstr "idioma"
 
-#: opac/webapp/admin/views.py:266
+#: build/lib/opac/webapp/admin/views.py:266 opac/webapp/admin/views.py:266
 msgid "Previsualização"
 msgstr "Previsualización"
 
-#: opac/webapp/admin/views.py:362 opac/webapp/admin/views.py:547
-#: opac/webapp/admin/views.py:627
+#: build/lib/opac/webapp/admin/views.py:362
+#: build/lib/opac/webapp/admin/views.py:547
+#: build/lib/opac/webapp/admin/views.py:627 opac/webapp/admin/views.py:362
+#: opac/webapp/admin/views.py:547 opac/webapp/admin/views.py:627
 msgid "Ordem"
 msgstr "Orden"
 
-#: opac/webapp/admin/views.py:364
+#: build/lib/opac/webapp/admin/views.py:364 opac/webapp/admin/views.py:364
 msgid "URL"
 msgstr "URL"
 
-#: opac/webapp/admin/views.py:365
+#: build/lib/opac/webapp/admin/views.py:365 opac/webapp/admin/views.py:365
 msgid "URL da logomarca"
 msgstr "URL del logo"
 
-#: opac/webapp/admin/views.py:375
+#: build/lib/opac/webapp/admin/views.py:375 opac/webapp/admin/views.py:375
 msgid "Financiador com Ordem ou Nome já cadastrado!"
 msgstr "Financiador con Orden o Nombre ya registrado!"
 
-#: opac/webapp/admin/views.py:394
+#: build/lib/opac/webapp/admin/views.py:394 opac/webapp/admin/views.py:394
 msgid "Acerca de"
 msgstr "Acerca de"
 
-#: opac/webapp/admin/views.py:395 opac/webapp/admin/views.py:462
+#: build/lib/opac/webapp/admin/views.py:395
+#: build/lib/opac/webapp/admin/views.py:462 opac/webapp/admin/views.py:395
+#: opac/webapp/admin/views.py:462
 msgid "Acrônimo"
 msgstr "Acrónimo"
 
-#: opac/webapp/admin/views.py:396
+#: build/lib/opac/webapp/admin/views.py:396 opac/webapp/admin/views.py:396
 msgid "Endereço principal"
 msgstr "Dirección principal"
 
-#: opac/webapp/admin/views.py:397
+#: build/lib/opac/webapp/admin/views.py:397 opac/webapp/admin/views.py:397
 msgid "Endereço secundário"
 msgstr "Dirección secundaria"
 
-#: opac/webapp/admin/views.py:398
+#: build/lib/opac/webapp/admin/views.py:398 opac/webapp/admin/views.py:398
 msgid "Logo da Home (PT)"
 msgstr "Logo de la Homepage (PT)"
 
-#: opac/webapp/admin/views.py:399
+#: build/lib/opac/webapp/admin/views.py:399 opac/webapp/admin/views.py:399
 msgid "Logo da Home (EN)"
 msgstr "Logo de la Homepage (EN)"
 
-#: opac/webapp/admin/views.py:400
+#: build/lib/opac/webapp/admin/views.py:400 opac/webapp/admin/views.py:400
 msgid "Logo da Home (ES)"
 msgstr "Logo de la Homepage (ES)"
 
-#: opac/webapp/admin/views.py:401
+#: build/lib/opac/webapp/admin/views.py:401 opac/webapp/admin/views.py:401
 msgid "Logo do cabeçalho (PT)"
 msgstr "Logo del encabezado (PT)"
 
-#: opac/webapp/admin/views.py:402
+#: build/lib/opac/webapp/admin/views.py:402 opac/webapp/admin/views.py:402
 msgid "Logo do cabeçalho (EN)"
 msgstr "Logo del encabezado (EN)"
 
-#: opac/webapp/admin/views.py:403
+#: build/lib/opac/webapp/admin/views.py:403 opac/webapp/admin/views.py:403
 msgid "Logo do cabeçalho (ES)"
 msgstr "Logo del encabezado (ES)"
 
-#: opac/webapp/admin/views.py:404
+#: build/lib/opac/webapp/admin/views.py:404 opac/webapp/admin/views.py:404
 msgid "Logo do menu (PT)"
 msgstr "Logo del menú (PT)"
 
-#: opac/webapp/admin/views.py:405 opac/webapp/admin/views.py:406
+#: build/lib/opac/webapp/admin/views.py:405
+#: build/lib/opac/webapp/admin/views.py:406 opac/webapp/admin/views.py:405
+#: opac/webapp/admin/views.py:406
 msgid "Logo do menu (ES)"
 msgstr "Logo del menú (ES)"
 
-#: opac/webapp/admin/views.py:407
+#: build/lib/opac/webapp/admin/views.py:407 opac/webapp/admin/views.py:407
 msgid "Logo do menu (drop)"
 msgstr "Logo del menú (drop)"
 
-#: opac/webapp/admin/views.py:408
+#: build/lib/opac/webapp/admin/views.py:408 opac/webapp/admin/views.py:408
 msgid "Logo do rodapé"
 msgstr "Logo del pié de página"
 
-#: opac/webapp/admin/views.py:451
+#: build/lib/opac/webapp/admin/views.py:451 opac/webapp/admin/views.py:451
 msgid "Id Periódico"
 msgstr "Id Revista"
 
-#: opac/webapp/admin/views.py:453
+#: build/lib/opac/webapp/admin/views.py:453 opac/webapp/admin/views.py:453
 msgid "Linha do tempo"
 msgstr "Línea de tiempo"
 
-#: opac/webapp/admin/views.py:454
+#: build/lib/opac/webapp/admin/views.py:454 opac/webapp/admin/views.py:454
 msgid "Categorias de assunto"
 msgstr "Categorías de asunto"
 
-#: opac/webapp/admin/views.py:455
+#: build/lib/opac/webapp/admin/views.py:455 opac/webapp/admin/views.py:455
 msgid "Áreas de estudo"
 msgstr "Áreas de estudio"
 
-#: opac/webapp/admin/views.py:456
+#: build/lib/opac/webapp/admin/views.py:456 opac/webapp/admin/views.py:456
 msgid "Redes sociais"
 msgstr "Redes sociales"
 
+#: build/lib/opac/webapp/admin/views.py:457
+#: build/lib/opac/webapp/admin/views.py:611
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:30
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:73
 #: opac/webapp/admin/views.py:457 opac/webapp/admin/views.py:611
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:30
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:73
 msgid "Título"
 msgstr "Título"
 
-#: opac/webapp/admin/views.py:458
+#: build/lib/opac/webapp/admin/views.py:458 opac/webapp/admin/views.py:458
 msgid "Título ISO"
 msgstr "Título ISO"
 
-#: opac/webapp/admin/views.py:459
+#: build/lib/opac/webapp/admin/views.py:459 opac/webapp/admin/views.py:459
 msgid "Título curto"
 msgstr "Título corto"
 
-#: opac/webapp/admin/views.py:460 opac/webapp/admin/views.py:538
-#: opac/webapp/admin/views.py:614
+#: build/lib/opac/webapp/admin/views.py:460
+#: build/lib/opac/webapp/admin/views.py:538
+#: build/lib/opac/webapp/admin/views.py:614 opac/webapp/admin/views.py:460
+#: opac/webapp/admin/views.py:538 opac/webapp/admin/views.py:614
 msgid "Criado"
 msgstr "Creado"
 
-#: opac/webapp/admin/views.py:461 opac/webapp/admin/views.py:539
-#: opac/webapp/admin/views.py:615
+#: build/lib/opac/webapp/admin/views.py:461
+#: build/lib/opac/webapp/admin/views.py:539
+#: build/lib/opac/webapp/admin/views.py:615 opac/webapp/admin/views.py:461
+#: opac/webapp/admin/views.py:539 opac/webapp/admin/views.py:615
 msgid "Atualizado"
 msgstr "Actualizado"
 
-#: opac/webapp/admin/views.py:463
+#: build/lib/opac/webapp/admin/views.py:463 opac/webapp/admin/views.py:463
 msgid "ISSN SciELO"
 msgstr "ISSN SciELO"
 
-#: opac/webapp/admin/views.py:464
+#: build/lib/opac/webapp/admin/views.py:464 opac/webapp/admin/views.py:464
 msgid "ISSN impresso"
 msgstr "ISSN impreso"
 
-#: opac/webapp/admin/views.py:465
+#: build/lib/opac/webapp/admin/views.py:465 opac/webapp/admin/views.py:465
 msgid "ISSN eletrônico"
 msgstr "ISSN electrónico"
 
-#: opac/webapp/admin/views.py:466
+#: build/lib/opac/webapp/admin/views.py:466 opac/webapp/admin/views.py:466
 msgid "Descritores de assunto"
 msgstr "Descriptores de asunto"
 
-#: opac/webapp/admin/views.py:467
+#: build/lib/opac/webapp/admin/views.py:467 opac/webapp/admin/views.py:467
 msgid "Url da submissão online"
 msgstr "Url de envío online"
 
-#: opac/webapp/admin/views.py:468
+#: build/lib/opac/webapp/admin/views.py:468 opac/webapp/admin/views.py:468
 msgid "Url do capa"
 msgstr "Url de carátula"
 
-#: opac/webapp/admin/views.py:469
+#: build/lib/opac/webapp/admin/views.py:469 opac/webapp/admin/views.py:469
 msgid "Url do logotipo"
 msgstr "Url de logotipo"
 
-#: opac/webapp/admin/views.py:470
+#: build/lib/opac/webapp/admin/views.py:470 opac/webapp/admin/views.py:470
 msgid "Outros títulos"
 msgstr "Otros títulos"
 
-#: opac/webapp/admin/views.py:471
+#: build/lib/opac/webapp/admin/views.py:471 opac/webapp/admin/views.py:471
 msgid "Nome da editora"
 msgstr "Nombre de la editorial"
 
-#: opac/webapp/admin/views.py:472
+#: build/lib/opac/webapp/admin/views.py:472 opac/webapp/admin/views.py:472
 msgid "País da editora"
 msgstr "País de la editorial"
 
-#: opac/webapp/admin/views.py:473
+#: build/lib/opac/webapp/admin/views.py:473 opac/webapp/admin/views.py:473
 msgid "Estado da editora"
 msgstr "Estado de la editorial"
 
-#: opac/webapp/admin/views.py:474
+#: build/lib/opac/webapp/admin/views.py:474 opac/webapp/admin/views.py:474
 msgid "Cidade da editora"
 msgstr "Ciudad de la editorial"
 
-#: opac/webapp/admin/views.py:475
+#: build/lib/opac/webapp/admin/views.py:475 opac/webapp/admin/views.py:475
 msgid "Endereço da editora"
 msgstr "Dirección de la editorial"
 
-#: opac/webapp/admin/views.py:476
+#: build/lib/opac/webapp/admin/views.py:476 opac/webapp/admin/views.py:476
 msgid "Telefone da editora"
 msgstr "Teléfono de la editorial"
 
-#: opac/webapp/admin/views.py:477
+#: build/lib/opac/webapp/admin/views.py:477 opac/webapp/admin/views.py:477
 msgid "Missão"
 msgstr "Misión"
 
-#: opac/webapp/admin/views.py:478
+#: build/lib/opac/webapp/admin/views.py:478 opac/webapp/admin/views.py:478
 msgid "No índice"
 msgstr "En el índice"
 
-#: opac/webapp/admin/views.py:479
+#: build/lib/opac/webapp/admin/views.py:479 opac/webapp/admin/views.py:479
 msgid "Patrocinadores"
 msgstr "Patrocinadores"
 
-#: opac/webapp/admin/views.py:480
+#: build/lib/opac/webapp/admin/views.py:480 opac/webapp/admin/views.py:480
 msgid "Ref periódico anterior"
 msgstr "Ref. de la revista anterior"
 
-#: opac/webapp/admin/views.py:481
+#: build/lib/opac/webapp/admin/views.py:481 opac/webapp/admin/views.py:481
 msgid "Situação atual"
 msgstr "Estado actual"
 
-#: opac/webapp/admin/views.py:482
+#: build/lib/opac/webapp/admin/views.py:482 opac/webapp/admin/views.py:482
 msgid "Total de números"
 msgstr "Total de números"
 
-#: opac/webapp/admin/views.py:483 opac/webapp/admin/views.py:548
-#: opac/webapp/admin/views.py:618
+#: build/lib/opac/webapp/admin/views.py:483
+#: build/lib/opac/webapp/admin/views.py:548
+#: build/lib/opac/webapp/admin/views.py:618 opac/webapp/admin/views.py:483
+#: opac/webapp/admin/views.py:548 opac/webapp/admin/views.py:618
 msgid "Publicado?"
 msgstr "¿Publicado?"
 
-#: opac/webapp/admin/views.py:484 opac/webapp/admin/views.py:549
-#: opac/webapp/admin/views.py:619
+#: build/lib/opac/webapp/admin/views.py:484
+#: build/lib/opac/webapp/admin/views.py:549
+#: build/lib/opac/webapp/admin/views.py:619 opac/webapp/admin/views.py:484
+#: opac/webapp/admin/views.py:549 opac/webapp/admin/views.py:619
 msgid "Motivo de despublicação"
 msgstr "Motivo de la despublicación"
 
-#: opac/webapp/admin/views.py:485 opac/webapp/admin/views.py:551
-#: opac/webapp/admin/views.py:620
+#: build/lib/opac/webapp/admin/views.py:485
+#: build/lib/opac/webapp/admin/views.py:551
+#: build/lib/opac/webapp/admin/views.py:620 opac/webapp/admin/views.py:485
+#: opac/webapp/admin/views.py:551 opac/webapp/admin/views.py:620
 msgid "Segmento de URL"
 msgstr "Segmento de la URL"
 
-#: opac/webapp/admin/views.py:488 opac/webapp/admin/views.py:554
-#: opac/webapp/admin/views.py:633
+#: build/lib/opac/webapp/admin/views.py:488
+#: build/lib/opac/webapp/admin/views.py:554
+#: build/lib/opac/webapp/admin/views.py:633 opac/webapp/admin/views.py:488
+#: opac/webapp/admin/views.py:554 opac/webapp/admin/views.py:633
 msgid "Publicar"
 msgstr "Publicar"
 
-#: opac/webapp/admin/views.py:493
+#: build/lib/opac/webapp/admin/views.py:493 opac/webapp/admin/views.py:493
 msgid "Periódico(s) publicado(s) com sucesso!!"
 msgstr "Revista(s) publicada(s) éxitosamente!!"
 
-#: opac/webapp/admin/views.py:495
+#: build/lib/opac/webapp/admin/views.py:495 opac/webapp/admin/views.py:495
 msgid "Ocorreu um erro tentando publicar o(s) periódico(s)!!"
 msgstr "Ocurrió un error intentando publicar la/s revista(s)!!"
 
-#: opac/webapp/admin/views.py:501
+#: build/lib/opac/webapp/admin/views.py:501 opac/webapp/admin/views.py:501
 msgid "Periódico(s) despublicado com sucesso!!"
 msgstr "Revista(s) despublicada(s) éxitosamente!!"
 
-#: opac/webapp/admin/views.py:504
+#: build/lib/opac/webapp/admin/views.py:504 opac/webapp/admin/views.py:504
 #, python-format
 msgid "Ocorreu um erro tentando despublicar o(s) periódico(s)!!. Erro: %(ex)s"
 msgstr "Ocurrió un error intentando despublicar la/s revista(s)!!. Error: %(ex)s"
 
-#: opac/webapp/admin/views.py:508 opac/webapp/admin/views.py:576
-#: opac/webapp/admin/views.py:656
+#: build/lib/opac/webapp/admin/views.py:508
+#: build/lib/opac/webapp/admin/views.py:576
+#: build/lib/opac/webapp/admin/views.py:656 opac/webapp/admin/views.py:508
+#: opac/webapp/admin/views.py:576 opac/webapp/admin/views.py:656
 #, python-format
 msgid "Despublicar por %s"
 msgstr "Despublicar por %s"
 
-#: opac/webapp/admin/views.py:532
+#: build/lib/opac/webapp/admin/views.py:532 opac/webapp/admin/views.py:532
 msgid "Id Número"
 msgstr "Id. Número"
 
-#: opac/webapp/admin/views.py:534 opac/webapp/admin/views.py:624
+#: build/lib/opac/webapp/admin/views.py:534
+#: build/lib/opac/webapp/admin/views.py:624 opac/webapp/admin/views.py:534
+#: opac/webapp/admin/views.py:624
 msgid "Seções"
 msgstr "Secciones"
 
-#: opac/webapp/admin/views.py:535
+#: build/lib/opac/webapp/admin/views.py:535 opac/webapp/admin/views.py:535
 msgid "Url da capa"
 msgstr "URL de la capa"
 
+#: build/lib/opac/webapp/admin/views.py:536
+#: build/lib/opac/webapp/templates/collection/list_feed_content.html:3
+#: build/lib/opac/webapp/templates/issue/grid.html:40
+#: build/lib/opac/webapp/templates/news/includes/issue_last_row.html:7
 #: opac/webapp/admin/views.py:536
 #: opac/webapp/templates/collection/list_feed_content.html:3
 #: opac/webapp/templates/issue/grid.html:40
@@ -797,26 +928,31 @@ msgstr "URL de la capa"
 msgid "Volume"
 msgstr "Volumen"
 
-#: opac/webapp/admin/views.py:540
+#: build/lib/opac/webapp/admin/views.py:540 opac/webapp/admin/views.py:540
 msgid "Tipo"
 msgstr "Tipo"
 
-#: opac/webapp/admin/views.py:541
+#: build/lib/opac/webapp/admin/views.py:541 opac/webapp/admin/views.py:541
 msgid "Texto do suplemento"
 msgstr "Texto del suplemento"
 
-#: opac/webapp/admin/views.py:542
+#: build/lib/opac/webapp/admin/views.py:542 opac/webapp/admin/views.py:542
 msgid "Texto do especial"
 msgstr "Texto del especial"
 
-#: opac/webapp/admin/views.py:543
+#: build/lib/opac/webapp/admin/views.py:543 opac/webapp/admin/views.py:543
 msgid "Mês inicial"
 msgstr "Mes inicial"
 
-#: opac/webapp/admin/views.py:544
+#: build/lib/opac/webapp/admin/views.py:544 opac/webapp/admin/views.py:544
 msgid "Mês final"
 msgstr "Mes final"
 
+#: build/lib/opac/webapp/admin/views.py:545
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:25
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:68
+#: build/lib/opac/webapp/templates/issue/grid.html:39
+#: build/lib/opac/webapp/templates/news/includes/issue_last_row.html:5
 #: opac/webapp/admin/views.py:545
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:25
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:68
@@ -825,64 +961,74 @@ msgstr "Mes final"
 msgid "Ano"
 msgstr "Año"
 
-#: opac/webapp/admin/views.py:546
+#: build/lib/opac/webapp/admin/views.py:546 opac/webapp/admin/views.py:546
 msgid "Etiqueta"
 msgstr "Etiqueta"
 
-#: opac/webapp/admin/views.py:550 opac/webapp/admin/views.py:621
+#: build/lib/opac/webapp/admin/views.py:550
+#: build/lib/opac/webapp/admin/views.py:621 opac/webapp/admin/views.py:550
+#: opac/webapp/admin/views.py:621
 msgid "PID"
 msgstr "PID"
 
-#: opac/webapp/admin/views.py:559
+#: build/lib/opac/webapp/admin/views.py:559 opac/webapp/admin/views.py:559
 msgid "Número(s) publicado(s) com sucesso!!"
 msgstr "Fascículo(s) publicado(s) con éxito!!"
 
-#: opac/webapp/admin/views.py:562 opac/webapp/admin/views.py:642
+#: build/lib/opac/webapp/admin/views.py:562
+#: build/lib/opac/webapp/admin/views.py:642 opac/webapp/admin/views.py:562
+#: opac/webapp/admin/views.py:642
 #, python-format
 msgid "Ocorreu um erro tentando publicar o(s) número(s)!!. Erro: %(ex)s"
 msgstr "Ocurrió un error intentando publicar el/los fascículo(s)!! Error: %(ex)s"
 
-#: opac/webapp/admin/views.py:569
+#: build/lib/opac/webapp/admin/views.py:569 opac/webapp/admin/views.py:569
 msgid "Número(s) despublicado(s) com sucesso!!"
 msgstr "Fascículo(s) despublicado(s) con éxito!!"
 
-#: opac/webapp/admin/views.py:572 opac/webapp/admin/views.py:652
+#: build/lib/opac/webapp/admin/views.py:572
+#: build/lib/opac/webapp/admin/views.py:652 opac/webapp/admin/views.py:572
+#: opac/webapp/admin/views.py:652
 #, python-format
 msgid "Ocorreu um erro tentando despublicar o(s) número(s)!!. Erro: %(ex)s"
 msgstr "Ocurrió un error intentando despublicar el/los fascículo(s)!! Error:%(ex)s"
 
-#: opac/webapp/admin/views.py:608
+#: build/lib/opac/webapp/admin/views.py:608 opac/webapp/admin/views.py:608
 msgid "Id Artigo"
 msgstr "Id. Artículo"
 
-#: opac/webapp/admin/views.py:612
+#: build/lib/opac/webapp/admin/views.py:612 opac/webapp/admin/views.py:612
 msgid "Seção"
 msgstr "Sección"
 
-#: opac/webapp/admin/views.py:613
+#: build/lib/opac/webapp/admin/views.py:613 opac/webapp/admin/views.py:613
 msgid "É Ahead of Print?"
 msgstr "¿Es Ahead of Print?"
 
-#: opac/webapp/admin/views.py:616
+#: build/lib/opac/webapp/admin/views.py:616 opac/webapp/admin/views.py:616
 msgid "HTML's"
 msgstr "HTML's"
 
-#: opac/webapp/admin/views.py:617
+#: build/lib/opac/webapp/admin/views.py:617 opac/webapp/admin/views.py:617
 msgid "Chave de domínio"
 msgstr "Clave de domínio"
 
-#: opac/webapp/admin/views.py:622
+#: build/lib/opac/webapp/admin/views.py:622 opac/webapp/admin/views.py:622
 msgid "Idioma original"
 msgstr "Idioma original"
 
-#: opac/webapp/admin/views.py:623
+#: build/lib/opac/webapp/admin/views.py:623 opac/webapp/admin/views.py:623
 msgid "Idiomas das traduções"
 msgstr "Idiomas de las traducciones"
 
-#: opac/webapp/admin/views.py:625
+#: build/lib/opac/webapp/admin/views.py:625 opac/webapp/admin/views.py:625
 msgid "Autores"
 msgstr "Autores"
 
+#: build/lib/opac/webapp/admin/views.py:626
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:29
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:72
+#: build/lib/opac/webapp/templates/issue/toc.html:176
 #: opac/webapp/admin/views.py:626
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:29
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:72
@@ -890,120 +1036,143 @@ msgstr "Autores"
 msgid "Resumo"
 msgstr "Resumen"
 
-#: opac/webapp/admin/views.py:628
+#: build/lib/opac/webapp/admin/views.py:628 opac/webapp/admin/views.py:628
 msgid "DOI"
 msgstr "DOI"
 
-#: opac/webapp/admin/views.py:629
+#: build/lib/opac/webapp/admin/views.py:629 opac/webapp/admin/views.py:629
 msgid "Idiomas"
 msgstr "Idiomas"
 
-#: opac/webapp/admin/views.py:630
+#: build/lib/opac/webapp/admin/views.py:630 opac/webapp/admin/views.py:630
 msgid "Idiomas dos resumos"
 msgstr "Idiomas de los resúmenes"
 
-#: opac/webapp/admin/views.py:638
+#: build/lib/opac/webapp/admin/views.py:638 opac/webapp/admin/views.py:638
 msgid "Artigo(s) publicado com sucesso!!"
 msgstr "Artículo(s) publicado éxitosamente!!"
 
-#: opac/webapp/admin/views.py:649
+#: build/lib/opac/webapp/admin/views.py:649 opac/webapp/admin/views.py:649
 msgid "Artigo(s) despublicado com sucesso!!"
 msgstr "Artículo(s) despublicado éxitosamente!!"
 
-#: opac/webapp/admin/views.py:679
+#: build/lib/opac/webapp/admin/views.py:679 opac/webapp/admin/views.py:679
 msgid "Conteúdo"
 msgstr "Contenido"
 
-#: opac/webapp/admin/views.py:681 opac/webapp/admin/views.py:901
+#: build/lib/opac/webapp/admin/views.py:681
+#: build/lib/opac/webapp/admin/views.py:901 opac/webapp/admin/views.py:681
+#: opac/webapp/admin/views.py:901
 msgid "Descrição"
 msgstr "Descripción"
 
-#: opac/webapp/admin/views.py:682 opac/webapp/admin/views.py:898
+#: build/lib/opac/webapp/admin/views.py:682
+#: build/lib/opac/webapp/admin/views.py:898 opac/webapp/admin/views.py:682
+#: opac/webapp/admin/views.py:898
 msgid "Data de Criação"
 msgstr ""
 
-#: opac/webapp/admin/views.py:683
+#: build/lib/opac/webapp/admin/views.py:683 opac/webapp/admin/views.py:683
 msgid "Data de Atualização"
 msgstr ""
 
-#: opac/webapp/admin/views.py:897
+#: build/lib/opac/webapp/admin/views.py:897 opac/webapp/admin/views.py:897
 msgid "Ação"
 msgstr ""
 
-#: opac/webapp/admin/views.py:899
+#: build/lib/opac/webapp/admin/views.py:899 opac/webapp/admin/views.py:899
 msgid "Modelo Auditado"
 msgstr ""
 
-#: opac/webapp/admin/views.py:900
+#: build/lib/opac/webapp/admin/views.py:900 opac/webapp/admin/views.py:900
 msgid "Id Auditado"
 msgstr ""
 
-#: opac/webapp/admin/views.py:902
+#: build/lib/opac/webapp/admin/views.py:902 opac/webapp/admin/views.py:902
 msgid "Dados dos campos"
 msgstr ""
 
-#: opac/webapp/main/views.py:29
+#: build/lib/opac/webapp/main/views.py:34 opac/webapp/main/views.py:34
 msgid "O periódico está indisponível por motivo de: "
 msgstr "La revista no está disponible debido a:"
 
-#: opac/webapp/main/views.py:30
+#: build/lib/opac/webapp/main/views.py:35 opac/webapp/main/views.py:35
 msgid "O número está indisponível por motivo de: "
 msgstr "O fascículo esta indisponible por motivo de:"
 
-#: opac/webapp/main/views.py:31
+#: build/lib/opac/webapp/main/views.py:36 opac/webapp/main/views.py:36
 msgid "O artigo está indisponível por motivo de: "
 msgstr "El artículo no está disponible debido a:"
 
-#: opac/webapp/main/views.py:78
+#: build/lib/opac/webapp/main/views.py:127 opac/webapp/main/views.py:127
 msgid "Código de idioma inválido"
 msgstr "Código de idioma inválido"
 
-#: opac/webapp/main/views.py:148
+#: build/lib/opac/webapp/main/views.py:197 opac/webapp/main/views.py:197
 msgid "Últimos periódicos inseridos na coleção"
 msgstr "Últimas revistas incluidas en la colección"
 
-#: opac/webapp/main/views.py:149
+#: build/lib/opac/webapp/main/views.py:198 opac/webapp/main/views.py:198
 #, python-format
 msgid "10 últimos periódicos inseridos na coleção %s"
 msgstr "10 últimas revistas incluidas en la colección %s"
 
-#: opac/webapp/main/views.py:208
+#: build/lib/opac/webapp/main/views.py:257 opac/webapp/main/views.py:257
 msgid "Página não encontrada"
 msgstr "Página no encontrada"
 
-#: opac/webapp/main/views.py:232 opac/webapp/main/views.py:322
+#: build/lib/opac/webapp/main/views.py:281
+#: build/lib/opac/webapp/main/views.py:371 opac/webapp/main/views.py:281
+#: opac/webapp/main/views.py:371
 #, python-format
 msgid "Requsição inválida ao tentar acessar o artigo com pid: %s"
 msgstr "Requiere no válida al intentar tener acceso al artículo con pid:% s"
 
-#: opac/webapp/main/views.py:240 opac/webapp/main/views.py:290
-#: opac/webapp/main/views.py:334 opac/webapp/main/views.py:403
-#: opac/webapp/main/views.py:450 opac/webapp/main/views.py:597
-#: opac/webapp/main/views.py:614 opac/webapp/main/views.py:1055
+#: build/lib/opac/webapp/main/views.py:289
+#: build/lib/opac/webapp/main/views.py:339
+#: build/lib/opac/webapp/main/views.py:383
+#: build/lib/opac/webapp/main/views.py:452
+#: build/lib/opac/webapp/main/views.py:500
+#: build/lib/opac/webapp/main/views.py:647
+#: build/lib/opac/webapp/main/views.py:664
+#: build/lib/opac/webapp/main/views.py:1127 opac/webapp/main/views.py:289
+#: opac/webapp/main/views.py:339 opac/webapp/main/views.py:383
+#: opac/webapp/main/views.py:452 opac/webapp/main/views.py:500
+#: opac/webapp/main/views.py:647 opac/webapp/main/views.py:664
+#: opac/webapp/main/views.py:1127
 msgid "Periódico não encontrado"
 msgstr "Revista no encontrada"
 
-#: opac/webapp/main/views.py:252 opac/webapp/main/views.py:664
-#: opac/webapp/main/views.py:723 opac/webapp/main/views.py:1064
+#: build/lib/opac/webapp/main/views.py:301
+#: build/lib/opac/webapp/main/views.py:714
+#: build/lib/opac/webapp/main/views.py:773
+#: build/lib/opac/webapp/main/views.py:1136 opac/webapp/main/views.py:301
+#: opac/webapp/main/views.py:714 opac/webapp/main/views.py:773
+#: opac/webapp/main/views.py:1136
 msgid "Número não encontrado"
 msgstr "Fascículo no encontrado"
 
-#: opac/webapp/main/views.py:270 opac/webapp/main/views.py:305
-#: opac/webapp/main/views.py:774 opac/webapp/main/views.py:805
-#: opac/webapp/main/views.py:881 opac/webapp/main/views.py:884
-#: opac/webapp/main/views.py:988
+#: build/lib/opac/webapp/main/views.py:319
+#: build/lib/opac/webapp/main/views.py:354
+#: build/lib/opac/webapp/main/views.py:825
+#: build/lib/opac/webapp/main/views.py:910
+#: build/lib/opac/webapp/main/views.py:1060 opac/webapp/main/views.py:319
+#: opac/webapp/main/views.py:354 opac/webapp/main/views.py:825
+#: opac/webapp/main/views.py:910 opac/webapp/main/views.py:1060
 msgid "Artigo não encontrado"
 msgstr "Artículo no encontrado"
 
-#: opac/webapp/main/views.py:427
+#: build/lib/opac/webapp/main/views.py:476 opac/webapp/main/views.py:476
 msgid "Artigo sem título"
 msgstr "Artículo sin título"
 
-#: opac/webapp/main/views.py:498 opac/webapp/main/views.py:515
+#: build/lib/opac/webapp/main/views.py:548
+#: build/lib/opac/webapp/main/views.py:565 opac/webapp/main/views.py:548
+#: opac/webapp/main/views.py:565
 msgid "Requisição inválida. Deve ser por ajax"
 msgstr "Solicitud no válida. Debe ser por ajax"
 
-#: opac/webapp/main/views.py:531
+#: build/lib/opac/webapp/main/views.py:581 opac/webapp/main/views.py:581
 msgid ""
 "Parámetro \"filter\" é inválido, deve ser \"areas\", \"wos\" ou "
 "\"publisher\"."
@@ -1011,11 +1180,11 @@ msgstr ""
 "Parámetro \"filter\" no es válido, debe ser \"areas\", \"wos\" o "
 "\"publisher\"."
 
-#: opac/webapp/main/views.py:540
+#: build/lib/opac/webapp/main/views.py:590 opac/webapp/main/views.py:590
 msgid "Parámetro \"extension\" é inválido, deve ser \"csv\" ou \"xls\"."
 msgstr "Parámetro \"extension\" no es válido, debe ser \"csv\" o \"xls\"."
 
-#: opac/webapp/main/views.py:542
+#: build/lib/opac/webapp/main/views.py:592 opac/webapp/main/views.py:592
 msgid ""
 "Parámetro \"list_type\" é inválido, deve ser: \"alpha\", \"areas\", "
 "\"wos\" ou \"publisher\"."
@@ -1023,69 +1192,78 @@ msgstr ""
 "Parámetro \"list_type\" no es válido, debe ser:  \"alpha\", \"areas\", "
 "\"wos\" o \"publisher\"."
 
-#: opac/webapp/main/views.py:563
+#: build/lib/opac/webapp/main/views.py:613 opac/webapp/main/views.py:613
 msgid "Requisição inválida, deve ser ajax."
 msgstr ""
 
-#: opac/webapp/main/views.py:572
+#: build/lib/opac/webapp/main/views.py:622 opac/webapp/main/views.py:622
 msgid "Periódico não permite envio de email."
 msgstr "La revista no permite envío de correo electrónico"
 
-#: opac/webapp/main/views.py:590
+#: build/lib/opac/webapp/main/views.py:640 opac/webapp/main/views.py:640
 msgid "Requisição inválida, captcha inválido."
 msgstr "Solicitud no válida, captcha inválida."
 
-#: opac/webapp/main/views.py:796 opac/webapp/main/views.py:983
+#: build/lib/opac/webapp/main/views.py:901
+#: build/lib/opac/webapp/main/views.py:1055 opac/webapp/main/views.py:901
+#: opac/webapp/main/views.py:1055
 msgid "Issue não encontrado"
 msgstr "Fascículo no encontrado"
 
-#: opac/webapp/main/views.py:841 opac/webapp/main/views.py:847
-#: opac/webapp/main/views.py:1020 opac/webapp/main/views.py:1028
-#: opac/webapp/main/views.py:1030
+#: build/lib/opac/webapp/main/views.py:943
+#: build/lib/opac/webapp/main/views.py:949
+#: build/lib/opac/webapp/main/views.py:1092
+#: build/lib/opac/webapp/main/views.py:1100
+#: build/lib/opac/webapp/main/views.py:1102 opac/webapp/main/views.py:943
+#: opac/webapp/main/views.py:949 opac/webapp/main/views.py:1092
+#: opac/webapp/main/views.py:1100 opac/webapp/main/views.py:1102
 msgid "PDF do Artigo não encontrado"
 msgstr "PDF del artículo no encontrado"
 
-#: opac/webapp/main/views.py:857
-msgid "HTML do Artigo não encontrado"
-msgstr "HTML del artículo no encontrado"
-
-#: opac/webapp/main/views.py:871
+#: build/lib/opac/webapp/main/views.py:954 opac/webapp/main/views.py:954
 msgid "HTML do Artigo não encontrado ou indisponível"
 msgstr ""
 
-#: opac/webapp/main/views.py:930
+#: build/lib/opac/webapp/main/views.py:1001 opac/webapp/main/views.py:1001
 msgid "Parâmetros insuficientes para obter o EPDF do artigo"
 msgstr "Parámetros insuficientes para obtener el EPDF del artículo"
 
-#: opac/webapp/main/views.py:947
+#: build/lib/opac/webapp/main/views.py:1022 opac/webapp/main/views.py:1022
 msgid "Recruso não encontrado"
 msgstr ""
 
-#: opac/webapp/main/views.py:952
-msgid "Recurso não encontrado"
-msgstr "Recurso no encontrado"
-
-#: opac/webapp/main/views.py:969
+#: build/lib/opac/webapp/main/views.py:1041 opac/webapp/main/views.py:1041
 msgid "Recurso do Artigo não encontrado. Caminho inválido!"
 msgstr "Recurso del Artículo no encontrado. Camino inválido!"
 
-#: opac/webapp/main/views.py:1082
+#: build/lib/opac/webapp/main/views.py:1154 opac/webapp/main/views.py:1154
 msgid "PDF do artigo não foi encontrado"
 msgstr "PDF del artículo no encontrado"
 
-#: opac/webapp/main/views.py:1110 opac/webapp/main/views.py:1141
+#: build/lib/opac/webapp/main/views.py:1169
+#: build/lib/opac/webapp/main/views.py:1200 opac/webapp/main/views.py:1169
+#: opac/webapp/main/views.py:1200
 msgid "Requisição inválida."
 msgstr "Petición inválida."
 
+#: build/lib/opac/webapp/templates/admin/index.html:7
 #: opac/webapp/templates/admin/index.html:7
 msgid "da coleção"
 msgstr "de la colección"
 
+#: build/lib/opac/webapp/templates/admin/index.html:12
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu.html:31
 #: opac/webapp/templates/admin/index.html:12
 #: opac/webapp/templates/collection/includes/levelMenu.html:31
 msgid "Periódicos"
 msgstr "Revistas"
 
+#: build/lib/opac/webapp/templates/admin/index.html:15
+#: build/lib/opac/webapp/templates/admin/index.html:22
+#: build/lib/opac/webapp/templates/admin/index.html:35
+#: build/lib/opac/webapp/templates/admin/index.html:42
+#: build/lib/opac/webapp/templates/admin/index.html:55
+#: build/lib/opac/webapp/templates/admin/index.html:62
 #: opac/webapp/templates/admin/index.html:15
 #: opac/webapp/templates/admin/index.html:22
 #: opac/webapp/templates/admin/index.html:35
@@ -1095,6 +1273,12 @@ msgstr "Revistas"
 msgid "Publicados"
 msgstr "Publicados"
 
+#: build/lib/opac/webapp/templates/admin/index.html:16
+#: build/lib/opac/webapp/templates/admin/index.html:36
+#: build/lib/opac/webapp/templates/admin/index.html:56
+#: build/lib/opac/webapp/templates/admin/index.html:75
+#: build/lib/opac/webapp/templates/admin/index.html:85
+#: build/lib/opac/webapp/templates/admin/index.html:95
 #: opac/webapp/templates/admin/index.html:16
 #: opac/webapp/templates/admin/index.html:36
 #: opac/webapp/templates/admin/index.html:56
@@ -1104,58 +1288,78 @@ msgstr "Publicados"
 msgid "Total"
 msgstr "Total"
 
+#: build/lib/opac/webapp/templates/admin/index.html:32
 #: opac/webapp/templates/admin/index.html:32
 msgid "Fascícluos"
 msgstr "Fascículos"
 
+#: build/lib/opac/webapp/templates/admin/index.html:52
 #: opac/webapp/templates/admin/index.html:52
 msgid "Artigos"
 msgstr "Artículos"
 
+#: build/lib/opac/webapp/templates/admin/index.html:72
 #: opac/webapp/templates/admin/index.html:72
 msgid "News"
 msgstr "News"
 
+#: build/lib/opac/webapp/templates/admin/index.html:82
 #: opac/webapp/templates/admin/index.html:82
 msgid "Sponsors"
 msgstr "Patrocinadores"
 
+#: build/lib/opac/webapp/templates/admin/index.html:92
 #: opac/webapp/templates/admin/index.html:92
 msgid "Press Releases"
 msgstr "Comunicado de prensa "
 
+#: build/lib/opac/webapp/templates/admin/auth/reset.html:9
+#: build/lib/opac/webapp/templates/admin/auth/reset_with_token.html:9
+#: build/lib/opac/webapp/templates/admin/opac_base.html:13
 #: opac/webapp/templates/admin/auth/reset.html:9
 #: opac/webapp/templates/admin/auth/reset_with_token.html:9
 #: opac/webapp/templates/admin/opac_base.html:13
 msgid "Recuperar a senha"
 msgstr "Recuperar contraseña"
 
+#: build/lib/opac/webapp/templates/admin/opac_base.html:14
 #: opac/webapp/templates/admin/opac_base.html:14
 msgid "Terminar sessão"
 msgstr "Cerrar sesión"
 
+#: build/lib/opac/webapp/templates/admin/auth/login.html:11
+#: build/lib/opac/webapp/templates/admin/auth/login.html:20
+#: build/lib/opac/webapp/templates/admin/opac_base.html:18
 #: opac/webapp/templates/admin/auth/login.html:11
 #: opac/webapp/templates/admin/auth/login.html:20
 #: opac/webapp/templates/admin/opac_base.html:18
 msgid "Iniciar sessão"
 msgstr "Inicial sesión"
 
+#: build/lib/opac/webapp/templates/admin/audit_log/fields_data_table.html:4
 #: opac/webapp/templates/admin/audit_log/fields_data_table.html:4
 msgid "Campo: "
 msgstr ""
 
+#: build/lib/opac/webapp/templates/admin/audit_log/fields_data_table.html:5
 #: opac/webapp/templates/admin/audit_log/fields_data_table.html:5
 msgid "Valor anterior: "
 msgstr ""
 
+#: build/lib/opac/webapp/templates/admin/audit_log/fields_data_table.html:6
 #: opac/webapp/templates/admin/audit_log/fields_data_table.html:6
 msgid "Valor novo: "
 msgstr ""
 
+#: build/lib/opac/webapp/templates/admin/auth/login.html:13
 #: opac/webapp/templates/admin/auth/login.html:13
 msgid "Você já iniciou sessão!"
 msgstr "Usted ya inició sesión!"
 
+#: build/lib/opac/webapp/templates/admin/auth/login.html:24
+#: build/lib/opac/webapp/templates/admin/auth/reset.html:13
+#: build/lib/opac/webapp/templates/admin/auth/reset_with_token.html:13
+#: build/lib/opac/webapp/templates/includes/error_form.html:60
 #: opac/webapp/templates/admin/auth/login.html:24
 #: opac/webapp/templates/admin/auth/reset.html:13
 #: opac/webapp/templates/admin/auth/reset_with_token.html:13
@@ -1163,14 +1367,17 @@ msgstr "Usted ya inició sesión!"
 msgid "Enviar"
 msgstr "Enviar"
 
+#: build/lib/opac/webapp/templates/admin/auth/login.html:28
 #: opac/webapp/templates/admin/auth/login.html:28
 msgid "Esqueci a senha?"
 msgstr "Olvidé mi contraseña?"
 
+#: build/lib/opac/webapp/templates/admin/auth/unconfirm_email.html:7
 #: opac/webapp/templates/admin/auth/unconfirm_email.html:7
 msgid "Email não confirmado!"
 msgstr "Email no confirmado!"
 
+#: build/lib/opac/webapp/templates/admin/auth/unconfirm_email.html:9
 #: opac/webapp/templates/admin/auth/unconfirm_email.html:9
 msgid ""
 "Você <strong>deve</strong> confirmar seu email.<br>\n"
@@ -1181,6 +1388,7 @@ msgstr ""
 "            <strong>Por favor entre en contacto con el "
 "administrador.</strong>"
 
+#: build/lib/opac/webapp/templates/admin/pages/edit.html:7
 #: opac/webapp/templates/admin/pages/edit.html:7
 msgid ""
 "<strong>Atenção:</strong> ao selecionar um <strong>periódico</strong> "
@@ -1193,6 +1401,11 @@ msgstr ""
 "caso contrario será una página de la colección, verifique las páginas de "
 "la colección em <em>Acerca de SciELO</em>. "
 
+#: build/lib/opac/webapp/templates/article/includes/alternative_header.html:7
+#: build/lib/opac/webapp/templates/collection/includes/header.html:7
+#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:7
+#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:7
+#: build/lib/opac/webapp/templates/journal/includes/header.html:8
 #: opac/webapp/templates/article/includes/alternative_header.html:7
 #: opac/webapp/templates/collection/includes/header.html:7
 #: opac/webapp/templates/issue/includes/alternative_header.html:7
@@ -1201,6 +1414,10 @@ msgstr ""
 msgid "Abrir menu"
 msgstr "Abrir menú"
 
+#: build/lib/opac/webapp/templates/article/includes/alternative_header.html:9
+#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:9
+#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:9
+#: build/lib/opac/webapp/templates/journal/includes/header.html:10
 #: opac/webapp/templates/article/includes/alternative_header.html:9
 #: opac/webapp/templates/issue/includes/alternative_header.html:9
 #: opac/webapp/templates/journal/includes/alternative_header.html:9
@@ -1208,6 +1425,11 @@ msgstr "Abrir menú"
 msgid "Ir para a homepage da coleção: "
 msgstr "Ir a la página de inicio de la colección:"
 
+#: build/lib/opac/webapp/templates/article/includes/alternative_header.html:42
+#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:7
+#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:121
+#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:117
+#: build/lib/opac/webapp/templates/journal/includes/header.html:118
 #: opac/webapp/templates/article/includes/alternative_header.html:42
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:7
 #: opac/webapp/templates/issue/includes/alternative_header.html:121
@@ -1216,6 +1438,11 @@ msgstr "Ir a la página de inicio de la colección:"
 msgid "Submissão de manuscritos"
 msgstr "Envío de manuscritos"
 
+#: build/lib/opac/webapp/templates/article/includes/alternative_header.html:48
+#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:16
+#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:127
+#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:123
+#: build/lib/opac/webapp/templates/journal/includes/header.html:124
 #: opac/webapp/templates/article/includes/alternative_header.html:48
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:16
 #: opac/webapp/templates/issue/includes/alternative_header.html:127
@@ -1224,6 +1451,11 @@ msgstr "Envío de manuscritos"
 msgid "Sobre o periódico"
 msgstr "Acerca de la revista"
 
+#: build/lib/opac/webapp/templates/article/includes/alternative_header.html:53
+#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:10
+#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:132
+#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:128
+#: build/lib/opac/webapp/templates/journal/includes/header.html:129
 #: opac/webapp/templates/article/includes/alternative_header.html:53
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:10
 #: opac/webapp/templates/issue/includes/alternative_header.html:132
@@ -1232,6 +1464,11 @@ msgstr "Acerca de la revista"
 msgid "Corpo Editorial"
 msgstr "Cuerpo Editorial"
 
+#: build/lib/opac/webapp/templates/article/includes/alternative_header.html:58
+#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:13
+#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:137
+#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:133
+#: build/lib/opac/webapp/templates/journal/includes/header.html:134
 #: opac/webapp/templates/article/includes/alternative_header.html:58
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:13
 #: opac/webapp/templates/issue/includes/alternative_header.html:137
@@ -1240,6 +1477,11 @@ msgstr "Cuerpo Editorial"
 msgid "Instruções aos autores"
 msgstr "Instrucciones a los autores"
 
+#: build/lib/opac/webapp/templates/article/includes/alternative_header.html:63
+#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:19
+#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:142
+#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:138
+#: build/lib/opac/webapp/templates/journal/includes/header.html:140
 #: opac/webapp/templates/article/includes/alternative_header.html:63
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:19
 #: opac/webapp/templates/issue/includes/alternative_header.html:142
@@ -1248,56 +1490,81 @@ msgstr "Instrucciones a los autores"
 msgid "Contato"
 msgstr "Contacto"
 
+#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:2
+#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:60
 #: opac/webapp/templates/article/includes/floating_menu.html:2
 #: opac/webapp/templates/article/includes/floating_menu.html:60
 msgid "Ir para o topo"
 msgstr "Ir para arriba"
 
+#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:6
+#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:65
 #: opac/webapp/templates/article/includes/floating_menu.html:6
 #: opac/webapp/templates/article/includes/floating_menu.html:65
 msgid "PDFs"
 msgstr "PDFs"
 
+#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:26
+#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:77
 #: opac/webapp/templates/article/includes/floating_menu.html:26
 #: opac/webapp/templates/article/includes/floating_menu.html:77
 msgid "Figuras e tabelas"
 msgstr "Figuras y tablas"
 
+#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:32
+#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:83
 #: opac/webapp/templates/article/includes/floating_menu.html:32
 #: opac/webapp/templates/article/includes/floating_menu.html:83
 msgid "Versões e traduções"
 msgstr "Versiones y traducciones"
 
+#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:37
+#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:88
 #: opac/webapp/templates/article/includes/floating_menu.html:37
 #: opac/webapp/templates/article/includes/floating_menu.html:88
 msgid "Como citar este artigo"
 msgstr "Como citar este artículo"
 
+#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:42
+#: build/lib/opac/webapp/templates/article/includes/modal/related_article.html:9
 #: opac/webapp/templates/article/includes/floating_menu.html:42
 #: opac/webapp/templates/article/includes/modal/related_article.html:9
 msgid "Artigos relacionados"
 msgstr "Artículos relacionados"
 
+#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:93
 #: opac/webapp/templates/article/includes/floating_menu.html:93
 msgid "Artigos e similares"
 msgstr "Artículos y similares"
 
+#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:9
 #: opac/webapp/templates/article/includes/levelMenu.html:9
 msgid "home do periodico"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:17
+#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:70
+#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:123
 #: opac/webapp/templates/article/includes/levelMenu.html:17
 #: opac/webapp/templates/article/includes/levelMenu.html:70
 #: opac/webapp/templates/article/includes/levelMenu.html:123
 msgid "sumário"
 msgstr "tabla de contenidos"
 
+#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:30
+#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:75
+#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:71
 #: opac/webapp/templates/article/includes/levelMenu.html:30
 #: opac/webapp/templates/issue/includes/alternative_header.html:75
 #: opac/webapp/templates/journal/includes/alternative_header.html:71
 msgid "anterior"
 msgstr "anterior"
 
+#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:35
+#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:88
+#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:141
+#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:82
+#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:78
 #: opac/webapp/templates/article/includes/levelMenu.html:35
 #: opac/webapp/templates/article/includes/levelMenu.html:88
 #: opac/webapp/templates/article/includes/levelMenu.html:141
@@ -1306,10 +1573,15 @@ msgstr "anterior"
 msgid "atual"
 msgstr "actual"
 
+#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:48
 #: opac/webapp/templates/article/includes/levelMenu.html:48
 msgid "seguinte"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:193
+#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:219
+#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:264
+#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:290
 #: opac/webapp/templates/article/includes/levelMenu.html:193
 #: opac/webapp/templates/article/includes/levelMenu.html:219
 #: opac/webapp/templates/article/includes/levelMenu.html:264
@@ -1317,6 +1589,10 @@ msgstr ""
 msgid "Download PDF (Espanhol)"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:195
+#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:221
+#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:266
+#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:292
 #: opac/webapp/templates/article/includes/levelMenu.html:195
 #: opac/webapp/templates/article/includes/levelMenu.html:221
 #: opac/webapp/templates/article/includes/levelMenu.html:266
@@ -1324,6 +1600,10 @@ msgstr ""
 msgid "Download PDF (Inglês)"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:197
+#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:223
+#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:268
+#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:294
 #: opac/webapp/templates/article/includes/levelMenu.html:197
 #: opac/webapp/templates/article/includes/levelMenu.html:223
 #: opac/webapp/templates/article/includes/levelMenu.html:268
@@ -1331,6 +1611,13 @@ msgstr ""
 msgid "Download PDF (Português)"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:310
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu.html:38
+#: build/lib/opac/webapp/templates/collection/includes/list_journals_section_title.html:14
+#: build/lib/opac/webapp/templates/issue/grid.html:14
+#: build/lib/opac/webapp/templates/issue/toc.html:13
+#: build/lib/opac/webapp/templates/journal/about.html:16
+#: build/lib/opac/webapp/templates/journal/detail.html:11
 #: opac/webapp/templates/article/includes/levelMenu.html:310
 #: opac/webapp/templates/collection/includes/levelMenu.html:38
 #: opac/webapp/templates/collection/includes/list_journals_section_title.html:14
@@ -1341,6 +1628,11 @@ msgstr ""
 msgid "Compartilhe"
 msgstr "Compartir"
 
+#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:311
+#: build/lib/opac/webapp/templates/collection/includes/list_journals_section_title.html:16
+#: build/lib/opac/webapp/templates/issue/toc.html:14
+#: build/lib/opac/webapp/templates/journal/about.html:17
+#: build/lib/opac/webapp/templates/journal/detail.html:12
 #: opac/webapp/templates/article/includes/levelMenu.html:311
 #: opac/webapp/templates/collection/includes/list_journals_section_title.html:16
 #: opac/webapp/templates/issue/toc.html:14
@@ -1349,6 +1641,11 @@ msgstr "Compartir"
 msgid "Enviar link por e-mail"
 msgstr "Enviar vínculo por e-mail"
 
+#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:314
+#: build/lib/opac/webapp/templates/collection/includes/list_journals_section_title.html:19
+#: build/lib/opac/webapp/templates/issue/toc.html:15
+#: build/lib/opac/webapp/templates/journal/about.html:18
+#: build/lib/opac/webapp/templates/journal/detail.html:13
 #: opac/webapp/templates/article/includes/levelMenu.html:314
 #: opac/webapp/templates/collection/includes/list_journals_section_title.html:19
 #: opac/webapp/templates/issue/toc.html:15
@@ -1357,6 +1654,11 @@ msgstr "Enviar vínculo por e-mail"
 msgid "Compartilhar no Facebook"
 msgstr "Compartir en Facebook"
 
+#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:317
+#: build/lib/opac/webapp/templates/collection/includes/list_journals_section_title.html:22
+#: build/lib/opac/webapp/templates/issue/toc.html:16
+#: build/lib/opac/webapp/templates/journal/about.html:19
+#: build/lib/opac/webapp/templates/journal/detail.html:14
 #: opac/webapp/templates/article/includes/levelMenu.html:317
 #: opac/webapp/templates/collection/includes/list_journals_section_title.html:22
 #: opac/webapp/templates/issue/toc.html:16
@@ -1365,6 +1667,18 @@ msgstr "Compartir en Facebook"
 msgid "Compartilhar no Twitter"
 msgstr "Compartir en Twitter"
 
+#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:320
+#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:325
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu.html:46
+#: build/lib/opac/webapp/templates/collection/includes/list_journals_section_title.html:25
+#: build/lib/opac/webapp/templates/collection/includes/list_journals_section_title.html:30
+#: build/lib/opac/webapp/templates/issue/grid.html:20
+#: build/lib/opac/webapp/templates/issue/toc.html:17
+#: build/lib/opac/webapp/templates/issue/toc.html:19
+#: build/lib/opac/webapp/templates/journal/about.html:20
+#: build/lib/opac/webapp/templates/journal/about.html:22
+#: build/lib/opac/webapp/templates/journal/detail.html:15
+#: build/lib/opac/webapp/templates/journal/detail.html:17
 #: opac/webapp/templates/article/includes/levelMenu.html:320
 #: opac/webapp/templates/article/includes/levelMenu.html:325
 #: opac/webapp/templates/collection/includes/levelMenu.html:46
@@ -1380,16 +1694,24 @@ msgstr "Compartir en Twitter"
 msgid "Outras redes sociais"
 msgstr "Otras redes sociales"
 
+#: build/lib/opac/webapp/templates/article/includes/recent_articles_row.html:6
+#: build/lib/opac/webapp/templates/issue/toc.html:149
 #: opac/webapp/templates/article/includes/recent_articles_row.html:6
 #: opac/webapp/templates/issue/toc.html:149
 msgid "Documento sem título"
 msgstr "Documento sin título"
 
+#: build/lib/opac/webapp/templates/article/includes/recent_articles_row.html:13
+#: build/lib/opac/webapp/templates/news/includes/journal_news_row.html:14
 #: opac/webapp/templates/article/includes/recent_articles_row.html:13
-#: opac/webapp/templates/news/includes/journal_news_row.html:9
+#: opac/webapp/templates/news/includes/journal_news_row.html:14
 msgid "Continue lendo"
 msgstr "Continúe leyendo"
 
+#: build/lib/opac/webapp/templates/article/includes/modal/download.html:6
+#: build/lib/opac/webapp/templates/article/includes/modal/related_article.html:7
+#: build/lib/opac/webapp/templates/email/email_form.html:7
+#: build/lib/opac/webapp/templates/includes/metric_modal.html:6
 #: opac/webapp/templates/article/includes/modal/download.html:6
 #: opac/webapp/templates/article/includes/modal/related_article.html:7
 #: opac/webapp/templates/email/email_form.html:7
@@ -1397,317 +1719,416 @@ msgstr "Continúe leyendo"
 msgid "Fechar"
 msgstr "Cerrar"
 
+#: build/lib/opac/webapp/templates/article/includes/modal/download.html:8
 #: opac/webapp/templates/article/includes/modal/download.html:8
 msgid "Versão para download de PDF"
 msgstr "Versión para descarga de PDF"
 
+#: build/lib/opac/webapp/templates/article/includes/modal/translate_version.html:6
 #: opac/webapp/templates/article/includes/modal/translate_version.html:6
 msgid "Versões e tradução automática"
 msgstr "Versiones y traducción automática"
 
+#: build/lib/opac/webapp/templates/article/includes/modal/translate_version.html:11
 #: opac/webapp/templates/article/includes/modal/translate_version.html:11
 msgid "Versão original do texto"
 msgstr "Versión original del texto"
 
+#: build/lib/opac/webapp/templates/collection/about.html:23
+#: build/lib/opac/webapp/templates/collection/pages.html:21
 #: opac/webapp/templates/collection/about.html:23
+#: opac/webapp/templates/collection/pages.html:21
 #, python-format
 msgid " %(page)s "
 msgstr " %(page)s"
 
+#: build/lib/opac/webapp/templates/collection/about.html:38
+#: build/lib/opac/webapp/templates/collection/pages.html:36
 #: opac/webapp/templates/collection/about.html:38
+#: opac/webapp/templates/collection/pages.html:36
 msgid " Conteúdo não cadastrado "
 msgstr "Contenido no registrado"
 
+#: build/lib/opac/webapp/templates/collection/index.html:17
 #: opac/webapp/templates/collection/index.html:17
 msgid "em números | Métricas"
 msgstr "en números | Métricas"
 
+#: build/lib/opac/webapp/templates/collection/index.html:27
 #: opac/webapp/templates/collection/index.html:27
 msgid "períodicos"
 msgstr "revistas"
 
+#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:31
+#: build/lib/opac/webapp/templates/collection/index.html:31
+#: build/lib/opac/webapp/templates/collection/list_feed_content.html:7
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:31
 #: opac/webapp/templates/collection/index.html:31
 #: opac/webapp/templates/collection/list_feed_content.html:7
 msgid "números"
 msgstr "números"
 
+#: build/lib/opac/webapp/templates/collection/index.html:35
+#: build/lib/opac/webapp/templates/issue/grid.html:68
 #: opac/webapp/templates/collection/index.html:35
 #: opac/webapp/templates/issue/grid.html:68
 msgid "artigos"
 msgstr "artículos"
 
+#: build/lib/opac/webapp/templates/collection/index.html:39
 #: opac/webapp/templates/collection/index.html:39
 msgid "referências"
 msgstr "referencias"
 
+#: build/lib/opac/webapp/templates/collection/index.html:45
 #: opac/webapp/templates/collection/index.html:45
 msgid "Downloads"
 msgstr "Descargas"
 
+#: build/lib/opac/webapp/templates/collection/index.html:48
 #: opac/webapp/templates/collection/index.html:48
 msgid "Citações"
 msgstr "Citaciones"
 
+#: build/lib/opac/webapp/templates/collection/index.html:51
 #: opac/webapp/templates/collection/index.html:51
 msgid "Outros indicadores"
 msgstr "Otros indicadores"
 
+#: build/lib/opac/webapp/templates/collection/index.html:62
+#: build/lib/opac/webapp/templates/collection/list_journal.html:3
 #: opac/webapp/templates/collection/index.html:62
 #: opac/webapp/templates/collection/list_journal.html:3
 msgid "Lista de periódicos"
 msgstr "Listado de revistas"
 
+#: build/lib/opac/webapp/templates/collection/index.html:66
+#: build/lib/opac/webapp/templates/collection/list_journal.html:21
 #: opac/webapp/templates/collection/index.html:66
 #: opac/webapp/templates/collection/list_journal.html:21
 msgid "Alfabética"
 msgstr "Alfabética"
 
+#: build/lib/opac/webapp/templates/collection/index.html:69
+#: build/lib/opac/webapp/templates/collection/list_journal.html:24
 #: opac/webapp/templates/collection/index.html:69
 #: opac/webapp/templates/collection/list_journal.html:24
 msgid "Temática"
 msgstr "Temática"
 
+#: build/lib/opac/webapp/templates/collection/index.html:77
 #: opac/webapp/templates/collection/index.html:77
 msgid "Busca por periódicos"
 msgstr "Búsqueda por periódicos"
 
+#: build/lib/opac/webapp/templates/collection/index.html:105
 #: opac/webapp/templates/collection/index.html:105
 msgid "Números <span>mais recentes</span>"
 msgstr "Números <span>más recientes</span>"
 
+#: build/lib/opac/webapp/templates/collection/index.html:149
 #: opac/webapp/templates/collection/index.html:149
 msgid "em perspectiva"
 msgstr "en perspectiva"
 
+#: build/lib/opac/webapp/templates/collection/list_feed_content.html:1
 #: opac/webapp/templates/collection/list_feed_content.html:1
 msgid "Último número"
 msgstr "último número"
 
+#: build/lib/opac/webapp/templates/collection/list_feed_content.html:4
 #: opac/webapp/templates/collection/list_feed_content.html:4
 msgid "Nº"
 msgstr "Nº"
 
+#: build/lib/opac/webapp/templates/collection/list_feed_content.html:6
 #: opac/webapp/templates/collection/list_feed_content.html:6
 msgid "descontinuado"
 msgstr "discontinuado"
 
+#: build/lib/opac/webapp/templates/collection/list_feed_content.html:7
 #: opac/webapp/templates/collection/list_feed_content.html:7
 msgid "de"
 msgstr "de"
 
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu.html:11
+#: build/lib/opac/webapp/templates/collection/list_journal.html:16
 #: opac/webapp/templates/collection/includes/levelMenu.html:11
 #: opac/webapp/templates/collection/list_journal.html:16
 msgid "Home"
 msgstr "Inicio"
 
+#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_grouper_table_container.html:14
+#: build/lib/opac/webapp/templates/collection/list_journal.html:52
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_grouper_table_container.html:14
 #: opac/webapp/templates/collection/list_journal.html:52
 msgid "download da lista"
 msgstr "descarga de la lista"
 
+#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_grouper_table_container.html:15
+#: build/lib/opac/webapp/templates/collection/list_journal.html:53
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_grouper_table_container.html:15
 #: opac/webapp/templates/collection/list_journal.html:53
 msgid "Lista em arquivo para Excel"
 msgstr "Lista en archivo para Excel"
 
+#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_grouper_table_container.html:18
+#: build/lib/opac/webapp/templates/collection/list_journal.html:56
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_grouper_table_container.html:18
 #: opac/webapp/templates/collection/list_journal.html:56
 msgid "Lista em arquivo CSV"
 msgstr "Lista en archivo CSV"
 
+#: build/lib/opac/webapp/templates/collection/list_journal.html:80
+#: build/lib/opac/webapp/templates/collection/list_journal.html:84
 #: opac/webapp/templates/collection/list_journal.html:80
 #: opac/webapp/templates/collection/list_journal.html:84
 msgid "Grandes áreas do conhecimento"
 msgstr "Grandes áreas del conocimiento"
 
+#: build/lib/opac/webapp/templates/collection/list_journal.html:85
 #: opac/webapp/templates/collection/list_journal.html:85
 msgid "Áreas temáticas do Web of Science"
 msgstr "Áreas temáticas de Web of Science"
 
+#: build/lib/opac/webapp/templates/collection/list_journal.html:222
 #: opac/webapp/templates/collection/list_journal.html:222
 msgid "grandes áreas"
 msgstr "grandes áreas"
 
+#: build/lib/opac/webapp/templates/collection/list_journal.html:236
 #: opac/webapp/templates/collection/list_journal.html:236
 msgid "áreas WOS"
 msgstr "áreas WOS"
 
+#: build/lib/opac/webapp/templates/collection/list_journal.html:248
 #: opac/webapp/templates/collection/list_journal.html:248
 msgid "Editoras"
 msgstr "Editoriales"
 
+#: build/lib/opac/webapp/templates/collection/list_journal.html:249
 #: opac/webapp/templates/collection/list_journal.html:249
 msgid "editoras"
 msgstr "editoriales"
 
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:7
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:7
 msgid "Sobre o"
 msgstr "Sobre el"
 
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:19
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:62
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:19
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:62
 msgid "Entre uma ou mais palavras"
 msgstr "Ingrese una o más palabras"
 
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:24
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:67
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:24
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:67
 msgid "Todos os índices"
 msgstr "Todos los índices"
 
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:26
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:69
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:26
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:69
 msgid "Autor"
 msgstr "Autor"
 
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:38
+#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:95
+#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:91
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:38
 #: opac/webapp/templates/issue/includes/alternative_header.html:95
 #: opac/webapp/templates/journal/includes/alternative_header.html:91
 msgid "Buscar"
 msgstr "Buscar"
 
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:44
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:44
 msgid "Adicionar outro campo"
 msgstr "Agregar otro campo"
 
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:49
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:49
 msgid "Apagar campo"
 msgstr "Remover campo"
 
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:63
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:63
 msgid "Limpar expressão"
 msgstr "Borrar expresión"
 
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:92
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:92
 msgid "Sem resultados"
 msgstr "Sin resultados"
 
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:96
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:96
 msgid "Não foram encontrados documentos para sua pesquisa"
 msgstr "No fueron encontrados documentos para su búsqueda"
 
+#: build/lib/opac/webapp/templates/collection/includes/list_journals_search_input.html:5
 #: opac/webapp/templates/collection/includes/list_journals_search_input.html:5
 msgid "Todos"
 msgstr "Todos"
 
+#: build/lib/opac/webapp/templates/collection/includes/list_journals_search_input.html:9
 #: opac/webapp/templates/collection/includes/list_journals_search_input.html:9
 msgid "Periódicos ativos"
 msgstr "Revistas activas"
 
+#: build/lib/opac/webapp/templates/collection/includes/list_journals_search_input.html:13
 #: opac/webapp/templates/collection/includes/list_journals_search_input.html:13
 msgid "Periódicos descontinuados"
 msgstr "Revistas discontinuadas"
 
+#: build/lib/opac/webapp/templates/collection/includes/list_journals_search_input.html:24
 #: opac/webapp/templates/collection/includes/list_journals_search_input.html:24
 msgid "Digite uma ou mais palavras para filtrar a lista"
 msgstr "Ingrese una o más palabras para filtrar en la lista"
 
+#: build/lib/opac/webapp/templates/collection/includes/nav.html:22
+#: build/lib/opac/webapp/templates/collection/includes/nav.html:64
 #: opac/webapp/templates/collection/includes/nav.html:22
 #: opac/webapp/templates/collection/includes/nav.html:64
 msgid "Busca"
 msgstr "Buscar"
 
+#: build/lib/opac/webapp/templates/collection/includes/nav.html:32
 #: opac/webapp/templates/collection/includes/nav.html:32
 msgid "Sobre:"
 msgstr "Acerca de:"
 
+#: build/lib/opac/webapp/templates/collection/includes/nav.html:44
 #: opac/webapp/templates/collection/includes/nav.html:44
 msgid "SciELO.org - Rede SciELO"
 msgstr "SciELO.org - Rede SciELO"
 
+#: build/lib/opac/webapp/templates/collection/includes/nav.html:95
 #: opac/webapp/templates/collection/includes/nav.html:95
 msgid "Blog SciELO em Perspectiva"
 msgstr "Blog SciELO en Perspectiva"
 
+#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_empty.html:3
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_empty.html:3
 msgid "Nenhum periódico encontrado."
 msgstr "Ninguna revista encontrada."
 
+#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_error.html:3
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_error.html:3
 msgid "Ocorreu um erro obtendo a lista de periódicos."
 msgstr "Ocurrió un error obteniendo la lista de revistas."
 
+#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_grouper_table_container.html:10
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_grouper_table_container.html:10
 msgid "periódicos"
 msgstr "revistas"
 
+#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:3
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:3
 msgid "Homepage"
 msgstr "Página de inicio"
 
+#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:25
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:25
 msgid "Título do periódico"
 msgstr "Título de la revista"
 
+#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:29
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:29
 msgid "Grade de número"
 msgstr "Grilla de fascículo"
 
+#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:36
+#: build/lib/opac/webapp/templates/journal/detail.html:89
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:36
 #: opac/webapp/templates/journal/detail.html:89
 msgid "Número mais recente"
 msgstr "Número más reciente"
 
+#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:37
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:37
 msgid "Último"
 msgstr "Último"
 
+#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:45
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:45
 msgid "Continua como "
 msgstr "Sigue como "
 
+#: build/lib/opac/webapp/templates/email/email_form.html:10
 #: opac/webapp/templates/email/email_form.html:10
 msgid "Enviar página por e-mail"
 msgstr "Enviar pagina por e-mail"
 
+#: build/lib/opac/webapp/templates/email/email_form.html:18
+#: build/lib/opac/webapp/templates/includes/error_form.html:26
+#: build/lib/opac/webapp/templates/journal/includes/contact_form.html:20
 #: opac/webapp/templates/email/email_form.html:18
 #: opac/webapp/templates/includes/error_form.html:26
 #: opac/webapp/templates/journal/includes/contact_form.html:20
 msgid "Seu e-mail"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/email/email_form.html:23
 #: opac/webapp/templates/email/email_form.html:23
 msgid "Para"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/email/email_form.html:27
 #: opac/webapp/templates/email/email_form.html:27
 msgid "Utilize ; (ponto e vírgula) para inserir mais emails."
 msgstr ""
 
+#: build/lib/opac/webapp/templates/email/email_form.html:36
 #: opac/webapp/templates/email/email_form.html:36
 msgid "Alterar assunto e comentários"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/email/email_form.html:41
 #: opac/webapp/templates/email/email_form.html:41
 msgid "Assunto"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/email/email_form.html:45
 #: opac/webapp/templates/email/email_form.html:45
 msgid "Comentário"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/email/email_form.html:49
 #: opac/webapp/templates/email/email_form.html:49
 msgid "Remover remetente, assunto e comentários"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/email/email_form.html:75
 #: opac/webapp/templates/email/email_form.html:75
 msgid "Email enviado com sucesso."
 msgstr ""
 
+#: build/lib/opac/webapp/templates/email/email_form.html:76
+#: build/lib/opac/webapp/templates/includes/error_form.html:86
+#: build/lib/opac/webapp/templates/journal/includes/contact_form.html:77
 #: opac/webapp/templates/email/email_form.html:76
 #: opac/webapp/templates/includes/error_form.html:86
 #: opac/webapp/templates/journal/includes/contact_form.html:77
 msgid "Erro ao tentar enviar e-mail, por favor tente mais tarde."
 msgstr ""
 
+#: build/lib/opac/webapp/templates/errors/400.html:7
 #: opac/webapp/templates/errors/400.html:7
 msgid "Ação inválida"
 msgstr "Acción no válida"
 
+#: build/lib/opac/webapp/templates/errors/403.html:7
 #: opac/webapp/templates/errors/403.html:7
 msgid "Acesso não autorizado!"
 msgstr "Acceso no autorizado!"
 
+#: build/lib/opac/webapp/templates/errors/404.html:7
 #: opac/webapp/templates/errors/404.html:7
 msgid ""
 "A URL solicitada não foi encontrada no servidor. Se você digitou a URL "
@@ -1716,6 +2137,7 @@ msgstr ""
 "La URL no fue encontrada en el servidor. Si Ud. la escribió manualmente, "
 "por favor, revise e intente nuevamente."
 
+#: build/lib/opac/webapp/templates/errors/500.html:5
 #: opac/webapp/templates/errors/500.html:5
 msgid ""
 "Erro interno do servidor. Tente novamente mais tarde. Nossos engenheiros "
@@ -1724,284 +2146,368 @@ msgstr ""
 "Error interno del servidor. Intente nuevamente luego. Nuestros ingenieros"
 " fueron notificados."
 
+#: build/lib/opac/webapp/templates/errors/500.html:9
 #: opac/webapp/templates/errors/500.html:9
 msgid "Id. do erro"
 msgstr "Id. del error"
 
+#: build/lib/opac/webapp/templates/errors/base.html:24
 #: opac/webapp/templates/errors/base.html:24
 msgid "Erro"
 msgstr "Error"
 
+#: build/lib/opac/webapp/templates/errors/base.html:27
 #: opac/webapp/templates/errors/base.html:27
 msgid "Qualquer dúvida, por favor entre em contato com o administrador"
 msgstr "En caso de duda, por favor contacte el administrador"
 
+#: build/lib/opac/webapp/templates/includes/error_form.html:5
 #: opac/webapp/templates/includes/error_form.html:5
 msgid " Reportar erro "
 msgstr ""
 
+#: build/lib/opac/webapp/templates/includes/error_form.html:20
+#: build/lib/opac/webapp/templates/journal/includes/contact_form.html:14
 #: opac/webapp/templates/includes/error_form.html:20
 #: opac/webapp/templates/journal/includes/contact_form.html:14
 msgid "Seu Nome"
 msgstr "Su nombre"
 
+#: build/lib/opac/webapp/templates/includes/error_form.html:21
 #: opac/webapp/templates/includes/error_form.html:21
 msgid "Digite seu Nome"
 msgstr "Introduzca su nombre"
 
+#: build/lib/opac/webapp/templates/includes/error_form.html:32
 #: opac/webapp/templates/includes/error_form.html:32
 msgid "Erro referente"
 msgstr "Error de referencia"
 
+#: build/lib/opac/webapp/templates/includes/error_form.html:35
 #: opac/webapp/templates/includes/error_form.html:35
 msgid "ao conteúdo"
 msgstr "al contenido"
 
+#: build/lib/opac/webapp/templates/includes/error_form.html:39
 #: opac/webapp/templates/includes/error_form.html:39
 msgid "à aplicação"
 msgstr "a la aplicación"
 
+#: build/lib/opac/webapp/templates/includes/error_form.html:46
 #: opac/webapp/templates/includes/error_form.html:46
 msgid "Descrição do erro"
 msgstr "Descripción del error"
 
+#: build/lib/opac/webapp/templates/includes/error_form.html:47
 #: opac/webapp/templates/includes/error_form.html:47
 msgid "Digite sua mensagem"
 msgstr "Introduzca su mensaje"
 
+#: build/lib/opac/webapp/templates/includes/error_form.html:49
 #: opac/webapp/templates/includes/error_form.html:49
 msgid "Obs.: Link e título da página são enviados automaticamente"
 msgstr "Nota: El enlace y el título de la página se envían automáticamente"
 
+#: build/lib/opac/webapp/templates/includes/error_form.html:85
 #: opac/webapp/templates/includes/error_form.html:85
 msgid "Email de erro enviado com sucesso."
 msgstr "Correo electrónico de error enviado correctamente."
 
+#: build/lib/opac/webapp/templates/includes/footer.html:36
 #: opac/webapp/templates/includes/footer.html:36
 msgid "Open Access"
 msgstr "Acceso Abierto"
 
+#: build/lib/opac/webapp/templates/includes/footer.html:38
 #: opac/webapp/templates/includes/footer.html:38
 msgid "Leia"
 msgstr "Lea"
 
+#: build/lib/opac/webapp/templates/includes/footer.html:38
 #: opac/webapp/templates/includes/footer.html:38
 msgid "a Declaração de Acesso Aberto"
 msgstr "la Declaración de Acceso abierto"
 
+#: build/lib/opac/webapp/templates/issue/grid.html:4
 #: opac/webapp/templates/issue/grid.html:4
 msgid "Fascículos"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/issue/grid.html:33
 #: opac/webapp/templates/issue/grid.html:33
 msgid "Todos os números"
 msgstr "Todos los números"
 
+#: build/lib/opac/webapp/templates/issue/grid.html:79
 #: opac/webapp/templates/issue/grid.html:79
 msgid "supl."
 msgstr ""
 
+#: build/lib/opac/webapp/templates/issue/grid.html:98
 #: opac/webapp/templates/issue/grid.html:98
 msgid "Nenhum número encontrado para esse periódico"
 msgstr "Ningún fascículo fue encontrado para esta revista"
 
+#: build/lib/opac/webapp/templates/issue/grid.html:101
 #: opac/webapp/templates/issue/grid.html:101
 msgid "Histórico deste periódico na coleção"
 msgstr "Historial de esta revista en la colección"
 
+#: build/lib/opac/webapp/templates/issue/grid.html:105
 #: opac/webapp/templates/issue/grid.html:105
 msgid " admitido na coleção da SciELO"
 msgstr "admitido en la colección de SciELO"
 
+#: build/lib/opac/webapp/templates/issue/toc.html:10
+#: build/lib/opac/webapp/templates/journal/detail.html:8
 #: opac/webapp/templates/issue/toc.html:10
 #: opac/webapp/templates/journal/detail.html:8
 msgid "Imprimir"
 msgstr "Imprimir"
 
+#: build/lib/opac/webapp/templates/issue/toc.html:41
 #: opac/webapp/templates/issue/toc.html:41
 msgid "Editor científico"
 msgstr "Editor científico"
 
+#: build/lib/opac/webapp/templates/issue/toc.html:45
 #: opac/webapp/templates/issue/toc.html:45
 msgid "Editores associados"
 msgstr "Editores asociados"
 
+#: build/lib/opac/webapp/templates/issue/toc.html:52
 #: opac/webapp/templates/issue/toc.html:52
 msgid "Veja toda a equipe editorial"
 msgstr "Vea todo el equipo editorial"
 
+#: build/lib/opac/webapp/templates/issue/toc.html:63
 #: opac/webapp/templates/issue/toc.html:63
 msgid "Expandir/recolher conteúdo"
 msgstr "Expandir/reducir contenido"
 
+#: build/lib/opac/webapp/templates/issue/toc.html:72
+#: build/lib/opac/webapp/templates/journal/detail.html:96
 #: opac/webapp/templates/issue/toc.html:72
 #: opac/webapp/templates/journal/detail.html:96
 msgid "Sumário"
 msgstr "Sumario"
 
+#: build/lib/opac/webapp/templates/issue/toc.html:79
 #: opac/webapp/templates/issue/toc.html:79
 msgid "Ordenar publicações por"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/issue/toc.html:82
 #: opac/webapp/templates/issue/toc.html:82
 msgid "Ordem do fascículo"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/issue/toc.html:83
 #: opac/webapp/templates/issue/toc.html:83
 msgid "Mais novos primeiro"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/issue/toc.html:84
 #: opac/webapp/templates/issue/toc.html:84
 msgid "Mais antigos primeiro"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/issue/toc.html:102
+#: build/lib/opac/webapp/templates/issue/toc.html:104
 #: opac/webapp/templates/issue/toc.html:102
 #: opac/webapp/templates/issue/toc.html:104
 msgid "Todas as seções"
 msgstr "Todas las secciones"
 
+#: build/lib/opac/webapp/templates/issue/toc.html:187
 #: opac/webapp/templates/issue/toc.html:187
 msgid "Texto"
 msgstr "Texto"
 
+#: build/lib/opac/webapp/templates/issue/toc.html:214
 #: opac/webapp/templates/issue/toc.html:214
 msgid "Resumo em"
 msgstr "Resumen en"
 
+#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:31
+#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:31
 #: opac/webapp/templates/issue/includes/alternative_header.html:31
 #: opac/webapp/templates/journal/includes/alternative_header.html:31
 msgid "Número atual"
 msgstr "Número actual"
 
+#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:51
+#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:47
 #: opac/webapp/templates/issue/includes/alternative_header.html:51
 #: opac/webapp/templates/journal/includes/alternative_header.html:47
 msgid "Homepage do periódico"
 msgstr "Inicio de la revista"
 
+#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:62
+#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:58
 #: opac/webapp/templates/issue/includes/alternative_header.html:62
 #: opac/webapp/templates/journal/includes/alternative_header.html:58
 msgid "Números"
 msgstr "Números"
 
+#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:68
+#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:64
+#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:90
 #: opac/webapp/templates/issue/includes/alternative_header.html:68
 #: opac/webapp/templates/journal/includes/alternative_header.html:64
 #: opac/webapp/templates/journal/includes/levelMenu.html:90
 msgid "todos"
 msgstr "todos"
 
+#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:89
+#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:85
 #: opac/webapp/templates/issue/includes/alternative_header.html:89
 #: opac/webapp/templates/journal/includes/alternative_header.html:85
 msgid "próximo"
 msgstr "próximo"
 
+#: build/lib/opac/webapp/templates/journal/about.html:39
 #: opac/webapp/templates/journal/about.html:39
 msgid "Conteúdo não cadastrado"
 msgstr "Contenido no registrado"
 
+#: build/lib/opac/webapp/templates/journal/about.html:55
+#: build/lib/opac/webapp/templates/journal/includes/contact_footer.html:48
 #: opac/webapp/templates/journal/about.html:55
 #: opac/webapp/templates/journal/includes/contact_footer.html:48
 msgid "Siga este periódico nas redes sociais"
 msgstr "Siga a esta revista en las redes sociales"
 
+#: build/lib/opac/webapp/templates/journal/detail.html:32
 #: opac/webapp/templates/journal/detail.html:32
 msgid "Nossa Missão"
 msgstr "Nuestra misión"
 
+#: build/lib/opac/webapp/templates/journal/detail.html:34
 #: opac/webapp/templates/journal/detail.html:34
 msgid "Periódico sem missão cadastrada"
 msgstr "Revista sin misión registrada"
 
+#: build/lib/opac/webapp/templates/journal/detail.html:42
 #: opac/webapp/templates/journal/detail.html:42
 msgid "Métricas deste periódico"
 msgstr "Métricas de esta revista"
 
+#: build/lib/opac/webapp/templates/journal/detail.html:52
 #: opac/webapp/templates/journal/detail.html:52
 msgid "Índice h5"
 msgstr "Índice h5"
 
+#: build/lib/opac/webapp/templates/journal/detail.html:54
+#: build/lib/opac/webapp/templates/journal/detail.html:66
 #: opac/webapp/templates/journal/detail.html:54
 #: opac/webapp/templates/journal/detail.html:66
 msgid "ano"
 msgstr "año"
 
+#: build/lib/opac/webapp/templates/journal/detail.html:58
+#: build/lib/opac/webapp/templates/journal/detail.html:70
 #: opac/webapp/templates/journal/detail.html:58
 #: opac/webapp/templates/journal/detail.html:70
 msgid "Não possui"
 msgstr "No contiene"
 
+#: build/lib/opac/webapp/templates/journal/detail.html:63
 #: opac/webapp/templates/journal/detail.html:63
 msgid "Mediana h5"
 msgstr "Mediana h5"
 
+#: build/lib/opac/webapp/templates/journal/detail.html:86
 #: opac/webapp/templates/journal/detail.html:86
 msgid "Capa do número mais recente"
 msgstr "Tapa del número más reciente"
 
+#: build/lib/opac/webapp/templates/journal/detail.html:138
 #: opac/webapp/templates/journal/detail.html:138
 msgid "Artigos mais recentes"
 msgstr "Artículos más recientes"
 
+#: build/lib/opac/webapp/templates/journal/includes/contact_footer.html:57
 #: opac/webapp/templates/journal/includes/contact_footer.html:57
 msgid "Acompanhe os números deste periódico no seu leitor de RSS"
 msgstr "Acompañe los números de esta revista en su lector de RSS"
 
+#: build/lib/opac/webapp/templates/journal/includes/contact_form.html:26
 #: opac/webapp/templates/journal/includes/contact_form.html:26
 msgid "Mensagem"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/journal/includes/contact_form.html:76
 #: opac/webapp/templates/journal/includes/contact_form.html:76
 msgid "Email enviado para "
 msgstr ""
 
+#: build/lib/opac/webapp/templates/journal/includes/contact_form.html:76
 #: opac/webapp/templates/journal/includes/contact_form.html:76
 msgid "com sucesso."
 msgstr ""
 
+#: build/lib/opac/webapp/templates/journal/includes/header.html:42
 #: opac/webapp/templates/journal/includes/header.html:42
 msgid "Publicação de:"
 msgstr "Publicación de:"
 
+#: build/lib/opac/webapp/templates/journal/includes/header.html:47
 #: opac/webapp/templates/journal/includes/header.html:47
 msgid "Área:"
 msgstr "Área:"
 
+#: build/lib/opac/webapp/templates/journal/includes/header.html:51
 #: opac/webapp/templates/journal/includes/header.html:51
-msgid "Multidiciplinar"
+msgid "Multidisciplinar"
 msgstr "Multidisciplinaria"
 
+#: build/lib/opac/webapp/templates/journal/includes/header.html:60
 #: opac/webapp/templates/journal/includes/header.html:60
 msgid "Versão impressa ISSN:"
 msgstr "Versión impresa ISSN:"
 
+#: build/lib/opac/webapp/templates/journal/includes/header.html:67
 #: opac/webapp/templates/journal/includes/header.html:67
 msgid "Versão on-line ISSN:"
 msgstr "Versión on-line ISSN:"
 
+#: build/lib/opac/webapp/templates/journal/includes/header.html:76
 #: opac/webapp/templates/journal/includes/header.html:76
 msgid "Novo título:"
 msgstr "Nuevo titulo:"
 
+#: build/lib/opac/webapp/templates/journal/includes/header.html:93
 #: opac/webapp/templates/journal/includes/header.html:93
 msgid "Título anterior:"
 msgstr "Titulo anterior"
 
+#: build/lib/opac/webapp/templates/journal/includes/header.html:148
 #: opac/webapp/templates/journal/includes/header.html:148
 msgid "Siga-nos"
 msgstr "Síganos"
 
+#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:10
 #: opac/webapp/templates/journal/includes/levelMenu.html:10
 msgid "home do periódico"
 msgstr "página de la revista"
 
+#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:19
 #: opac/webapp/templates/journal/includes/levelMenu.html:19
 msgid "todos os números"
 msgstr "todos los números"
 
+#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:25
+#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:29
 #: opac/webapp/templates/journal/includes/levelMenu.html:25
 #: opac/webapp/templates/journal/includes/levelMenu.html:29
 msgid "número anterior"
 msgstr "número anterior"
 
+#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:36
+#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:40
+#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:107
+#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:111
 #: opac/webapp/templates/journal/includes/levelMenu.html:36
 #: opac/webapp/templates/journal/includes/levelMenu.html:40
 #: opac/webapp/templates/journal/includes/levelMenu.html:107
@@ -2009,16 +2515,24 @@ msgstr "número anterior"
 msgid "número atual"
 msgstr "número actual"
 
+#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:47
+#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:51
 #: opac/webapp/templates/journal/includes/levelMenu.html:47
 #: opac/webapp/templates/journal/includes/levelMenu.html:51
 msgid "número seguinte"
 msgstr "número siguiente"
 
+#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:59
+#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:130
 #: opac/webapp/templates/journal/includes/levelMenu.html:59
 #: opac/webapp/templates/journal/includes/levelMenu.html:130
 msgid "buscar"
 msgstr "buscar"
 
+#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:65
+#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:69
+#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:136
+#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:140
 #: opac/webapp/templates/journal/includes/levelMenu.html:65
 #: opac/webapp/templates/journal/includes/levelMenu.html:69
 #: opac/webapp/templates/journal/includes/levelMenu.html:136
@@ -2026,22 +2540,27 @@ msgstr "buscar"
 msgid "métricas"
 msgstr "métricas"
 
+#: build/lib/opac/webapp/templates/macros/issue.html:5
 #: opac/webapp/templates/macros/issue.html:5
 msgid " número especial "
 msgstr ""
 
+#: build/lib/opac/webapp/templates/macros/issue.html:10
 #: opac/webapp/templates/macros/issue.html:10
 msgid "número especial"
 msgstr ""
 
-#: opac/webapp/templates/news/includes/collection_news_row.html:11
+#: build/lib/opac/webapp/templates/news/includes/collection_news_row.html:16
+#: opac/webapp/templates/news/includes/collection_news_row.html:16
 msgid "continue lendo"
 msgstr "seguir leyendo"
 
+#: build/lib/opac/webapp/templates/news/includes/issue_last_row.html:15
 #: opac/webapp/templates/news/includes/issue_last_row.html:15
 msgid "Suplemento"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/news/includes/issue_last_row.html:20
 #: opac/webapp/templates/news/includes/issue_last_row.html:20
 msgid "Ver"
 msgstr "Ver"
@@ -2098,4 +2617,10 @@ msgstr "Ver"
 
 #~ msgid "LINGUISTICS, LITERATURE AND ARTS"
 #~ msgstr ""
+
+#~ msgid "HTML do Artigo não encontrado"
+#~ msgstr "HTML del artículo no encontrado"
+
+#~ msgid "Recurso não encontrado"
+#~ msgstr "Recurso no encontrado"
 

--- a/opac/webapp/translations/es_ES/LC_MESSAGES/messages.po
+++ b/opac/webapp/translations/es_ES/LC_MESSAGES/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-03-15 11:46+0000\n"
+"POT-Creation-Date: 2019-05-09 17:02-0300\n"
 "PO-Revision-Date: 2016-02-09 09:39-0600\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es_ES\n"
@@ -19,6 +19,23 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.6.0\n"
 
+#: build/lib/opac/tests/test_admin_custom_filters.py:100
+#: build/lib/opac/tests/test_admin_custom_filters.py:114
+#: build/lib/opac/tests/test_admin_custom_filters.py:129
+#: build/lib/opac/tests/test_admin_custom_filters.py:144
+#: build/lib/opac/tests/test_admin_custom_filters.py:158
+#: build/lib/opac/webapp/__init__.py:119
+#: build/lib/opac/webapp/admin/views.py:533
+#: build/lib/opac/webapp/admin/views.py:610
+#: build/lib/opac/webapp/admin/views.py:680
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:28
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:71
+#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_grouper_table_row.html:15
+#: build/lib/opac/webapp/templates/collection/list_journal.html:49
+#: build/lib/opac/webapp/templates/collection/list_journal.html:221
+#: build/lib/opac/webapp/templates/collection/list_journal.html:235
+#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:116
+#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:112
 #: opac/tests/test_admin_custom_filters.py:100
 #: opac/tests/test_admin_custom_filters.py:114
 #: opac/tests/test_admin_custom_filters.py:129
@@ -37,21 +54,38 @@ msgstr ""
 msgid "Periódico"
 msgstr ""
 
+#: build/lib/opac/tests/test_interface_menu.py:51
 #: opac/tests/test_interface_menu.py:51
 msgid "NOME DA COLEÇÃO!!"
 msgstr ""
 
-#: opac/tests/test_interface_menu.py:53 opac/tests/test_interface_menu.py:72
+#: build/lib/opac/tests/test_interface_menu.py:53
+#: build/lib/opac/tests/test_interface_menu.py:75
+#: build/lib/opac/webapp/templates/collection/includes/nav.html:12
+#: build/lib/opac/webapp/templates/collection/includes/nav.html:54
+#: opac/tests/test_interface_menu.py:53 opac/tests/test_interface_menu.py:75
 #: opac/webapp/templates/collection/includes/nav.html:12
 #: opac/webapp/templates/collection/includes/nav.html:54
 msgid "Lista alfabética de periódicos"
 msgstr ""
 
+#: build/lib/opac/tests/test_interface_menu.py:55
+#: build/lib/opac/webapp/templates/collection/includes/nav.html:17
 #: opac/tests/test_interface_menu.py:55
 #: opac/webapp/templates/collection/includes/nav.html:17
 msgid "Lista temática de periódicos"
 msgstr ""
 
+#: build/lib/opac/tests/test_interface_menu.py:61
+#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:11
+#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:70
+#: build/lib/opac/webapp/templates/collection/includes/nav.html:27
+#: build/lib/opac/webapp/templates/collection/includes/nav.html:69
+#: build/lib/opac/webapp/templates/includes/metric_modal.html:7
+#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:101
+#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:105
+#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:97
+#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:101
 #: opac/tests/test_interface_menu.py:61
 #: opac/webapp/templates/article/includes/floating_menu.html:11
 #: opac/webapp/templates/article/includes/floating_menu.html:70
@@ -65,332 +99,383 @@ msgstr ""
 msgid "Métricas"
 msgstr ""
 
+#: build/lib/opac/tests/test_interface_menu.py:63
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu.html:12
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu.html:29
 #: opac/tests/test_interface_menu.py:63
 #: opac/webapp/templates/collection/includes/levelMenu.html:12
 #: opac/webapp/templates/collection/includes/levelMenu.html:29
 msgid "Sobre o SciELO"
 msgstr ""
 
-#: opac/tests/test_interface_menu.py:65 opac/tests/test_interface_menu.py:84
+#: build/lib/opac/tests/test_interface_menu.py:65
+#: build/lib/opac/tests/test_interface_menu.py:99
+#: build/lib/opac/webapp/templates/collection/includes/nav.html:37
+#: build/lib/opac/webapp/templates/collection/includes/nav.html:84
+#: opac/tests/test_interface_menu.py:65 opac/tests/test_interface_menu.py:99
 #: opac/webapp/templates/collection/includes/nav.html:37
 #: opac/webapp/templates/collection/includes/nav.html:84
 msgid "Contatos"
 msgstr ""
 
+#: build/lib/opac/tests/test_interface_menu.py:67
 #: opac/tests/test_interface_menu.py:67
 msgid "Rede SciELO"
 msgstr ""
 
-#: opac/tests/test_interface_menu.py:70
+#: build/lib/opac/tests/test_interface_menu.py:71
+#: build/lib/opac/webapp/templates/collection/includes/nav.html:49
+#: opac/tests/test_interface_menu.py:71
 #: opac/webapp/templates/collection/includes/nav.html:49
 msgid "Coleções nacionais e temáticas"
 msgstr ""
 
-#: opac/tests/test_interface_menu.py:74
+#: build/lib/opac/tests/test_interface_menu.py:79
+#: build/lib/opac/webapp/templates/collection/includes/nav.html:59
+#: opac/tests/test_interface_menu.py:79
 #: opac/webapp/templates/collection/includes/nav.html:59
 msgid "Lista de periódicos por assunto"
 msgstr ""
 
-#: opac/tests/test_interface_menu.py:80
+#: build/lib/opac/tests/test_interface_menu.py:91
+#: build/lib/opac/webapp/templates/collection/includes/nav.html:74
+#: opac/tests/test_interface_menu.py:91
 #: opac/webapp/templates/collection/includes/nav.html:74
 msgid "Acesso OAI e RSS"
 msgstr ""
 
-#: opac/tests/test_interface_menu.py:82
+#: build/lib/opac/tests/test_interface_menu.py:95
+#: build/lib/opac/webapp/templates/collection/includes/nav.html:79
+#: opac/tests/test_interface_menu.py:95
 #: opac/webapp/templates/collection/includes/nav.html:79
 msgid "Sobre a Rede SciELO"
 msgstr ""
 
-#: opac/tests/test_main_errors.py:8
+#: build/lib/opac/tests/test_main_errors.py:8 opac/tests/test_main_errors.py:8
 msgid "Mensagem de erro explicativo para o usuário"
 msgstr ""
 
+#: build/lib/opac/webapp/__init__.py:118 build/lib/opac/webapp/__init__.py:119
+#: build/lib/opac/webapp/__init__.py:120 build/lib/opac/webapp/__init__.py:121
+#: build/lib/opac/webapp/__init__.py:122 build/lib/opac/webapp/__init__.py:123
 #: opac/webapp/__init__.py:118 opac/webapp/__init__.py:119
 #: opac/webapp/__init__.py:120 opac/webapp/__init__.py:121
 #: opac/webapp/__init__.py:122 opac/webapp/__init__.py:123
 msgid "Catálogo"
 msgstr ""
 
-#: opac/webapp/__init__.py:118 opac/webapp/admin/views.py:452
+#: build/lib/opac/webapp/__init__.py:118
+#: build/lib/opac/webapp/admin/views.py:452 opac/webapp/__init__.py:118
+#: opac/webapp/admin/views.py:452
 msgid "Coleção"
 msgstr ""
 
+#: build/lib/opac/webapp/__init__.py:120
+#: build/lib/opac/webapp/admin/views.py:537
+#: build/lib/opac/webapp/admin/views.py:609
+#: build/lib/opac/webapp/templates/issue/grid.html:41
+#: build/lib/opac/webapp/templates/news/includes/issue_last_row.html:11
 #: opac/webapp/__init__.py:120 opac/webapp/admin/views.py:537
 #: opac/webapp/admin/views.py:609 opac/webapp/templates/issue/grid.html:41
 #: opac/webapp/templates/news/includes/issue_last_row.html:11
 msgid "Número"
 msgstr ""
 
-#: opac/webapp/__init__.py:121
+#: build/lib/opac/webapp/__init__.py:121 opac/webapp/__init__.py:121
 msgid "Artigo"
 msgstr ""
 
+#: build/lib/opac/webapp/__init__.py:122
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:27
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:70
 #: opac/webapp/__init__.py:122
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:27
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:70
 msgid "Financiador"
 msgstr ""
 
-#: opac/webapp/__init__.py:123
+#: build/lib/opac/webapp/__init__.py:123 opac/webapp/__init__.py:123
 msgid "Press Release"
 msgstr ""
 
+#: build/lib/opac/webapp/__init__.py:124
+#: build/lib/opac/webapp/templates/journal/detail.html:160
 #: opac/webapp/__init__.py:124 opac/webapp/templates/journal/detail.html:160
 msgid "Notícias"
 msgstr ""
 
+#: build/lib/opac/webapp/__init__.py:125 build/lib/opac/webapp/__init__.py:126
 #: opac/webapp/__init__.py:125 opac/webapp/__init__.py:126
 msgid "Ativos"
 msgstr ""
 
-#: opac/webapp/__init__.py:127
+#: build/lib/opac/webapp/__init__.py:127 opac/webapp/__init__.py:127
 msgid "Páginas"
 msgstr ""
 
+#: build/lib/opac/webapp/__init__.py:128 build/lib/opac/webapp/__init__.py:129
 #: opac/webapp/__init__.py:128 opac/webapp/__init__.py:129
 msgid "Gestão"
 msgstr ""
 
-#: opac/webapp/__init__.py:128
+#: build/lib/opac/webapp/__init__.py:128 opac/webapp/__init__.py:128
 msgid "Auditoria: Páginas"
 msgstr ""
 
-#: opac/webapp/__init__.py:129 opac/webapp/admin/views.py:896
+#: build/lib/opac/webapp/__init__.py:129
+#: build/lib/opac/webapp/admin/views.py:896 opac/webapp/__init__.py:129
+#: opac/webapp/admin/views.py:896
 msgid "Usuário"
 msgstr ""
 
-#: opac/webapp/choices.py:7
+#: build/lib/opac/webapp/choices.py:7 opac/webapp/choices.py:7
 msgid "Conteúdo temporariamente indisponível"
 msgstr ""
 
+#: build/lib/opac/webapp/choices.py:11 build/lib/opac/webapp/choices.py:23
+#: build/lib/opac/webapp/templates/article/includes/modal/download.html:26
 #: opac/webapp/choices.py:11 opac/webapp/choices.py:23
 #: opac/webapp/templates/article/includes/modal/download.html:26
 msgid "Português"
 msgstr ""
 
+#: build/lib/opac/webapp/choices.py:12 build/lib/opac/webapp/choices.py:24
+#: build/lib/opac/webapp/templates/article/includes/modal/download.html:24
 #: opac/webapp/choices.py:12 opac/webapp/choices.py:24
 #: opac/webapp/templates/article/includes/modal/download.html:24
 msgid "Inglês"
 msgstr ""
 
+#: build/lib/opac/webapp/choices.py:13 build/lib/opac/webapp/choices.py:25
+#: build/lib/opac/webapp/templates/article/includes/modal/download.html:22
 #: opac/webapp/choices.py:13 opac/webapp/choices.py:25
 #: opac/webapp/templates/article/includes/modal/download.html:22
 msgid "Espanhol"
 msgstr ""
 
-#: opac/webapp/choices.py:26
+#: build/lib/opac/webapp/choices.py:26 opac/webapp/choices.py:26
 msgid "Albanês"
 msgstr ""
 
+#: build/lib/opac/webapp/choices.py:27 build/lib/opac/webapp/choices.py:33
 #: opac/webapp/choices.py:27 opac/webapp/choices.py:33
 msgid "Chinês"
 msgstr ""
 
-#: opac/webapp/choices.py:28
+#: build/lib/opac/webapp/choices.py:28 opac/webapp/choices.py:28
 msgid "Romeno"
 msgstr ""
 
-#: opac/webapp/choices.py:29
+#: build/lib/opac/webapp/choices.py:29 opac/webapp/choices.py:29
 msgid "Francês"
 msgstr ""
 
-#: opac/webapp/choices.py:30
+#: build/lib/opac/webapp/choices.py:30 opac/webapp/choices.py:30
 msgid "Italiano"
 msgstr ""
 
-#: opac/webapp/choices.py:31
+#: build/lib/opac/webapp/choices.py:31 opac/webapp/choices.py:31
 msgid "Russo"
 msgstr ""
 
-#: opac/webapp/choices.py:32
+#: build/lib/opac/webapp/choices.py:32 opac/webapp/choices.py:32
 msgid "Árabe"
 msgstr ""
 
-#: opac/webapp/choices.py:37
+#: build/lib/opac/webapp/choices.py:37 opac/webapp/choices.py:37
 msgid "corrente"
 msgstr ""
 
-#: opac/webapp/choices.py:38
+#: build/lib/opac/webapp/choices.py:38 opac/webapp/choices.py:38
 msgid "terminado"
 msgstr ""
 
-#: opac/webapp/choices.py:39
+#: build/lib/opac/webapp/choices.py:39 opac/webapp/choices.py:39
 msgid "indexação interrompida"
 msgstr ""
 
-#: opac/webapp/choices.py:40
+#: build/lib/opac/webapp/choices.py:40 opac/webapp/choices.py:40
 msgid "indexação interrompida pelo Comitê"
 msgstr ""
 
-#: opac/webapp/choices.py:41
+#: build/lib/opac/webapp/choices.py:41 opac/webapp/choices.py:41
 msgid "publicação finalizada"
 msgstr ""
 
-#: opac/webapp/choices.py:45
+#: build/lib/opac/webapp/choices.py:45 opac/webapp/choices.py:45
 msgid "Ciências Agrárias"
 msgstr ""
 
-#: opac/webapp/choices.py:46
+#: build/lib/opac/webapp/choices.py:46 opac/webapp/choices.py:46
 msgid "Ciências Sociais Aplicadas"
 msgstr ""
 
-#: opac/webapp/choices.py:47
+#: build/lib/opac/webapp/choices.py:47 opac/webapp/choices.py:47
 msgid "Ciências Biológicas"
 msgstr ""
 
-#: opac/webapp/choices.py:48
+#: build/lib/opac/webapp/choices.py:48 opac/webapp/choices.py:48
 msgid "Engenharias"
 msgstr ""
 
-#: opac/webapp/choices.py:49
+#: build/lib/opac/webapp/choices.py:49 opac/webapp/choices.py:49
 msgid "Ciências Exatas e da Terra"
 msgstr ""
 
-#: opac/webapp/choices.py:50
+#: build/lib/opac/webapp/choices.py:50 opac/webapp/choices.py:50
 msgid "Ciências da Saúde"
 msgstr ""
 
-#: opac/webapp/choices.py:51
+#: build/lib/opac/webapp/choices.py:51 opac/webapp/choices.py:51
 msgid "Ciências Humanas"
 msgstr ""
 
+#: build/lib/opac/webapp/choices.py:52 build/lib/opac/webapp/choices.py:53
 #: opac/webapp/choices.py:52 opac/webapp/choices.py:53
 msgid "Lingüística, Letras e Artes"
 msgstr ""
 
-#: opac/webapp/controllers.py:353
+#: build/lib/opac/webapp/controllers.py:353 opac/webapp/controllers.py:353
 msgid "Lista Alfabética"
 msgstr ""
 
-#: opac/webapp/controllers.py:357
+#: build/lib/opac/webapp/controllers.py:357 opac/webapp/controllers.py:357
 msgid "Lista Temática"
 msgstr ""
 
-#: opac/webapp/controllers.py:361
+#: build/lib/opac/webapp/controllers.py:361 opac/webapp/controllers.py:361
 msgid "Lista Web of Science"
 msgstr ""
 
-#: opac/webapp/controllers.py:365
+#: build/lib/opac/webapp/controllers.py:365 opac/webapp/controllers.py:365
 msgid "Lista by Institution"
 msgstr ""
 
-#: opac/webapp/controllers.py:424
+#: build/lib/opac/webapp/controllers.py:424 opac/webapp/controllers.py:424
 msgid "Obrigatório um jid."
 msgstr ""
 
-#: opac/webapp/controllers.py:440
+#: build/lib/opac/webapp/controllers.py:440 opac/webapp/controllers.py:440
 msgid "Obrigatório um acronym."
 msgstr ""
 
-#: opac/webapp/controllers.py:456
+#: build/lib/opac/webapp/controllers.py:456 opac/webapp/controllers.py:456
 msgid "Obrigatório um url_seg."
 msgstr ""
 
-#: opac/webapp/controllers.py:472
+#: build/lib/opac/webapp/controllers.py:472 opac/webapp/controllers.py:472
 msgid "Obrigatório um issn."
 msgstr ""
 
-#: opac/webapp/controllers.py:487
+#: build/lib/opac/webapp/controllers.py:487 opac/webapp/controllers.py:487
 msgid "Obrigatório um title."
 msgstr ""
 
-#: opac/webapp/controllers.py:525 opac/webapp/controllers.py:669
-#: opac/webapp/controllers.py:830
+#: build/lib/opac/webapp/controllers.py:525
+#: build/lib/opac/webapp/controllers.py:669
+#: build/lib/opac/webapp/controllers.py:830 opac/webapp/controllers.py:525
+#: opac/webapp/controllers.py:669 opac/webapp/controllers.py:830
 msgid "Obrigatório uma lista de ids."
 msgstr ""
 
-#: opac/webapp/controllers.py:631 opac/webapp/controllers.py:851
+#: build/lib/opac/webapp/controllers.py:631
+#: build/lib/opac/webapp/controllers.py:851 opac/webapp/controllers.py:631
+#: opac/webapp/controllers.py:851
 msgid "Obrigatório um iid."
 msgstr ""
 
-#: opac/webapp/controllers.py:688
+#: build/lib/opac/webapp/controllers.py:688 opac/webapp/controllers.py:688
 msgid "Obrigatório um jacron e issue_label."
 msgstr ""
 
-#: opac/webapp/controllers.py:701
+#: build/lib/opac/webapp/controllers.py:701 opac/webapp/controllers.py:701
 msgid "Obrigatório um PID."
 msgstr ""
 
-#: opac/webapp/controllers.py:717
+#: build/lib/opac/webapp/controllers.py:717 opac/webapp/controllers.py:717
 msgid "Obrigatório um url_seg e url_seg_issue."
 msgstr ""
 
-#: opac/webapp/controllers.py:724
+#: build/lib/opac/webapp/controllers.py:724 opac/webapp/controllers.py:724
 msgid "Obrigatório um assets_code."
 msgstr ""
 
-#: opac/webapp/controllers.py:727
+#: build/lib/opac/webapp/controllers.py:727 opac/webapp/controllers.py:727
 msgid "Obrigatório um journal."
 msgstr ""
 
-#: opac/webapp/controllers.py:743
+#: build/lib/opac/webapp/controllers.py:743 opac/webapp/controllers.py:743
 msgid "Obrigatório um aid."
 msgstr ""
 
-#: opac/webapp/controllers.py:757
+#: build/lib/opac/webapp/controllers.py:757 opac/webapp/controllers.py:757
 msgid "Obrigatório um url_seg_article."
 msgstr ""
 
-#: opac/webapp/controllers.py:772
+#: build/lib/opac/webapp/controllers.py:772 opac/webapp/controllers.py:772
 msgid "Obrigatório um iid and url_seg_article."
 msgstr ""
 
-#: opac/webapp/controllers.py:788
+#: build/lib/opac/webapp/controllers.py:788 opac/webapp/controllers.py:788
 msgid "Obrigatório um jid, url_seg_issue and url_seg_article."
 msgstr ""
 
-#: opac/webapp/controllers.py:889
+#: build/lib/opac/webapp/controllers.py:889 opac/webapp/controllers.py:889
 msgid "Obrigatório um pid."
 msgstr ""
 
-#: opac/webapp/controllers.py:902
+#: build/lib/opac/webapp/controllers.py:902 opac/webapp/controllers.py:902
 msgid "Obrigatório um aop_pid."
 msgstr ""
 
-#: opac/webapp/controllers.py:913
+#: build/lib/opac/webapp/controllers.py:913 opac/webapp/controllers.py:913
 msgid "Parámetro obrigatório: issue_iid."
 msgstr ""
 
-#: opac/webapp/controllers.py:961
+#: build/lib/opac/webapp/controllers.py:961 opac/webapp/controllers.py:961
 msgid "Parâmetro email deve ser uma string"
 msgstr ""
 
-#: opac/webapp/controllers.py:972
+#: build/lib/opac/webapp/controllers.py:972 opac/webapp/controllers.py:972
 msgid "Parâmetro email deve ser uma inteiro"
 msgstr ""
 
-#: opac/webapp/controllers.py:984 opac/webapp/controllers.py:998
+#: build/lib/opac/webapp/controllers.py:984
+#: build/lib/opac/webapp/controllers.py:998 opac/webapp/controllers.py:984
+#: opac/webapp/controllers.py:998
 #, python-format
 msgid "Usuário deve ser do tipo %s"
 msgstr ""
 
-#: opac/webapp/controllers.py:1054
+#: build/lib/opac/webapp/controllers.py:1054 opac/webapp/controllers.py:1054
 msgid "Compartilhamento de link SciELO"
 msgstr ""
 
-#: opac/webapp/controllers.py:1055
+#: build/lib/opac/webapp/controllers.py:1055 opac/webapp/controllers.py:1055
 #, python-format
 msgid "O usuário %s compartilha este link: %s, da SciELO"
 msgstr ""
 
-#: opac/webapp/controllers.py:1063 opac/webapp/controllers.py:1099
-#: opac/webapp/controllers.py:1121
+#: build/lib/opac/webapp/controllers.py:1063
+#: build/lib/opac/webapp/controllers.py:1099
+#: build/lib/opac/webapp/controllers.py:1121 opac/webapp/controllers.py:1063
+#: opac/webapp/controllers.py:1099 opac/webapp/controllers.py:1121
 msgid "Mensagem enviada!"
 msgstr ""
 
-#: opac/webapp/controllers.py:1080
+#: build/lib/opac/webapp/controllers.py:1080 opac/webapp/controllers.py:1080
 msgid "[Erro] Erro informado pelo usuário no site SciELO"
 msgstr ""
 
-#: opac/webapp/controllers.py:1083
+#: build/lib/opac/webapp/controllers.py:1083 opac/webapp/controllers.py:1083
 msgid "aplicação"
 msgstr ""
 
-#: opac/webapp/controllers.py:1085
+#: build/lib/opac/webapp/controllers.py:1085 opac/webapp/controllers.py:1085
 msgid "conteúdo"
 msgstr ""
 
-#: opac/webapp/controllers.py:1090
+#: build/lib/opac/webapp/controllers.py:1090 opac/webapp/controllers.py:1090
 #, python-format
 msgid ""
 "O usuário <b>%s</b> com e-mail: <b>%s</b>, informa que existe um erro na "
@@ -398,384 +483,430 @@ msgid ""
 " %s"
 msgstr ""
 
-#: opac/webapp/controllers.py:1111
+#: build/lib/opac/webapp/controllers.py:1111 opac/webapp/controllers.py:1111
 msgid "Contato de usuário via site SciELO"
 msgstr ""
 
-#: opac/webapp/controllers.py:1113
+#: build/lib/opac/webapp/controllers.py:1113 opac/webapp/controllers.py:1113
 #, python-format
 msgid "O usuário %s, com e-mail: %s, entra em contato com a seguinte mensagem:"
 msgstr ""
 
-#: opac/webapp/controllers.py:1145
+#: build/lib/opac/webapp/controllers.py:1145 opac/webapp/controllers.py:1145
 msgid "Obrigatório um slug_name."
 msgstr ""
 
-#: opac/webapp/forms.py:29
+#: build/lib/opac/webapp/forms.py:29 opac/webapp/forms.py:29
 msgid "Endereço de e-mail inválido."
 msgstr ""
 
-#: opac/webapp/admin/forms.py:9 opac/webapp/admin/forms.py:21
+#: build/lib/opac/webapp/admin/forms.py:9
+#: build/lib/opac/webapp/admin/forms.py:21 opac/webapp/admin/forms.py:9
+#: opac/webapp/admin/forms.py:21
 msgid "Email"
 msgstr ""
 
-#: opac/webapp/admin/forms.py:10 opac/webapp/admin/forms.py:25
+#: build/lib/opac/webapp/admin/forms.py:10
+#: build/lib/opac/webapp/admin/forms.py:25 opac/webapp/admin/forms.py:10
+#: opac/webapp/admin/forms.py:25
 msgid "Senha"
 msgstr ""
 
-#: opac/webapp/admin/forms.py:15
+#: build/lib/opac/webapp/admin/forms.py:15 opac/webapp/admin/forms.py:15
 msgid "Usuário inválido"
 msgstr ""
 
-#: opac/webapp/admin/forms.py:17
+#: build/lib/opac/webapp/admin/forms.py:17 opac/webapp/admin/forms.py:17
 msgid "Senha inválida"
 msgstr ""
 
-#: opac/webapp/admin/views.py:28
+#: build/lib/opac/webapp/admin/views.py:28 opac/webapp/admin/views.py:28
 msgid "Tem certeza que quer publicar os itens selecionados?"
 msgstr ""
 
-#: opac/webapp/admin/views.py:29
+#: build/lib/opac/webapp/admin/views.py:29 opac/webapp/admin/views.py:29
 msgid "Tem certeza que quer despublicar os itens selecionados?"
 msgstr ""
 
-#: opac/webapp/admin/views.py:30
+#: build/lib/opac/webapp/admin/views.py:30 opac/webapp/admin/views.py:30
 msgid "Tem certeza que quer reconstruir os artigos selecionados?"
 msgstr ""
 
-#: opac/webapp/admin/views.py:31
+#: build/lib/opac/webapp/admin/views.py:31 opac/webapp/admin/views.py:31
 msgid ""
 "Tem certeza que quer enviar email de confirmação aos usuários "
 "selecionados?"
 msgstr ""
 
-#: opac/webapp/admin/views.py:91 opac/webapp/admin/views.py:104
+#: build/lib/opac/webapp/admin/views.py:91
+#: build/lib/opac/webapp/admin/views.py:104 opac/webapp/admin/views.py:91
+#: opac/webapp/admin/views.py:104
 msgid "Usuário não encontrado"
 msgstr ""
 
-#: opac/webapp/admin/views.py:94
+#: build/lib/opac/webapp/admin/views.py:94 opac/webapp/admin/views.py:94
 #, python-format
 msgid "Email: %(email)s confirmado com sucesso!"
 msgstr ""
 
-#: opac/webapp/admin/views.py:110
+#: build/lib/opac/webapp/admin/views.py:110 opac/webapp/admin/views.py:110
 #, python-format
 msgid "Enviamos as instruções para recuperar a senha para: %(email)s"
 msgstr ""
 
-#: opac/webapp/admin/views.py:113
+#: build/lib/opac/webapp/admin/views.py:113 opac/webapp/admin/views.py:113
 #, python-format
 msgid ""
 "Ocorreu um erro no envio das instruções por email para: %(email)s. Erro: "
 "%(error)s"
 msgstr ""
 
-#: opac/webapp/admin/views.py:139
+#: build/lib/opac/webapp/admin/views.py:139 opac/webapp/admin/views.py:139
 msgid "Nova senha salva com sucesso!!"
 msgstr ""
 
-#: opac/webapp/admin/views.py:167 opac/webapp/admin/views.py:186
+#: build/lib/opac/webapp/admin/views.py:167
+#: build/lib/opac/webapp/admin/views.py:186 opac/webapp/admin/views.py:167
+#: opac/webapp/admin/views.py:186
 #, python-format
 msgid "Enviamos o email de confirmação para: %(email)s"
 msgstr ""
 
-#: opac/webapp/admin/views.py:170
+#: build/lib/opac/webapp/admin/views.py:170 opac/webapp/admin/views.py:170
 #, python-format
 msgid ""
 "Ocorreu um erro no envio do email de confirmação para: %(email)s "
 "%(error_msg)s"
 msgstr ""
 
-#: opac/webapp/admin/views.py:177
+#: build/lib/opac/webapp/admin/views.py:177 opac/webapp/admin/views.py:177
 msgid "Enviar email de confirmação"
 msgstr ""
 
-#: opac/webapp/admin/views.py:189
+#: build/lib/opac/webapp/admin/views.py:189 opac/webapp/admin/views.py:189
 #, python-format
 msgid "Ocorreu um erro no envio do email de confirmação para: %(email)s"
 msgstr ""
 
-#: opac/webapp/admin/views.py:193
+#: build/lib/opac/webapp/admin/views.py:193 opac/webapp/admin/views.py:193
 #, python-format
 msgid "%(count)s usuários foram notificados com sucesso!"
 msgstr ""
 
-#: opac/webapp/admin/views.py:196
+#: build/lib/opac/webapp/admin/views.py:196 opac/webapp/admin/views.py:196
 #, python-format
 msgid "Ocorreu um erro no envio do emails de confirmação. Erro: %(ex)s"
 msgstr ""
 
-#: opac/webapp/admin/views.py:231 opac/webapp/admin/views.py:265
-#: opac/webapp/admin/views.py:363 opac/webapp/admin/views.py:393
-#: opac/webapp/admin/views.py:677
+#: build/lib/opac/webapp/admin/views.py:231
+#: build/lib/opac/webapp/admin/views.py:265
+#: build/lib/opac/webapp/admin/views.py:363
+#: build/lib/opac/webapp/admin/views.py:393
+#: build/lib/opac/webapp/admin/views.py:677 opac/webapp/admin/views.py:231
+#: opac/webapp/admin/views.py:265 opac/webapp/admin/views.py:363
+#: opac/webapp/admin/views.py:393 opac/webapp/admin/views.py:677
 msgid "Nome"
 msgstr ""
 
-#: opac/webapp/admin/views.py:232 opac/webapp/admin/views.py:267
+#: build/lib/opac/webapp/admin/views.py:232
+#: build/lib/opac/webapp/admin/views.py:267 opac/webapp/admin/views.py:232
+#: opac/webapp/admin/views.py:267
 msgid "Link"
 msgstr ""
 
-#: opac/webapp/admin/views.py:233 opac/webapp/admin/views.py:268
-#: opac/webapp/admin/views.py:678
+#: build/lib/opac/webapp/admin/views.py:233
+#: build/lib/opac/webapp/admin/views.py:268
+#: build/lib/opac/webapp/admin/views.py:678 opac/webapp/admin/views.py:233
+#: opac/webapp/admin/views.py:268 opac/webapp/admin/views.py:678
 msgid "Idioma"
 msgstr ""
 
-#: opac/webapp/admin/views.py:266
+#: build/lib/opac/webapp/admin/views.py:266 opac/webapp/admin/views.py:266
 msgid "Previsualização"
 msgstr ""
 
-#: opac/webapp/admin/views.py:362 opac/webapp/admin/views.py:547
-#: opac/webapp/admin/views.py:627
+#: build/lib/opac/webapp/admin/views.py:362
+#: build/lib/opac/webapp/admin/views.py:547
+#: build/lib/opac/webapp/admin/views.py:627 opac/webapp/admin/views.py:362
+#: opac/webapp/admin/views.py:547 opac/webapp/admin/views.py:627
 msgid "Ordem"
 msgstr ""
 
-#: opac/webapp/admin/views.py:364
+#: build/lib/opac/webapp/admin/views.py:364 opac/webapp/admin/views.py:364
 msgid "URL"
 msgstr ""
 
-#: opac/webapp/admin/views.py:365
+#: build/lib/opac/webapp/admin/views.py:365 opac/webapp/admin/views.py:365
 msgid "URL da logomarca"
 msgstr ""
 
-#: opac/webapp/admin/views.py:375
+#: build/lib/opac/webapp/admin/views.py:375 opac/webapp/admin/views.py:375
 msgid "Financiador com Ordem ou Nome já cadastrado!"
 msgstr ""
 
-#: opac/webapp/admin/views.py:394
+#: build/lib/opac/webapp/admin/views.py:394 opac/webapp/admin/views.py:394
 msgid "Acerca de"
 msgstr ""
 
-#: opac/webapp/admin/views.py:395 opac/webapp/admin/views.py:462
+#: build/lib/opac/webapp/admin/views.py:395
+#: build/lib/opac/webapp/admin/views.py:462 opac/webapp/admin/views.py:395
+#: opac/webapp/admin/views.py:462
 msgid "Acrônimo"
 msgstr ""
 
-#: opac/webapp/admin/views.py:396
+#: build/lib/opac/webapp/admin/views.py:396 opac/webapp/admin/views.py:396
 msgid "Endereço principal"
 msgstr ""
 
-#: opac/webapp/admin/views.py:397
+#: build/lib/opac/webapp/admin/views.py:397 opac/webapp/admin/views.py:397
 msgid "Endereço secundário"
 msgstr ""
 
-#: opac/webapp/admin/views.py:398
+#: build/lib/opac/webapp/admin/views.py:398 opac/webapp/admin/views.py:398
 msgid "Logo da Home (PT)"
 msgstr ""
 
-#: opac/webapp/admin/views.py:399
+#: build/lib/opac/webapp/admin/views.py:399 opac/webapp/admin/views.py:399
 msgid "Logo da Home (EN)"
 msgstr ""
 
-#: opac/webapp/admin/views.py:400
+#: build/lib/opac/webapp/admin/views.py:400 opac/webapp/admin/views.py:400
 msgid "Logo da Home (ES)"
 msgstr ""
 
-#: opac/webapp/admin/views.py:401
+#: build/lib/opac/webapp/admin/views.py:401 opac/webapp/admin/views.py:401
 msgid "Logo do cabeçalho (PT)"
 msgstr ""
 
-#: opac/webapp/admin/views.py:402
+#: build/lib/opac/webapp/admin/views.py:402 opac/webapp/admin/views.py:402
 msgid "Logo do cabeçalho (EN)"
 msgstr ""
 
-#: opac/webapp/admin/views.py:403
+#: build/lib/opac/webapp/admin/views.py:403 opac/webapp/admin/views.py:403
 msgid "Logo do cabeçalho (ES)"
 msgstr ""
 
-#: opac/webapp/admin/views.py:404
+#: build/lib/opac/webapp/admin/views.py:404 opac/webapp/admin/views.py:404
 msgid "Logo do menu (PT)"
 msgstr ""
 
-#: opac/webapp/admin/views.py:405 opac/webapp/admin/views.py:406
+#: build/lib/opac/webapp/admin/views.py:405
+#: build/lib/opac/webapp/admin/views.py:406 opac/webapp/admin/views.py:405
+#: opac/webapp/admin/views.py:406
 msgid "Logo do menu (ES)"
 msgstr ""
 
-#: opac/webapp/admin/views.py:407
+#: build/lib/opac/webapp/admin/views.py:407 opac/webapp/admin/views.py:407
 msgid "Logo do menu (drop)"
 msgstr ""
 
-#: opac/webapp/admin/views.py:408
+#: build/lib/opac/webapp/admin/views.py:408 opac/webapp/admin/views.py:408
 msgid "Logo do rodapé"
 msgstr ""
 
-#: opac/webapp/admin/views.py:451
+#: build/lib/opac/webapp/admin/views.py:451 opac/webapp/admin/views.py:451
 msgid "Id Periódico"
 msgstr ""
 
-#: opac/webapp/admin/views.py:453
+#: build/lib/opac/webapp/admin/views.py:453 opac/webapp/admin/views.py:453
 msgid "Linha do tempo"
 msgstr ""
 
-#: opac/webapp/admin/views.py:454
+#: build/lib/opac/webapp/admin/views.py:454 opac/webapp/admin/views.py:454
 msgid "Categorias de assunto"
 msgstr ""
 
-#: opac/webapp/admin/views.py:455
+#: build/lib/opac/webapp/admin/views.py:455 opac/webapp/admin/views.py:455
 msgid "Áreas de estudo"
 msgstr ""
 
-#: opac/webapp/admin/views.py:456
+#: build/lib/opac/webapp/admin/views.py:456 opac/webapp/admin/views.py:456
 msgid "Redes sociais"
 msgstr ""
 
+#: build/lib/opac/webapp/admin/views.py:457
+#: build/lib/opac/webapp/admin/views.py:611
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:30
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:73
 #: opac/webapp/admin/views.py:457 opac/webapp/admin/views.py:611
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:30
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:73
 msgid "Título"
 msgstr ""
 
-#: opac/webapp/admin/views.py:458
+#: build/lib/opac/webapp/admin/views.py:458 opac/webapp/admin/views.py:458
 msgid "Título ISO"
 msgstr ""
 
-#: opac/webapp/admin/views.py:459
+#: build/lib/opac/webapp/admin/views.py:459 opac/webapp/admin/views.py:459
 msgid "Título curto"
 msgstr ""
 
-#: opac/webapp/admin/views.py:460 opac/webapp/admin/views.py:538
-#: opac/webapp/admin/views.py:614
+#: build/lib/opac/webapp/admin/views.py:460
+#: build/lib/opac/webapp/admin/views.py:538
+#: build/lib/opac/webapp/admin/views.py:614 opac/webapp/admin/views.py:460
+#: opac/webapp/admin/views.py:538 opac/webapp/admin/views.py:614
 msgid "Criado"
 msgstr ""
 
-#: opac/webapp/admin/views.py:461 opac/webapp/admin/views.py:539
-#: opac/webapp/admin/views.py:615
+#: build/lib/opac/webapp/admin/views.py:461
+#: build/lib/opac/webapp/admin/views.py:539
+#: build/lib/opac/webapp/admin/views.py:615 opac/webapp/admin/views.py:461
+#: opac/webapp/admin/views.py:539 opac/webapp/admin/views.py:615
 msgid "Atualizado"
 msgstr ""
 
-#: opac/webapp/admin/views.py:463
+#: build/lib/opac/webapp/admin/views.py:463 opac/webapp/admin/views.py:463
 msgid "ISSN SciELO"
 msgstr ""
 
-#: opac/webapp/admin/views.py:464
+#: build/lib/opac/webapp/admin/views.py:464 opac/webapp/admin/views.py:464
 msgid "ISSN impresso"
 msgstr ""
 
-#: opac/webapp/admin/views.py:465
+#: build/lib/opac/webapp/admin/views.py:465 opac/webapp/admin/views.py:465
 msgid "ISSN eletrônico"
 msgstr ""
 
-#: opac/webapp/admin/views.py:466
+#: build/lib/opac/webapp/admin/views.py:466 opac/webapp/admin/views.py:466
 msgid "Descritores de assunto"
 msgstr ""
 
-#: opac/webapp/admin/views.py:467
+#: build/lib/opac/webapp/admin/views.py:467 opac/webapp/admin/views.py:467
 msgid "Url da submissão online"
 msgstr ""
 
-#: opac/webapp/admin/views.py:468
+#: build/lib/opac/webapp/admin/views.py:468 opac/webapp/admin/views.py:468
 msgid "Url do capa"
 msgstr ""
 
-#: opac/webapp/admin/views.py:469
+#: build/lib/opac/webapp/admin/views.py:469 opac/webapp/admin/views.py:469
 msgid "Url do logotipo"
 msgstr ""
 
-#: opac/webapp/admin/views.py:470
+#: build/lib/opac/webapp/admin/views.py:470 opac/webapp/admin/views.py:470
 msgid "Outros títulos"
 msgstr ""
 
-#: opac/webapp/admin/views.py:471
+#: build/lib/opac/webapp/admin/views.py:471 opac/webapp/admin/views.py:471
 msgid "Nome da editora"
 msgstr ""
 
-#: opac/webapp/admin/views.py:472
+#: build/lib/opac/webapp/admin/views.py:472 opac/webapp/admin/views.py:472
 msgid "País da editora"
 msgstr ""
 
-#: opac/webapp/admin/views.py:473
+#: build/lib/opac/webapp/admin/views.py:473 opac/webapp/admin/views.py:473
 msgid "Estado da editora"
 msgstr ""
 
-#: opac/webapp/admin/views.py:474
+#: build/lib/opac/webapp/admin/views.py:474 opac/webapp/admin/views.py:474
 msgid "Cidade da editora"
 msgstr ""
 
-#: opac/webapp/admin/views.py:475
+#: build/lib/opac/webapp/admin/views.py:475 opac/webapp/admin/views.py:475
 msgid "Endereço da editora"
 msgstr ""
 
-#: opac/webapp/admin/views.py:476
+#: build/lib/opac/webapp/admin/views.py:476 opac/webapp/admin/views.py:476
 msgid "Telefone da editora"
 msgstr ""
 
-#: opac/webapp/admin/views.py:477
+#: build/lib/opac/webapp/admin/views.py:477 opac/webapp/admin/views.py:477
 msgid "Missão"
 msgstr ""
 
-#: opac/webapp/admin/views.py:478
+#: build/lib/opac/webapp/admin/views.py:478 opac/webapp/admin/views.py:478
 msgid "No índice"
 msgstr ""
 
-#: opac/webapp/admin/views.py:479
+#: build/lib/opac/webapp/admin/views.py:479 opac/webapp/admin/views.py:479
 msgid "Patrocinadores"
 msgstr ""
 
-#: opac/webapp/admin/views.py:480
+#: build/lib/opac/webapp/admin/views.py:480 opac/webapp/admin/views.py:480
 msgid "Ref periódico anterior"
 msgstr ""
 
-#: opac/webapp/admin/views.py:481
+#: build/lib/opac/webapp/admin/views.py:481 opac/webapp/admin/views.py:481
 msgid "Situação atual"
 msgstr ""
 
-#: opac/webapp/admin/views.py:482
+#: build/lib/opac/webapp/admin/views.py:482 opac/webapp/admin/views.py:482
 msgid "Total de números"
 msgstr ""
 
-#: opac/webapp/admin/views.py:483 opac/webapp/admin/views.py:548
-#: opac/webapp/admin/views.py:618
+#: build/lib/opac/webapp/admin/views.py:483
+#: build/lib/opac/webapp/admin/views.py:548
+#: build/lib/opac/webapp/admin/views.py:618 opac/webapp/admin/views.py:483
+#: opac/webapp/admin/views.py:548 opac/webapp/admin/views.py:618
 msgid "Publicado?"
 msgstr ""
 
-#: opac/webapp/admin/views.py:484 opac/webapp/admin/views.py:549
-#: opac/webapp/admin/views.py:619
+#: build/lib/opac/webapp/admin/views.py:484
+#: build/lib/opac/webapp/admin/views.py:549
+#: build/lib/opac/webapp/admin/views.py:619 opac/webapp/admin/views.py:484
+#: opac/webapp/admin/views.py:549 opac/webapp/admin/views.py:619
 msgid "Motivo de despublicação"
 msgstr ""
 
-#: opac/webapp/admin/views.py:485 opac/webapp/admin/views.py:551
-#: opac/webapp/admin/views.py:620
+#: build/lib/opac/webapp/admin/views.py:485
+#: build/lib/opac/webapp/admin/views.py:551
+#: build/lib/opac/webapp/admin/views.py:620 opac/webapp/admin/views.py:485
+#: opac/webapp/admin/views.py:551 opac/webapp/admin/views.py:620
 msgid "Segmento de URL"
 msgstr ""
 
-#: opac/webapp/admin/views.py:488 opac/webapp/admin/views.py:554
-#: opac/webapp/admin/views.py:633
+#: build/lib/opac/webapp/admin/views.py:488
+#: build/lib/opac/webapp/admin/views.py:554
+#: build/lib/opac/webapp/admin/views.py:633 opac/webapp/admin/views.py:488
+#: opac/webapp/admin/views.py:554 opac/webapp/admin/views.py:633
 msgid "Publicar"
 msgstr ""
 
-#: opac/webapp/admin/views.py:493
+#: build/lib/opac/webapp/admin/views.py:493 opac/webapp/admin/views.py:493
 msgid "Periódico(s) publicado(s) com sucesso!!"
 msgstr ""
 
-#: opac/webapp/admin/views.py:495
+#: build/lib/opac/webapp/admin/views.py:495 opac/webapp/admin/views.py:495
 msgid "Ocorreu um erro tentando publicar o(s) periódico(s)!!"
 msgstr ""
 
-#: opac/webapp/admin/views.py:501
+#: build/lib/opac/webapp/admin/views.py:501 opac/webapp/admin/views.py:501
 msgid "Periódico(s) despublicado com sucesso!!"
 msgstr ""
 
-#: opac/webapp/admin/views.py:504
+#: build/lib/opac/webapp/admin/views.py:504 opac/webapp/admin/views.py:504
 #, python-format
 msgid "Ocorreu um erro tentando despublicar o(s) periódico(s)!!. Erro: %(ex)s"
 msgstr ""
 
-#: opac/webapp/admin/views.py:508 opac/webapp/admin/views.py:576
-#: opac/webapp/admin/views.py:656
+#: build/lib/opac/webapp/admin/views.py:508
+#: build/lib/opac/webapp/admin/views.py:576
+#: build/lib/opac/webapp/admin/views.py:656 opac/webapp/admin/views.py:508
+#: opac/webapp/admin/views.py:576 opac/webapp/admin/views.py:656
 #, python-format
 msgid "Despublicar por %s"
 msgstr ""
 
-#: opac/webapp/admin/views.py:532
+#: build/lib/opac/webapp/admin/views.py:532 opac/webapp/admin/views.py:532
 msgid "Id Número"
 msgstr ""
 
-#: opac/webapp/admin/views.py:534 opac/webapp/admin/views.py:624
+#: build/lib/opac/webapp/admin/views.py:534
+#: build/lib/opac/webapp/admin/views.py:624 opac/webapp/admin/views.py:534
+#: opac/webapp/admin/views.py:624
 msgid "Seções"
 msgstr ""
 
-#: opac/webapp/admin/views.py:535
+#: build/lib/opac/webapp/admin/views.py:535 opac/webapp/admin/views.py:535
 msgid "Url da capa"
 msgstr ""
 
+#: build/lib/opac/webapp/admin/views.py:536
+#: build/lib/opac/webapp/templates/collection/list_feed_content.html:3
+#: build/lib/opac/webapp/templates/issue/grid.html:40
+#: build/lib/opac/webapp/templates/news/includes/issue_last_row.html:7
 #: opac/webapp/admin/views.py:536
 #: opac/webapp/templates/collection/list_feed_content.html:3
 #: opac/webapp/templates/issue/grid.html:40
@@ -783,26 +914,31 @@ msgstr ""
 msgid "Volume"
 msgstr ""
 
-#: opac/webapp/admin/views.py:540
+#: build/lib/opac/webapp/admin/views.py:540 opac/webapp/admin/views.py:540
 msgid "Tipo"
 msgstr ""
 
-#: opac/webapp/admin/views.py:541
+#: build/lib/opac/webapp/admin/views.py:541 opac/webapp/admin/views.py:541
 msgid "Texto do suplemento"
 msgstr ""
 
-#: opac/webapp/admin/views.py:542
+#: build/lib/opac/webapp/admin/views.py:542 opac/webapp/admin/views.py:542
 msgid "Texto do especial"
 msgstr ""
 
-#: opac/webapp/admin/views.py:543
+#: build/lib/opac/webapp/admin/views.py:543 opac/webapp/admin/views.py:543
 msgid "Mês inicial"
 msgstr ""
 
-#: opac/webapp/admin/views.py:544
+#: build/lib/opac/webapp/admin/views.py:544 opac/webapp/admin/views.py:544
 msgid "Mês final"
 msgstr ""
 
+#: build/lib/opac/webapp/admin/views.py:545
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:25
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:68
+#: build/lib/opac/webapp/templates/issue/grid.html:39
+#: build/lib/opac/webapp/templates/news/includes/issue_last_row.html:5
 #: opac/webapp/admin/views.py:545
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:25
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:68
@@ -811,64 +947,74 @@ msgstr ""
 msgid "Ano"
 msgstr ""
 
-#: opac/webapp/admin/views.py:546
+#: build/lib/opac/webapp/admin/views.py:546 opac/webapp/admin/views.py:546
 msgid "Etiqueta"
 msgstr ""
 
-#: opac/webapp/admin/views.py:550 opac/webapp/admin/views.py:621
+#: build/lib/opac/webapp/admin/views.py:550
+#: build/lib/opac/webapp/admin/views.py:621 opac/webapp/admin/views.py:550
+#: opac/webapp/admin/views.py:621
 msgid "PID"
 msgstr ""
 
-#: opac/webapp/admin/views.py:559
+#: build/lib/opac/webapp/admin/views.py:559 opac/webapp/admin/views.py:559
 msgid "Número(s) publicado(s) com sucesso!!"
 msgstr ""
 
-#: opac/webapp/admin/views.py:562 opac/webapp/admin/views.py:642
+#: build/lib/opac/webapp/admin/views.py:562
+#: build/lib/opac/webapp/admin/views.py:642 opac/webapp/admin/views.py:562
+#: opac/webapp/admin/views.py:642
 #, python-format
 msgid "Ocorreu um erro tentando publicar o(s) número(s)!!. Erro: %(ex)s"
 msgstr ""
 
-#: opac/webapp/admin/views.py:569
+#: build/lib/opac/webapp/admin/views.py:569 opac/webapp/admin/views.py:569
 msgid "Número(s) despublicado(s) com sucesso!!"
 msgstr ""
 
-#: opac/webapp/admin/views.py:572 opac/webapp/admin/views.py:652
+#: build/lib/opac/webapp/admin/views.py:572
+#: build/lib/opac/webapp/admin/views.py:652 opac/webapp/admin/views.py:572
+#: opac/webapp/admin/views.py:652
 #, python-format
 msgid "Ocorreu um erro tentando despublicar o(s) número(s)!!. Erro: %(ex)s"
 msgstr ""
 
-#: opac/webapp/admin/views.py:608
+#: build/lib/opac/webapp/admin/views.py:608 opac/webapp/admin/views.py:608
 msgid "Id Artigo"
 msgstr ""
 
-#: opac/webapp/admin/views.py:612
+#: build/lib/opac/webapp/admin/views.py:612 opac/webapp/admin/views.py:612
 msgid "Seção"
 msgstr ""
 
-#: opac/webapp/admin/views.py:613
+#: build/lib/opac/webapp/admin/views.py:613 opac/webapp/admin/views.py:613
 msgid "É Ahead of Print?"
 msgstr ""
 
-#: opac/webapp/admin/views.py:616
+#: build/lib/opac/webapp/admin/views.py:616 opac/webapp/admin/views.py:616
 msgid "HTML's"
 msgstr ""
 
-#: opac/webapp/admin/views.py:617
+#: build/lib/opac/webapp/admin/views.py:617 opac/webapp/admin/views.py:617
 msgid "Chave de domínio"
 msgstr ""
 
-#: opac/webapp/admin/views.py:622
+#: build/lib/opac/webapp/admin/views.py:622 opac/webapp/admin/views.py:622
 msgid "Idioma original"
 msgstr ""
 
-#: opac/webapp/admin/views.py:623
+#: build/lib/opac/webapp/admin/views.py:623 opac/webapp/admin/views.py:623
 msgid "Idiomas das traduções"
 msgstr ""
 
-#: opac/webapp/admin/views.py:625
+#: build/lib/opac/webapp/admin/views.py:625 opac/webapp/admin/views.py:625
 msgid "Autores"
 msgstr ""
 
+#: build/lib/opac/webapp/admin/views.py:626
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:29
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:72
+#: build/lib/opac/webapp/templates/issue/toc.html:176
 #: opac/webapp/admin/views.py:626
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:29
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:72
@@ -876,198 +1022,230 @@ msgstr ""
 msgid "Resumo"
 msgstr ""
 
-#: opac/webapp/admin/views.py:628
+#: build/lib/opac/webapp/admin/views.py:628 opac/webapp/admin/views.py:628
 msgid "DOI"
 msgstr ""
 
-#: opac/webapp/admin/views.py:629
+#: build/lib/opac/webapp/admin/views.py:629 opac/webapp/admin/views.py:629
 msgid "Idiomas"
 msgstr ""
 
-#: opac/webapp/admin/views.py:630
+#: build/lib/opac/webapp/admin/views.py:630 opac/webapp/admin/views.py:630
 msgid "Idiomas dos resumos"
 msgstr ""
 
-#: opac/webapp/admin/views.py:638
+#: build/lib/opac/webapp/admin/views.py:638 opac/webapp/admin/views.py:638
 msgid "Artigo(s) publicado com sucesso!!"
 msgstr ""
 
-#: opac/webapp/admin/views.py:649
+#: build/lib/opac/webapp/admin/views.py:649 opac/webapp/admin/views.py:649
 msgid "Artigo(s) despublicado com sucesso!!"
 msgstr ""
 
-#: opac/webapp/admin/views.py:679
+#: build/lib/opac/webapp/admin/views.py:679 opac/webapp/admin/views.py:679
 msgid "Conteúdo"
 msgstr ""
 
-#: opac/webapp/admin/views.py:681 opac/webapp/admin/views.py:901
+#: build/lib/opac/webapp/admin/views.py:681
+#: build/lib/opac/webapp/admin/views.py:901 opac/webapp/admin/views.py:681
+#: opac/webapp/admin/views.py:901
 msgid "Descrição"
 msgstr ""
 
-#: opac/webapp/admin/views.py:682 opac/webapp/admin/views.py:898
+#: build/lib/opac/webapp/admin/views.py:682
+#: build/lib/opac/webapp/admin/views.py:898 opac/webapp/admin/views.py:682
+#: opac/webapp/admin/views.py:898
 msgid "Data de Criação"
 msgstr ""
 
-#: opac/webapp/admin/views.py:683
+#: build/lib/opac/webapp/admin/views.py:683 opac/webapp/admin/views.py:683
 msgid "Data de Atualização"
 msgstr ""
 
-#: opac/webapp/admin/views.py:897
+#: build/lib/opac/webapp/admin/views.py:897 opac/webapp/admin/views.py:897
 msgid "Ação"
 msgstr ""
 
-#: opac/webapp/admin/views.py:899
+#: build/lib/opac/webapp/admin/views.py:899 opac/webapp/admin/views.py:899
 msgid "Modelo Auditado"
 msgstr ""
 
-#: opac/webapp/admin/views.py:900
+#: build/lib/opac/webapp/admin/views.py:900 opac/webapp/admin/views.py:900
 msgid "Id Auditado"
 msgstr ""
 
-#: opac/webapp/admin/views.py:902
+#: build/lib/opac/webapp/admin/views.py:902 opac/webapp/admin/views.py:902
 msgid "Dados dos campos"
 msgstr ""
 
-#: opac/webapp/main/views.py:29
+#: build/lib/opac/webapp/main/views.py:34 opac/webapp/main/views.py:34
 msgid "O periódico está indisponível por motivo de: "
 msgstr ""
 
-#: opac/webapp/main/views.py:30
+#: build/lib/opac/webapp/main/views.py:35 opac/webapp/main/views.py:35
 msgid "O número está indisponível por motivo de: "
 msgstr ""
 
-#: opac/webapp/main/views.py:31
+#: build/lib/opac/webapp/main/views.py:36 opac/webapp/main/views.py:36
 msgid "O artigo está indisponível por motivo de: "
 msgstr ""
 
-#: opac/webapp/main/views.py:78
+#: build/lib/opac/webapp/main/views.py:127 opac/webapp/main/views.py:127
 msgid "Código de idioma inválido"
 msgstr ""
 
-#: opac/webapp/main/views.py:148
+#: build/lib/opac/webapp/main/views.py:197 opac/webapp/main/views.py:197
 msgid "Últimos periódicos inseridos na coleção"
 msgstr ""
 
-#: opac/webapp/main/views.py:149
+#: build/lib/opac/webapp/main/views.py:198 opac/webapp/main/views.py:198
 #, python-format
 msgid "10 últimos periódicos inseridos na coleção %s"
 msgstr ""
 
-#: opac/webapp/main/views.py:208
+#: build/lib/opac/webapp/main/views.py:257 opac/webapp/main/views.py:257
 msgid "Página não encontrada"
 msgstr ""
 
-#: opac/webapp/main/views.py:232 opac/webapp/main/views.py:322
+#: build/lib/opac/webapp/main/views.py:281
+#: build/lib/opac/webapp/main/views.py:371 opac/webapp/main/views.py:281
+#: opac/webapp/main/views.py:371
 #, python-format
 msgid "Requsição inválida ao tentar acessar o artigo com pid: %s"
 msgstr ""
 
-#: opac/webapp/main/views.py:240 opac/webapp/main/views.py:290
-#: opac/webapp/main/views.py:334 opac/webapp/main/views.py:403
-#: opac/webapp/main/views.py:450 opac/webapp/main/views.py:597
-#: opac/webapp/main/views.py:614 opac/webapp/main/views.py:1055
+#: build/lib/opac/webapp/main/views.py:289
+#: build/lib/opac/webapp/main/views.py:339
+#: build/lib/opac/webapp/main/views.py:383
+#: build/lib/opac/webapp/main/views.py:452
+#: build/lib/opac/webapp/main/views.py:500
+#: build/lib/opac/webapp/main/views.py:647
+#: build/lib/opac/webapp/main/views.py:664
+#: build/lib/opac/webapp/main/views.py:1127 opac/webapp/main/views.py:289
+#: opac/webapp/main/views.py:339 opac/webapp/main/views.py:383
+#: opac/webapp/main/views.py:452 opac/webapp/main/views.py:500
+#: opac/webapp/main/views.py:647 opac/webapp/main/views.py:664
+#: opac/webapp/main/views.py:1127
 msgid "Periódico não encontrado"
 msgstr ""
 
-#: opac/webapp/main/views.py:252 opac/webapp/main/views.py:664
-#: opac/webapp/main/views.py:723 opac/webapp/main/views.py:1064
+#: build/lib/opac/webapp/main/views.py:301
+#: build/lib/opac/webapp/main/views.py:714
+#: build/lib/opac/webapp/main/views.py:773
+#: build/lib/opac/webapp/main/views.py:1136 opac/webapp/main/views.py:301
+#: opac/webapp/main/views.py:714 opac/webapp/main/views.py:773
+#: opac/webapp/main/views.py:1136
 msgid "Número não encontrado"
 msgstr ""
 
-#: opac/webapp/main/views.py:270 opac/webapp/main/views.py:305
-#: opac/webapp/main/views.py:774 opac/webapp/main/views.py:805
-#: opac/webapp/main/views.py:881 opac/webapp/main/views.py:884
-#: opac/webapp/main/views.py:988
+#: build/lib/opac/webapp/main/views.py:319
+#: build/lib/opac/webapp/main/views.py:354
+#: build/lib/opac/webapp/main/views.py:825
+#: build/lib/opac/webapp/main/views.py:910
+#: build/lib/opac/webapp/main/views.py:1060 opac/webapp/main/views.py:319
+#: opac/webapp/main/views.py:354 opac/webapp/main/views.py:825
+#: opac/webapp/main/views.py:910 opac/webapp/main/views.py:1060
 msgid "Artigo não encontrado"
 msgstr ""
 
-#: opac/webapp/main/views.py:427
+#: build/lib/opac/webapp/main/views.py:476 opac/webapp/main/views.py:476
 msgid "Artigo sem título"
 msgstr ""
 
-#: opac/webapp/main/views.py:498 opac/webapp/main/views.py:515
+#: build/lib/opac/webapp/main/views.py:548
+#: build/lib/opac/webapp/main/views.py:565 opac/webapp/main/views.py:548
+#: opac/webapp/main/views.py:565
 msgid "Requisição inválida. Deve ser por ajax"
 msgstr ""
 
-#: opac/webapp/main/views.py:531
+#: build/lib/opac/webapp/main/views.py:581 opac/webapp/main/views.py:581
 msgid ""
 "Parámetro \"filter\" é inválido, deve ser \"areas\", \"wos\" ou "
 "\"publisher\"."
 msgstr ""
 
-#: opac/webapp/main/views.py:540
+#: build/lib/opac/webapp/main/views.py:590 opac/webapp/main/views.py:590
 msgid "Parámetro \"extension\" é inválido, deve ser \"csv\" ou \"xls\"."
 msgstr ""
 
-#: opac/webapp/main/views.py:542
+#: build/lib/opac/webapp/main/views.py:592 opac/webapp/main/views.py:592
 msgid ""
 "Parámetro \"list_type\" é inválido, deve ser: \"alpha\", \"areas\", "
 "\"wos\" ou \"publisher\"."
 msgstr ""
 
-#: opac/webapp/main/views.py:563
+#: build/lib/opac/webapp/main/views.py:613 opac/webapp/main/views.py:613
 msgid "Requisição inválida, deve ser ajax."
 msgstr ""
 
-#: opac/webapp/main/views.py:572
+#: build/lib/opac/webapp/main/views.py:622 opac/webapp/main/views.py:622
 msgid "Periódico não permite envio de email."
 msgstr ""
 
-#: opac/webapp/main/views.py:590
+#: build/lib/opac/webapp/main/views.py:640 opac/webapp/main/views.py:640
 msgid "Requisição inválida, captcha inválido."
 msgstr ""
 
-#: opac/webapp/main/views.py:796 opac/webapp/main/views.py:983
+#: build/lib/opac/webapp/main/views.py:901
+#: build/lib/opac/webapp/main/views.py:1055 opac/webapp/main/views.py:901
+#: opac/webapp/main/views.py:1055
 msgid "Issue não encontrado"
 msgstr ""
 
-#: opac/webapp/main/views.py:841 opac/webapp/main/views.py:847
-#: opac/webapp/main/views.py:1020 opac/webapp/main/views.py:1028
-#: opac/webapp/main/views.py:1030
+#: build/lib/opac/webapp/main/views.py:943
+#: build/lib/opac/webapp/main/views.py:949
+#: build/lib/opac/webapp/main/views.py:1092
+#: build/lib/opac/webapp/main/views.py:1100
+#: build/lib/opac/webapp/main/views.py:1102 opac/webapp/main/views.py:943
+#: opac/webapp/main/views.py:949 opac/webapp/main/views.py:1092
+#: opac/webapp/main/views.py:1100 opac/webapp/main/views.py:1102
 msgid "PDF do Artigo não encontrado"
 msgstr ""
 
-#: opac/webapp/main/views.py:857
-msgid "HTML do Artigo não encontrado"
-msgstr ""
-
-#: opac/webapp/main/views.py:871
+#: build/lib/opac/webapp/main/views.py:954 opac/webapp/main/views.py:954
 msgid "HTML do Artigo não encontrado ou indisponível"
 msgstr ""
 
-#: opac/webapp/main/views.py:930
+#: build/lib/opac/webapp/main/views.py:1001 opac/webapp/main/views.py:1001
 msgid "Parâmetros insuficientes para obter o EPDF do artigo"
 msgstr ""
 
-#: opac/webapp/main/views.py:947
+#: build/lib/opac/webapp/main/views.py:1022 opac/webapp/main/views.py:1022
 msgid "Recruso não encontrado"
 msgstr ""
 
-#: opac/webapp/main/views.py:952
-msgid "Recurso não encontrado"
-msgstr ""
-
-#: opac/webapp/main/views.py:969
+#: build/lib/opac/webapp/main/views.py:1041 opac/webapp/main/views.py:1041
 msgid "Recurso do Artigo não encontrado. Caminho inválido!"
 msgstr ""
 
-#: opac/webapp/main/views.py:1082
+#: build/lib/opac/webapp/main/views.py:1154 opac/webapp/main/views.py:1154
 msgid "PDF do artigo não foi encontrado"
 msgstr ""
 
-#: opac/webapp/main/views.py:1110 opac/webapp/main/views.py:1141
+#: build/lib/opac/webapp/main/views.py:1169
+#: build/lib/opac/webapp/main/views.py:1200 opac/webapp/main/views.py:1169
+#: opac/webapp/main/views.py:1200
 msgid "Requisição inválida."
 msgstr ""
 
+#: build/lib/opac/webapp/templates/admin/index.html:7
 #: opac/webapp/templates/admin/index.html:7
 msgid "da coleção"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/admin/index.html:12
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu.html:31
 #: opac/webapp/templates/admin/index.html:12
 #: opac/webapp/templates/collection/includes/levelMenu.html:31
 msgid "Periódicos"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/admin/index.html:15
+#: build/lib/opac/webapp/templates/admin/index.html:22
+#: build/lib/opac/webapp/templates/admin/index.html:35
+#: build/lib/opac/webapp/templates/admin/index.html:42
+#: build/lib/opac/webapp/templates/admin/index.html:55
+#: build/lib/opac/webapp/templates/admin/index.html:62
 #: opac/webapp/templates/admin/index.html:15
 #: opac/webapp/templates/admin/index.html:22
 #: opac/webapp/templates/admin/index.html:35
@@ -1077,6 +1255,12 @@ msgstr ""
 msgid "Publicados"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/admin/index.html:16
+#: build/lib/opac/webapp/templates/admin/index.html:36
+#: build/lib/opac/webapp/templates/admin/index.html:56
+#: build/lib/opac/webapp/templates/admin/index.html:75
+#: build/lib/opac/webapp/templates/admin/index.html:85
+#: build/lib/opac/webapp/templates/admin/index.html:95
 #: opac/webapp/templates/admin/index.html:16
 #: opac/webapp/templates/admin/index.html:36
 #: opac/webapp/templates/admin/index.html:56
@@ -1086,58 +1270,78 @@ msgstr ""
 msgid "Total"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/admin/index.html:32
 #: opac/webapp/templates/admin/index.html:32
 msgid "Fascícluos"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/admin/index.html:52
 #: opac/webapp/templates/admin/index.html:52
 msgid "Artigos"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/admin/index.html:72
 #: opac/webapp/templates/admin/index.html:72
 msgid "News"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/admin/index.html:82
 #: opac/webapp/templates/admin/index.html:82
 msgid "Sponsors"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/admin/index.html:92
 #: opac/webapp/templates/admin/index.html:92
 msgid "Press Releases"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/admin/auth/reset.html:9
+#: build/lib/opac/webapp/templates/admin/auth/reset_with_token.html:9
+#: build/lib/opac/webapp/templates/admin/opac_base.html:13
 #: opac/webapp/templates/admin/auth/reset.html:9
 #: opac/webapp/templates/admin/auth/reset_with_token.html:9
 #: opac/webapp/templates/admin/opac_base.html:13
 msgid "Recuperar a senha"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/admin/opac_base.html:14
 #: opac/webapp/templates/admin/opac_base.html:14
 msgid "Terminar sessão"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/admin/auth/login.html:11
+#: build/lib/opac/webapp/templates/admin/auth/login.html:20
+#: build/lib/opac/webapp/templates/admin/opac_base.html:18
 #: opac/webapp/templates/admin/auth/login.html:11
 #: opac/webapp/templates/admin/auth/login.html:20
 #: opac/webapp/templates/admin/opac_base.html:18
 msgid "Iniciar sessão"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/admin/audit_log/fields_data_table.html:4
 #: opac/webapp/templates/admin/audit_log/fields_data_table.html:4
 msgid "Campo: "
 msgstr ""
 
+#: build/lib/opac/webapp/templates/admin/audit_log/fields_data_table.html:5
 #: opac/webapp/templates/admin/audit_log/fields_data_table.html:5
 msgid "Valor anterior: "
 msgstr ""
 
+#: build/lib/opac/webapp/templates/admin/audit_log/fields_data_table.html:6
 #: opac/webapp/templates/admin/audit_log/fields_data_table.html:6
 msgid "Valor novo: "
 msgstr ""
 
+#: build/lib/opac/webapp/templates/admin/auth/login.html:13
 #: opac/webapp/templates/admin/auth/login.html:13
 msgid "Você já iniciou sessão!"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/admin/auth/login.html:24
+#: build/lib/opac/webapp/templates/admin/auth/reset.html:13
+#: build/lib/opac/webapp/templates/admin/auth/reset_with_token.html:13
+#: build/lib/opac/webapp/templates/includes/error_form.html:60
 #: opac/webapp/templates/admin/auth/login.html:24
 #: opac/webapp/templates/admin/auth/reset.html:13
 #: opac/webapp/templates/admin/auth/reset_with_token.html:13
@@ -1145,14 +1349,17 @@ msgstr ""
 msgid "Enviar"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/admin/auth/login.html:28
 #: opac/webapp/templates/admin/auth/login.html:28
 msgid "Esqueci a senha?"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/admin/auth/unconfirm_email.html:7
 #: opac/webapp/templates/admin/auth/unconfirm_email.html:7
 msgid "Email não confirmado!"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/admin/auth/unconfirm_email.html:9
 #: opac/webapp/templates/admin/auth/unconfirm_email.html:9
 msgid ""
 "Você <strong>deve</strong> confirmar seu email.<br>\n"
@@ -1160,6 +1367,7 @@ msgid ""
 "administrador.</strong>"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/admin/pages/edit.html:7
 #: opac/webapp/templates/admin/pages/edit.html:7
 msgid ""
 "<strong>Atenção:</strong> ao selecionar um <strong>periódico</strong> "
@@ -1168,6 +1376,11 @@ msgid ""
 "<em>Sobre o SciELO</em>. "
 msgstr ""
 
+#: build/lib/opac/webapp/templates/article/includes/alternative_header.html:7
+#: build/lib/opac/webapp/templates/collection/includes/header.html:7
+#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:7
+#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:7
+#: build/lib/opac/webapp/templates/journal/includes/header.html:8
 #: opac/webapp/templates/article/includes/alternative_header.html:7
 #: opac/webapp/templates/collection/includes/header.html:7
 #: opac/webapp/templates/issue/includes/alternative_header.html:7
@@ -1176,6 +1389,10 @@ msgstr ""
 msgid "Abrir menu"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/article/includes/alternative_header.html:9
+#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:9
+#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:9
+#: build/lib/opac/webapp/templates/journal/includes/header.html:10
 #: opac/webapp/templates/article/includes/alternative_header.html:9
 #: opac/webapp/templates/issue/includes/alternative_header.html:9
 #: opac/webapp/templates/journal/includes/alternative_header.html:9
@@ -1183,6 +1400,11 @@ msgstr ""
 msgid "Ir para a homepage da coleção: "
 msgstr ""
 
+#: build/lib/opac/webapp/templates/article/includes/alternative_header.html:42
+#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:7
+#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:121
+#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:117
+#: build/lib/opac/webapp/templates/journal/includes/header.html:118
 #: opac/webapp/templates/article/includes/alternative_header.html:42
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:7
 #: opac/webapp/templates/issue/includes/alternative_header.html:121
@@ -1191,6 +1413,11 @@ msgstr ""
 msgid "Submissão de manuscritos"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/article/includes/alternative_header.html:48
+#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:16
+#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:127
+#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:123
+#: build/lib/opac/webapp/templates/journal/includes/header.html:124
 #: opac/webapp/templates/article/includes/alternative_header.html:48
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:16
 #: opac/webapp/templates/issue/includes/alternative_header.html:127
@@ -1199,6 +1426,11 @@ msgstr ""
 msgid "Sobre o periódico"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/article/includes/alternative_header.html:53
+#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:10
+#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:132
+#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:128
+#: build/lib/opac/webapp/templates/journal/includes/header.html:129
 #: opac/webapp/templates/article/includes/alternative_header.html:53
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:10
 #: opac/webapp/templates/issue/includes/alternative_header.html:132
@@ -1207,6 +1439,11 @@ msgstr ""
 msgid "Corpo Editorial"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/article/includes/alternative_header.html:58
+#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:13
+#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:137
+#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:133
+#: build/lib/opac/webapp/templates/journal/includes/header.html:134
 #: opac/webapp/templates/article/includes/alternative_header.html:58
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:13
 #: opac/webapp/templates/issue/includes/alternative_header.html:137
@@ -1215,6 +1452,11 @@ msgstr ""
 msgid "Instruções aos autores"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/article/includes/alternative_header.html:63
+#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:19
+#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:142
+#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:138
+#: build/lib/opac/webapp/templates/journal/includes/header.html:140
 #: opac/webapp/templates/article/includes/alternative_header.html:63
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:19
 #: opac/webapp/templates/issue/includes/alternative_header.html:142
@@ -1223,56 +1465,81 @@ msgstr ""
 msgid "Contato"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:2
+#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:60
 #: opac/webapp/templates/article/includes/floating_menu.html:2
 #: opac/webapp/templates/article/includes/floating_menu.html:60
 msgid "Ir para o topo"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:6
+#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:65
 #: opac/webapp/templates/article/includes/floating_menu.html:6
 #: opac/webapp/templates/article/includes/floating_menu.html:65
 msgid "PDFs"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:26
+#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:77
 #: opac/webapp/templates/article/includes/floating_menu.html:26
 #: opac/webapp/templates/article/includes/floating_menu.html:77
 msgid "Figuras e tabelas"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:32
+#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:83
 #: opac/webapp/templates/article/includes/floating_menu.html:32
 #: opac/webapp/templates/article/includes/floating_menu.html:83
 msgid "Versões e traduções"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:37
+#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:88
 #: opac/webapp/templates/article/includes/floating_menu.html:37
 #: opac/webapp/templates/article/includes/floating_menu.html:88
 msgid "Como citar este artigo"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:42
+#: build/lib/opac/webapp/templates/article/includes/modal/related_article.html:9
 #: opac/webapp/templates/article/includes/floating_menu.html:42
 #: opac/webapp/templates/article/includes/modal/related_article.html:9
 msgid "Artigos relacionados"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:93
 #: opac/webapp/templates/article/includes/floating_menu.html:93
 msgid "Artigos e similares"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:9
 #: opac/webapp/templates/article/includes/levelMenu.html:9
 msgid "home do periodico"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:17
+#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:70
+#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:123
 #: opac/webapp/templates/article/includes/levelMenu.html:17
 #: opac/webapp/templates/article/includes/levelMenu.html:70
 #: opac/webapp/templates/article/includes/levelMenu.html:123
 msgid "sumário"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:30
+#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:75
+#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:71
 #: opac/webapp/templates/article/includes/levelMenu.html:30
 #: opac/webapp/templates/issue/includes/alternative_header.html:75
 #: opac/webapp/templates/journal/includes/alternative_header.html:71
 msgid "anterior"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:35
+#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:88
+#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:141
+#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:82
+#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:78
 #: opac/webapp/templates/article/includes/levelMenu.html:35
 #: opac/webapp/templates/article/includes/levelMenu.html:88
 #: opac/webapp/templates/article/includes/levelMenu.html:141
@@ -1281,10 +1548,15 @@ msgstr ""
 msgid "atual"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:48
 #: opac/webapp/templates/article/includes/levelMenu.html:48
 msgid "seguinte"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:193
+#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:219
+#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:264
+#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:290
 #: opac/webapp/templates/article/includes/levelMenu.html:193
 #: opac/webapp/templates/article/includes/levelMenu.html:219
 #: opac/webapp/templates/article/includes/levelMenu.html:264
@@ -1292,6 +1564,10 @@ msgstr ""
 msgid "Download PDF (Espanhol)"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:195
+#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:221
+#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:266
+#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:292
 #: opac/webapp/templates/article/includes/levelMenu.html:195
 #: opac/webapp/templates/article/includes/levelMenu.html:221
 #: opac/webapp/templates/article/includes/levelMenu.html:266
@@ -1299,6 +1575,10 @@ msgstr ""
 msgid "Download PDF (Inglês)"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:197
+#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:223
+#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:268
+#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:294
 #: opac/webapp/templates/article/includes/levelMenu.html:197
 #: opac/webapp/templates/article/includes/levelMenu.html:223
 #: opac/webapp/templates/article/includes/levelMenu.html:268
@@ -1306,6 +1586,13 @@ msgstr ""
 msgid "Download PDF (Português)"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:310
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu.html:38
+#: build/lib/opac/webapp/templates/collection/includes/list_journals_section_title.html:14
+#: build/lib/opac/webapp/templates/issue/grid.html:14
+#: build/lib/opac/webapp/templates/issue/toc.html:13
+#: build/lib/opac/webapp/templates/journal/about.html:16
+#: build/lib/opac/webapp/templates/journal/detail.html:11
 #: opac/webapp/templates/article/includes/levelMenu.html:310
 #: opac/webapp/templates/collection/includes/levelMenu.html:38
 #: opac/webapp/templates/collection/includes/list_journals_section_title.html:14
@@ -1316,6 +1603,11 @@ msgstr ""
 msgid "Compartilhe"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:311
+#: build/lib/opac/webapp/templates/collection/includes/list_journals_section_title.html:16
+#: build/lib/opac/webapp/templates/issue/toc.html:14
+#: build/lib/opac/webapp/templates/journal/about.html:17
+#: build/lib/opac/webapp/templates/journal/detail.html:12
 #: opac/webapp/templates/article/includes/levelMenu.html:311
 #: opac/webapp/templates/collection/includes/list_journals_section_title.html:16
 #: opac/webapp/templates/issue/toc.html:14
@@ -1324,6 +1616,11 @@ msgstr ""
 msgid "Enviar link por e-mail"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:314
+#: build/lib/opac/webapp/templates/collection/includes/list_journals_section_title.html:19
+#: build/lib/opac/webapp/templates/issue/toc.html:15
+#: build/lib/opac/webapp/templates/journal/about.html:18
+#: build/lib/opac/webapp/templates/journal/detail.html:13
 #: opac/webapp/templates/article/includes/levelMenu.html:314
 #: opac/webapp/templates/collection/includes/list_journals_section_title.html:19
 #: opac/webapp/templates/issue/toc.html:15
@@ -1332,6 +1629,11 @@ msgstr ""
 msgid "Compartilhar no Facebook"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:317
+#: build/lib/opac/webapp/templates/collection/includes/list_journals_section_title.html:22
+#: build/lib/opac/webapp/templates/issue/toc.html:16
+#: build/lib/opac/webapp/templates/journal/about.html:19
+#: build/lib/opac/webapp/templates/journal/detail.html:14
 #: opac/webapp/templates/article/includes/levelMenu.html:317
 #: opac/webapp/templates/collection/includes/list_journals_section_title.html:22
 #: opac/webapp/templates/issue/toc.html:16
@@ -1340,6 +1642,18 @@ msgstr ""
 msgid "Compartilhar no Twitter"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:320
+#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:325
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu.html:46
+#: build/lib/opac/webapp/templates/collection/includes/list_journals_section_title.html:25
+#: build/lib/opac/webapp/templates/collection/includes/list_journals_section_title.html:30
+#: build/lib/opac/webapp/templates/issue/grid.html:20
+#: build/lib/opac/webapp/templates/issue/toc.html:17
+#: build/lib/opac/webapp/templates/issue/toc.html:19
+#: build/lib/opac/webapp/templates/journal/about.html:20
+#: build/lib/opac/webapp/templates/journal/about.html:22
+#: build/lib/opac/webapp/templates/journal/detail.html:15
+#: build/lib/opac/webapp/templates/journal/detail.html:17
 #: opac/webapp/templates/article/includes/levelMenu.html:320
 #: opac/webapp/templates/article/includes/levelMenu.html:325
 #: opac/webapp/templates/collection/includes/levelMenu.html:46
@@ -1355,16 +1669,24 @@ msgstr ""
 msgid "Outras redes sociais"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/article/includes/recent_articles_row.html:6
+#: build/lib/opac/webapp/templates/issue/toc.html:149
 #: opac/webapp/templates/article/includes/recent_articles_row.html:6
 #: opac/webapp/templates/issue/toc.html:149
 msgid "Documento sem título"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/article/includes/recent_articles_row.html:13
+#: build/lib/opac/webapp/templates/news/includes/journal_news_row.html:14
 #: opac/webapp/templates/article/includes/recent_articles_row.html:13
-#: opac/webapp/templates/news/includes/journal_news_row.html:9
+#: opac/webapp/templates/news/includes/journal_news_row.html:14
 msgid "Continue lendo"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/article/includes/modal/download.html:6
+#: build/lib/opac/webapp/templates/article/includes/modal/related_article.html:7
+#: build/lib/opac/webapp/templates/email/email_form.html:7
+#: build/lib/opac/webapp/templates/includes/metric_modal.html:6
 #: opac/webapp/templates/article/includes/modal/download.html:6
 #: opac/webapp/templates/article/includes/modal/related_article.html:7
 #: opac/webapp/templates/email/email_form.html:7
@@ -1372,607 +1694,791 @@ msgstr ""
 msgid "Fechar"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/article/includes/modal/download.html:8
 #: opac/webapp/templates/article/includes/modal/download.html:8
 msgid "Versão para download de PDF"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/article/includes/modal/translate_version.html:6
 #: opac/webapp/templates/article/includes/modal/translate_version.html:6
 msgid "Versões e tradução automática"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/article/includes/modal/translate_version.html:11
 #: opac/webapp/templates/article/includes/modal/translate_version.html:11
 msgid "Versão original do texto"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/about.html:23
+#: build/lib/opac/webapp/templates/collection/pages.html:21
 #: opac/webapp/templates/collection/about.html:23
+#: opac/webapp/templates/collection/pages.html:21
 #, python-format
 msgid " %(page)s "
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/about.html:38
+#: build/lib/opac/webapp/templates/collection/pages.html:36
 #: opac/webapp/templates/collection/about.html:38
+#: opac/webapp/templates/collection/pages.html:36
 msgid " Conteúdo não cadastrado "
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/index.html:17
 #: opac/webapp/templates/collection/index.html:17
 msgid "em números | Métricas"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/index.html:27
 #: opac/webapp/templates/collection/index.html:27
 msgid "períodicos"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:31
+#: build/lib/opac/webapp/templates/collection/index.html:31
+#: build/lib/opac/webapp/templates/collection/list_feed_content.html:7
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:31
 #: opac/webapp/templates/collection/index.html:31
 #: opac/webapp/templates/collection/list_feed_content.html:7
 msgid "números"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/index.html:35
+#: build/lib/opac/webapp/templates/issue/grid.html:68
 #: opac/webapp/templates/collection/index.html:35
 #: opac/webapp/templates/issue/grid.html:68
 msgid "artigos"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/index.html:39
 #: opac/webapp/templates/collection/index.html:39
 msgid "referências"
 msgstr "referencias"
 
+#: build/lib/opac/webapp/templates/collection/index.html:45
 #: opac/webapp/templates/collection/index.html:45
 msgid "Downloads"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/index.html:48
 #: opac/webapp/templates/collection/index.html:48
 msgid "Citações"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/index.html:51
 #: opac/webapp/templates/collection/index.html:51
 msgid "Outros indicadores"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/index.html:62
+#: build/lib/opac/webapp/templates/collection/list_journal.html:3
 #: opac/webapp/templates/collection/index.html:62
 #: opac/webapp/templates/collection/list_journal.html:3
 msgid "Lista de periódicos"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/index.html:66
+#: build/lib/opac/webapp/templates/collection/list_journal.html:21
 #: opac/webapp/templates/collection/index.html:66
 #: opac/webapp/templates/collection/list_journal.html:21
 msgid "Alfabética"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/index.html:69
+#: build/lib/opac/webapp/templates/collection/list_journal.html:24
 #: opac/webapp/templates/collection/index.html:69
 #: opac/webapp/templates/collection/list_journal.html:24
 msgid "Temática"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/index.html:77
 #: opac/webapp/templates/collection/index.html:77
 msgid "Busca por periódicos"
 msgstr "Búsqueda por periódicos"
 
+#: build/lib/opac/webapp/templates/collection/index.html:105
 #: opac/webapp/templates/collection/index.html:105
 msgid "Números <span>mais recentes</span>"
 msgstr "Números <span>más recientes</span>"
 
+#: build/lib/opac/webapp/templates/collection/index.html:149
 #: opac/webapp/templates/collection/index.html:149
 msgid "em perspectiva"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/list_feed_content.html:1
 #: opac/webapp/templates/collection/list_feed_content.html:1
 msgid "Último número"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/list_feed_content.html:4
 #: opac/webapp/templates/collection/list_feed_content.html:4
 msgid "Nº"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/list_feed_content.html:6
 #: opac/webapp/templates/collection/list_feed_content.html:6
 msgid "descontinuado"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/list_feed_content.html:7
 #: opac/webapp/templates/collection/list_feed_content.html:7
 msgid "de"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu.html:11
+#: build/lib/opac/webapp/templates/collection/list_journal.html:16
 #: opac/webapp/templates/collection/includes/levelMenu.html:11
 #: opac/webapp/templates/collection/list_journal.html:16
 msgid "Home"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_grouper_table_container.html:14
+#: build/lib/opac/webapp/templates/collection/list_journal.html:52
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_grouper_table_container.html:14
 #: opac/webapp/templates/collection/list_journal.html:52
 msgid "download da lista"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_grouper_table_container.html:15
+#: build/lib/opac/webapp/templates/collection/list_journal.html:53
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_grouper_table_container.html:15
 #: opac/webapp/templates/collection/list_journal.html:53
 msgid "Lista em arquivo para Excel"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_grouper_table_container.html:18
+#: build/lib/opac/webapp/templates/collection/list_journal.html:56
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_grouper_table_container.html:18
 #: opac/webapp/templates/collection/list_journal.html:56
 msgid "Lista em arquivo CSV"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/list_journal.html:80
+#: build/lib/opac/webapp/templates/collection/list_journal.html:84
 #: opac/webapp/templates/collection/list_journal.html:80
 #: opac/webapp/templates/collection/list_journal.html:84
 msgid "Grandes áreas do conhecimento"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/list_journal.html:85
 #: opac/webapp/templates/collection/list_journal.html:85
 msgid "Áreas temáticas do Web of Science"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/list_journal.html:222
 #: opac/webapp/templates/collection/list_journal.html:222
 msgid "grandes áreas"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/list_journal.html:236
 #: opac/webapp/templates/collection/list_journal.html:236
 msgid "áreas WOS"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/list_journal.html:248
 #: opac/webapp/templates/collection/list_journal.html:248
 msgid "Editoras"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/list_journal.html:249
 #: opac/webapp/templates/collection/list_journal.html:249
 msgid "editoras"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:7
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:7
 msgid "Sobre o"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:19
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:62
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:19
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:62
 msgid "Entre uma ou mais palavras"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:24
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:67
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:24
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:67
 msgid "Todos os índices"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:26
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:69
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:26
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:69
 msgid "Autor"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:38
+#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:95
+#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:91
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:38
 #: opac/webapp/templates/issue/includes/alternative_header.html:95
 #: opac/webapp/templates/journal/includes/alternative_header.html:91
 msgid "Buscar"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:44
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:44
 msgid "Adicionar outro campo"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:49
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:49
 msgid "Apagar campo"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:63
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:63
 msgid "Limpar expressão"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:92
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:92
 msgid "Sem resultados"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:96
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:96
 msgid "Não foram encontrados documentos para sua pesquisa"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/includes/list_journals_search_input.html:5
 #: opac/webapp/templates/collection/includes/list_journals_search_input.html:5
 msgid "Todos"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/includes/list_journals_search_input.html:9
 #: opac/webapp/templates/collection/includes/list_journals_search_input.html:9
 msgid "Periódicos ativos"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/includes/list_journals_search_input.html:13
 #: opac/webapp/templates/collection/includes/list_journals_search_input.html:13
 msgid "Periódicos descontinuados"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/includes/list_journals_search_input.html:24
 #: opac/webapp/templates/collection/includes/list_journals_search_input.html:24
 msgid "Digite uma ou mais palavras para filtrar a lista"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/includes/nav.html:22
+#: build/lib/opac/webapp/templates/collection/includes/nav.html:64
 #: opac/webapp/templates/collection/includes/nav.html:22
 #: opac/webapp/templates/collection/includes/nav.html:64
 msgid "Busca"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/includes/nav.html:32
 #: opac/webapp/templates/collection/includes/nav.html:32
 msgid "Sobre:"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/includes/nav.html:44
 #: opac/webapp/templates/collection/includes/nav.html:44
 msgid "SciELO.org - Rede SciELO"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/includes/nav.html:95
 #: opac/webapp/templates/collection/includes/nav.html:95
 msgid "Blog SciELO em Perspectiva"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_empty.html:3
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_empty.html:3
 msgid "Nenhum periódico encontrado."
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_error.html:3
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_error.html:3
 msgid "Ocorreu um erro obtendo a lista de periódicos."
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_grouper_table_container.html:10
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_grouper_table_container.html:10
 msgid "periódicos"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:3
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:3
 msgid "Homepage"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:25
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:25
 msgid "Título do periódico"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:29
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:29
 msgid "Grade de número"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:36
+#: build/lib/opac/webapp/templates/journal/detail.html:89
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:36
 #: opac/webapp/templates/journal/detail.html:89
 msgid "Número mais recente"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:37
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:37
 msgid "Último"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:45
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:45
 msgid "Continua como "
 msgstr ""
 
+#: build/lib/opac/webapp/templates/email/email_form.html:10
 #: opac/webapp/templates/email/email_form.html:10
 msgid "Enviar página por e-mail"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/email/email_form.html:18
+#: build/lib/opac/webapp/templates/includes/error_form.html:26
+#: build/lib/opac/webapp/templates/journal/includes/contact_form.html:20
 #: opac/webapp/templates/email/email_form.html:18
 #: opac/webapp/templates/includes/error_form.html:26
 #: opac/webapp/templates/journal/includes/contact_form.html:20
 msgid "Seu e-mail"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/email/email_form.html:23
 #: opac/webapp/templates/email/email_form.html:23
 msgid "Para"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/email/email_form.html:27
 #: opac/webapp/templates/email/email_form.html:27
 msgid "Utilize ; (ponto e vírgula) para inserir mais emails."
 msgstr ""
 
+#: build/lib/opac/webapp/templates/email/email_form.html:36
 #: opac/webapp/templates/email/email_form.html:36
 msgid "Alterar assunto e comentários"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/email/email_form.html:41
 #: opac/webapp/templates/email/email_form.html:41
 msgid "Assunto"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/email/email_form.html:45
 #: opac/webapp/templates/email/email_form.html:45
 msgid "Comentário"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/email/email_form.html:49
 #: opac/webapp/templates/email/email_form.html:49
 msgid "Remover remetente, assunto e comentários"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/email/email_form.html:75
 #: opac/webapp/templates/email/email_form.html:75
 msgid "Email enviado com sucesso."
 msgstr ""
 
+#: build/lib/opac/webapp/templates/email/email_form.html:76
+#: build/lib/opac/webapp/templates/includes/error_form.html:86
+#: build/lib/opac/webapp/templates/journal/includes/contact_form.html:77
 #: opac/webapp/templates/email/email_form.html:76
 #: opac/webapp/templates/includes/error_form.html:86
 #: opac/webapp/templates/journal/includes/contact_form.html:77
 msgid "Erro ao tentar enviar e-mail, por favor tente mais tarde."
 msgstr ""
 
+#: build/lib/opac/webapp/templates/errors/400.html:7
 #: opac/webapp/templates/errors/400.html:7
 msgid "Ação inválida"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/errors/403.html:7
 #: opac/webapp/templates/errors/403.html:7
 msgid "Acesso não autorizado!"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/errors/404.html:7
 #: opac/webapp/templates/errors/404.html:7
 msgid ""
 "A URL solicitada não foi encontrada no servidor. Se você digitou a URL "
 "manualmente, por favor verifique e tente novamente."
 msgstr ""
 
+#: build/lib/opac/webapp/templates/errors/500.html:5
 #: opac/webapp/templates/errors/500.html:5
 msgid ""
 "Erro interno do servidor. Tente novamente mais tarde. Nossos engenheiros "
 "foram notificados."
 msgstr ""
 
+#: build/lib/opac/webapp/templates/errors/500.html:9
 #: opac/webapp/templates/errors/500.html:9
 msgid "Id. do erro"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/errors/base.html:24
 #: opac/webapp/templates/errors/base.html:24
 msgid "Erro"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/errors/base.html:27
 #: opac/webapp/templates/errors/base.html:27
 msgid "Qualquer dúvida, por favor entre em contato com o administrador"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/includes/error_form.html:5
 #: opac/webapp/templates/includes/error_form.html:5
 msgid " Reportar erro "
 msgstr ""
 
+#: build/lib/opac/webapp/templates/includes/error_form.html:20
+#: build/lib/opac/webapp/templates/journal/includes/contact_form.html:14
 #: opac/webapp/templates/includes/error_form.html:20
 #: opac/webapp/templates/journal/includes/contact_form.html:14
 msgid "Seu Nome"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/includes/error_form.html:21
 #: opac/webapp/templates/includes/error_form.html:21
 msgid "Digite seu Nome"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/includes/error_form.html:32
 #: opac/webapp/templates/includes/error_form.html:32
 msgid "Erro referente"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/includes/error_form.html:35
 #: opac/webapp/templates/includes/error_form.html:35
 msgid "ao conteúdo"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/includes/error_form.html:39
 #: opac/webapp/templates/includes/error_form.html:39
 msgid "à aplicação"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/includes/error_form.html:46
 #: opac/webapp/templates/includes/error_form.html:46
 msgid "Descrição do erro"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/includes/error_form.html:47
 #: opac/webapp/templates/includes/error_form.html:47
 msgid "Digite sua mensagem"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/includes/error_form.html:49
 #: opac/webapp/templates/includes/error_form.html:49
 msgid "Obs.: Link e título da página são enviados automaticamente"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/includes/error_form.html:85
 #: opac/webapp/templates/includes/error_form.html:85
 msgid "Email de erro enviado com sucesso."
 msgstr ""
 
+#: build/lib/opac/webapp/templates/includes/footer.html:36
 #: opac/webapp/templates/includes/footer.html:36
 msgid "Open Access"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/includes/footer.html:38
 #: opac/webapp/templates/includes/footer.html:38
 msgid "Leia"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/includes/footer.html:38
 #: opac/webapp/templates/includes/footer.html:38
 msgid "a Declaração de Acesso Aberto"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/issue/grid.html:4
 #: opac/webapp/templates/issue/grid.html:4
 msgid "Fascículos"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/issue/grid.html:33
 #: opac/webapp/templates/issue/grid.html:33
 msgid "Todos os números"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/issue/grid.html:79
 #: opac/webapp/templates/issue/grid.html:79
 msgid "supl."
 msgstr ""
 
+#: build/lib/opac/webapp/templates/issue/grid.html:98
 #: opac/webapp/templates/issue/grid.html:98
 msgid "Nenhum número encontrado para esse periódico"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/issue/grid.html:101
 #: opac/webapp/templates/issue/grid.html:101
 msgid "Histórico deste periódico na coleção"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/issue/grid.html:105
 #: opac/webapp/templates/issue/grid.html:105
 msgid " admitido na coleção da SciELO"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/issue/toc.html:10
+#: build/lib/opac/webapp/templates/journal/detail.html:8
 #: opac/webapp/templates/issue/toc.html:10
 #: opac/webapp/templates/journal/detail.html:8
 msgid "Imprimir"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/issue/toc.html:41
 #: opac/webapp/templates/issue/toc.html:41
 msgid "Editor científico"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/issue/toc.html:45
 #: opac/webapp/templates/issue/toc.html:45
 msgid "Editores associados"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/issue/toc.html:52
 #: opac/webapp/templates/issue/toc.html:52
 msgid "Veja toda a equipe editorial"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/issue/toc.html:63
 #: opac/webapp/templates/issue/toc.html:63
 msgid "Expandir/recolher conteúdo"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/issue/toc.html:72
+#: build/lib/opac/webapp/templates/journal/detail.html:96
 #: opac/webapp/templates/issue/toc.html:72
 #: opac/webapp/templates/journal/detail.html:96
 msgid "Sumário"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/issue/toc.html:79
 #: opac/webapp/templates/issue/toc.html:79
 msgid "Ordenar publicações por"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/issue/toc.html:82
 #: opac/webapp/templates/issue/toc.html:82
 msgid "Ordem do fascículo"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/issue/toc.html:83
 #: opac/webapp/templates/issue/toc.html:83
 msgid "Mais novos primeiro"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/issue/toc.html:84
 #: opac/webapp/templates/issue/toc.html:84
 msgid "Mais antigos primeiro"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/issue/toc.html:102
+#: build/lib/opac/webapp/templates/issue/toc.html:104
 #: opac/webapp/templates/issue/toc.html:102
 #: opac/webapp/templates/issue/toc.html:104
 msgid "Todas as seções"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/issue/toc.html:187
 #: opac/webapp/templates/issue/toc.html:187
 msgid "Texto"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/issue/toc.html:214
 #: opac/webapp/templates/issue/toc.html:214
 msgid "Resumo em"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:31
+#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:31
 #: opac/webapp/templates/issue/includes/alternative_header.html:31
 #: opac/webapp/templates/journal/includes/alternative_header.html:31
 msgid "Número atual"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:51
+#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:47
 #: opac/webapp/templates/issue/includes/alternative_header.html:51
 #: opac/webapp/templates/journal/includes/alternative_header.html:47
 msgid "Homepage do periódico"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:62
+#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:58
 #: opac/webapp/templates/issue/includes/alternative_header.html:62
 #: opac/webapp/templates/journal/includes/alternative_header.html:58
 msgid "Números"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:68
+#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:64
+#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:90
 #: opac/webapp/templates/issue/includes/alternative_header.html:68
 #: opac/webapp/templates/journal/includes/alternative_header.html:64
 #: opac/webapp/templates/journal/includes/levelMenu.html:90
 msgid "todos"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:89
+#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:85
 #: opac/webapp/templates/issue/includes/alternative_header.html:89
 #: opac/webapp/templates/journal/includes/alternative_header.html:85
 msgid "próximo"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/journal/about.html:39
 #: opac/webapp/templates/journal/about.html:39
 msgid "Conteúdo não cadastrado"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/journal/about.html:55
+#: build/lib/opac/webapp/templates/journal/includes/contact_footer.html:48
 #: opac/webapp/templates/journal/about.html:55
 #: opac/webapp/templates/journal/includes/contact_footer.html:48
 msgid "Siga este periódico nas redes sociais"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/journal/detail.html:32
 #: opac/webapp/templates/journal/detail.html:32
 msgid "Nossa Missão"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/journal/detail.html:34
 #: opac/webapp/templates/journal/detail.html:34
 msgid "Periódico sem missão cadastrada"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/journal/detail.html:42
 #: opac/webapp/templates/journal/detail.html:42
 msgid "Métricas deste periódico"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/journal/detail.html:52
 #: opac/webapp/templates/journal/detail.html:52
 msgid "Índice h5"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/journal/detail.html:54
+#: build/lib/opac/webapp/templates/journal/detail.html:66
 #: opac/webapp/templates/journal/detail.html:54
 #: opac/webapp/templates/journal/detail.html:66
 msgid "ano"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/journal/detail.html:58
+#: build/lib/opac/webapp/templates/journal/detail.html:70
 #: opac/webapp/templates/journal/detail.html:58
 #: opac/webapp/templates/journal/detail.html:70
 msgid "Não possui"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/journal/detail.html:63
 #: opac/webapp/templates/journal/detail.html:63
 msgid "Mediana h5"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/journal/detail.html:86
 #: opac/webapp/templates/journal/detail.html:86
 msgid "Capa do número mais recente"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/journal/detail.html:138
 #: opac/webapp/templates/journal/detail.html:138
 msgid "Artigos mais recentes"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/journal/includes/contact_footer.html:57
 #: opac/webapp/templates/journal/includes/contact_footer.html:57
 msgid "Acompanhe os números deste periódico no seu leitor de RSS"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/journal/includes/contact_form.html:26
 #: opac/webapp/templates/journal/includes/contact_form.html:26
 msgid "Mensagem"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/journal/includes/contact_form.html:76
 #: opac/webapp/templates/journal/includes/contact_form.html:76
 msgid "Email enviado para "
 msgstr ""
 
+#: build/lib/opac/webapp/templates/journal/includes/contact_form.html:76
 #: opac/webapp/templates/journal/includes/contact_form.html:76
 msgid "com sucesso."
 msgstr ""
 
+#: build/lib/opac/webapp/templates/journal/includes/header.html:42
 #: opac/webapp/templates/journal/includes/header.html:42
 msgid "Publicação de:"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/journal/includes/header.html:47
 #: opac/webapp/templates/journal/includes/header.html:47
 msgid "Área:"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/journal/includes/header.html:51
 #: opac/webapp/templates/journal/includes/header.html:51
-msgid "Multidiciplinar"
+msgid "Multidisciplinar"
 msgstr "Multidisciplinaria"
 
+#: build/lib/opac/webapp/templates/journal/includes/header.html:60
 #: opac/webapp/templates/journal/includes/header.html:60
 msgid "Versão impressa ISSN:"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/journal/includes/header.html:67
 #: opac/webapp/templates/journal/includes/header.html:67
 msgid "Versão on-line ISSN:"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/journal/includes/header.html:76
 #: opac/webapp/templates/journal/includes/header.html:76
 msgid "Novo título:"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/journal/includes/header.html:93
 #: opac/webapp/templates/journal/includes/header.html:93
 msgid "Título anterior:"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/journal/includes/header.html:148
 #: opac/webapp/templates/journal/includes/header.html:148
 msgid "Siga-nos"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:10
 #: opac/webapp/templates/journal/includes/levelMenu.html:10
 msgid "home do periódico"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:19
 #: opac/webapp/templates/journal/includes/levelMenu.html:19
 msgid "todos os números"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:25
+#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:29
 #: opac/webapp/templates/journal/includes/levelMenu.html:25
 #: opac/webapp/templates/journal/includes/levelMenu.html:29
 msgid "número anterior"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:36
+#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:40
+#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:107
+#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:111
 #: opac/webapp/templates/journal/includes/levelMenu.html:36
 #: opac/webapp/templates/journal/includes/levelMenu.html:40
 #: opac/webapp/templates/journal/includes/levelMenu.html:107
@@ -1980,16 +2486,24 @@ msgstr ""
 msgid "número atual"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:47
+#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:51
 #: opac/webapp/templates/journal/includes/levelMenu.html:47
 #: opac/webapp/templates/journal/includes/levelMenu.html:51
 msgid "número seguinte"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:59
+#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:130
 #: opac/webapp/templates/journal/includes/levelMenu.html:59
 #: opac/webapp/templates/journal/includes/levelMenu.html:130
 msgid "buscar"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:65
+#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:69
+#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:136
+#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:140
 #: opac/webapp/templates/journal/includes/levelMenu.html:65
 #: opac/webapp/templates/journal/includes/levelMenu.html:69
 #: opac/webapp/templates/journal/includes/levelMenu.html:136
@@ -1997,22 +2511,27 @@ msgstr ""
 msgid "métricas"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/macros/issue.html:5
 #: opac/webapp/templates/macros/issue.html:5
 msgid " número especial "
 msgstr ""
 
+#: build/lib/opac/webapp/templates/macros/issue.html:10
 #: opac/webapp/templates/macros/issue.html:10
 msgid "número especial"
 msgstr ""
 
-#: opac/webapp/templates/news/includes/collection_news_row.html:11
+#: build/lib/opac/webapp/templates/news/includes/collection_news_row.html:16
+#: opac/webapp/templates/news/includes/collection_news_row.html:16
 msgid "continue lendo"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/news/includes/issue_last_row.html:15
 #: opac/webapp/templates/news/includes/issue_last_row.html:15
 msgid "Suplemento"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/news/includes/issue_last_row.html:20
 #: opac/webapp/templates/news/includes/issue_last_row.html:20
 msgid "Ver"
 msgstr ""
@@ -2258,5 +2777,11 @@ msgstr ""
 #~ msgstr ""
 
 #~ msgid "LINGUISTICS, LITERATURE AND ARTS"
+#~ msgstr ""
+
+#~ msgid "HTML do Artigo não encontrado"
+#~ msgstr ""
+
+#~ msgid "Recurso não encontrado"
 #~ msgstr ""
 

--- a/opac/webapp/translations/es_MX/LC_MESSAGES/messages.po
+++ b/opac/webapp/translations/es_MX/LC_MESSAGES/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-03-15 11:46+0000\n"
+"POT-Creation-Date: 2019-05-09 17:02-0300\n"
 "PO-Revision-Date: 2016-02-09 09:39-0600\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es_MX\n"
@@ -19,6 +19,23 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.6.0\n"
 
+#: build/lib/opac/tests/test_admin_custom_filters.py:100
+#: build/lib/opac/tests/test_admin_custom_filters.py:114
+#: build/lib/opac/tests/test_admin_custom_filters.py:129
+#: build/lib/opac/tests/test_admin_custom_filters.py:144
+#: build/lib/opac/tests/test_admin_custom_filters.py:158
+#: build/lib/opac/webapp/__init__.py:119
+#: build/lib/opac/webapp/admin/views.py:533
+#: build/lib/opac/webapp/admin/views.py:610
+#: build/lib/opac/webapp/admin/views.py:680
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:28
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:71
+#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_grouper_table_row.html:15
+#: build/lib/opac/webapp/templates/collection/list_journal.html:49
+#: build/lib/opac/webapp/templates/collection/list_journal.html:221
+#: build/lib/opac/webapp/templates/collection/list_journal.html:235
+#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:116
+#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:112
 #: opac/tests/test_admin_custom_filters.py:100
 #: opac/tests/test_admin_custom_filters.py:114
 #: opac/tests/test_admin_custom_filters.py:129
@@ -37,21 +54,38 @@ msgstr ""
 msgid "Periódico"
 msgstr ""
 
+#: build/lib/opac/tests/test_interface_menu.py:51
 #: opac/tests/test_interface_menu.py:51
 msgid "NOME DA COLEÇÃO!!"
 msgstr ""
 
-#: opac/tests/test_interface_menu.py:53 opac/tests/test_interface_menu.py:72
+#: build/lib/opac/tests/test_interface_menu.py:53
+#: build/lib/opac/tests/test_interface_menu.py:75
+#: build/lib/opac/webapp/templates/collection/includes/nav.html:12
+#: build/lib/opac/webapp/templates/collection/includes/nav.html:54
+#: opac/tests/test_interface_menu.py:53 opac/tests/test_interface_menu.py:75
 #: opac/webapp/templates/collection/includes/nav.html:12
 #: opac/webapp/templates/collection/includes/nav.html:54
 msgid "Lista alfabética de periódicos"
 msgstr ""
 
+#: build/lib/opac/tests/test_interface_menu.py:55
+#: build/lib/opac/webapp/templates/collection/includes/nav.html:17
 #: opac/tests/test_interface_menu.py:55
 #: opac/webapp/templates/collection/includes/nav.html:17
 msgid "Lista temática de periódicos"
 msgstr ""
 
+#: build/lib/opac/tests/test_interface_menu.py:61
+#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:11
+#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:70
+#: build/lib/opac/webapp/templates/collection/includes/nav.html:27
+#: build/lib/opac/webapp/templates/collection/includes/nav.html:69
+#: build/lib/opac/webapp/templates/includes/metric_modal.html:7
+#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:101
+#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:105
+#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:97
+#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:101
 #: opac/tests/test_interface_menu.py:61
 #: opac/webapp/templates/article/includes/floating_menu.html:11
 #: opac/webapp/templates/article/includes/floating_menu.html:70
@@ -65,332 +99,383 @@ msgstr ""
 msgid "Métricas"
 msgstr ""
 
+#: build/lib/opac/tests/test_interface_menu.py:63
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu.html:12
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu.html:29
 #: opac/tests/test_interface_menu.py:63
 #: opac/webapp/templates/collection/includes/levelMenu.html:12
 #: opac/webapp/templates/collection/includes/levelMenu.html:29
 msgid "Sobre o SciELO"
 msgstr ""
 
-#: opac/tests/test_interface_menu.py:65 opac/tests/test_interface_menu.py:84
+#: build/lib/opac/tests/test_interface_menu.py:65
+#: build/lib/opac/tests/test_interface_menu.py:99
+#: build/lib/opac/webapp/templates/collection/includes/nav.html:37
+#: build/lib/opac/webapp/templates/collection/includes/nav.html:84
+#: opac/tests/test_interface_menu.py:65 opac/tests/test_interface_menu.py:99
 #: opac/webapp/templates/collection/includes/nav.html:37
 #: opac/webapp/templates/collection/includes/nav.html:84
 msgid "Contatos"
 msgstr ""
 
+#: build/lib/opac/tests/test_interface_menu.py:67
 #: opac/tests/test_interface_menu.py:67
 msgid "Rede SciELO"
 msgstr ""
 
-#: opac/tests/test_interface_menu.py:70
+#: build/lib/opac/tests/test_interface_menu.py:71
+#: build/lib/opac/webapp/templates/collection/includes/nav.html:49
+#: opac/tests/test_interface_menu.py:71
 #: opac/webapp/templates/collection/includes/nav.html:49
 msgid "Coleções nacionais e temáticas"
 msgstr ""
 
-#: opac/tests/test_interface_menu.py:74
+#: build/lib/opac/tests/test_interface_menu.py:79
+#: build/lib/opac/webapp/templates/collection/includes/nav.html:59
+#: opac/tests/test_interface_menu.py:79
 #: opac/webapp/templates/collection/includes/nav.html:59
 msgid "Lista de periódicos por assunto"
 msgstr ""
 
-#: opac/tests/test_interface_menu.py:80
+#: build/lib/opac/tests/test_interface_menu.py:91
+#: build/lib/opac/webapp/templates/collection/includes/nav.html:74
+#: opac/tests/test_interface_menu.py:91
 #: opac/webapp/templates/collection/includes/nav.html:74
 msgid "Acesso OAI e RSS"
 msgstr ""
 
-#: opac/tests/test_interface_menu.py:82
+#: build/lib/opac/tests/test_interface_menu.py:95
+#: build/lib/opac/webapp/templates/collection/includes/nav.html:79
+#: opac/tests/test_interface_menu.py:95
 #: opac/webapp/templates/collection/includes/nav.html:79
 msgid "Sobre a Rede SciELO"
 msgstr ""
 
-#: opac/tests/test_main_errors.py:8
+#: build/lib/opac/tests/test_main_errors.py:8 opac/tests/test_main_errors.py:8
 msgid "Mensagem de erro explicativo para o usuário"
 msgstr ""
 
+#: build/lib/opac/webapp/__init__.py:118 build/lib/opac/webapp/__init__.py:119
+#: build/lib/opac/webapp/__init__.py:120 build/lib/opac/webapp/__init__.py:121
+#: build/lib/opac/webapp/__init__.py:122 build/lib/opac/webapp/__init__.py:123
 #: opac/webapp/__init__.py:118 opac/webapp/__init__.py:119
 #: opac/webapp/__init__.py:120 opac/webapp/__init__.py:121
 #: opac/webapp/__init__.py:122 opac/webapp/__init__.py:123
 msgid "Catálogo"
 msgstr ""
 
-#: opac/webapp/__init__.py:118 opac/webapp/admin/views.py:452
+#: build/lib/opac/webapp/__init__.py:118
+#: build/lib/opac/webapp/admin/views.py:452 opac/webapp/__init__.py:118
+#: opac/webapp/admin/views.py:452
 msgid "Coleção"
 msgstr ""
 
+#: build/lib/opac/webapp/__init__.py:120
+#: build/lib/opac/webapp/admin/views.py:537
+#: build/lib/opac/webapp/admin/views.py:609
+#: build/lib/opac/webapp/templates/issue/grid.html:41
+#: build/lib/opac/webapp/templates/news/includes/issue_last_row.html:11
 #: opac/webapp/__init__.py:120 opac/webapp/admin/views.py:537
 #: opac/webapp/admin/views.py:609 opac/webapp/templates/issue/grid.html:41
 #: opac/webapp/templates/news/includes/issue_last_row.html:11
 msgid "Número"
 msgstr ""
 
-#: opac/webapp/__init__.py:121
+#: build/lib/opac/webapp/__init__.py:121 opac/webapp/__init__.py:121
 msgid "Artigo"
 msgstr ""
 
+#: build/lib/opac/webapp/__init__.py:122
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:27
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:70
 #: opac/webapp/__init__.py:122
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:27
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:70
 msgid "Financiador"
 msgstr ""
 
-#: opac/webapp/__init__.py:123
+#: build/lib/opac/webapp/__init__.py:123 opac/webapp/__init__.py:123
 msgid "Press Release"
 msgstr ""
 
+#: build/lib/opac/webapp/__init__.py:124
+#: build/lib/opac/webapp/templates/journal/detail.html:160
 #: opac/webapp/__init__.py:124 opac/webapp/templates/journal/detail.html:160
 msgid "Notícias"
 msgstr ""
 
+#: build/lib/opac/webapp/__init__.py:125 build/lib/opac/webapp/__init__.py:126
 #: opac/webapp/__init__.py:125 opac/webapp/__init__.py:126
 msgid "Ativos"
 msgstr ""
 
-#: opac/webapp/__init__.py:127
+#: build/lib/opac/webapp/__init__.py:127 opac/webapp/__init__.py:127
 msgid "Páginas"
 msgstr ""
 
+#: build/lib/opac/webapp/__init__.py:128 build/lib/opac/webapp/__init__.py:129
 #: opac/webapp/__init__.py:128 opac/webapp/__init__.py:129
 msgid "Gestão"
 msgstr ""
 
-#: opac/webapp/__init__.py:128
+#: build/lib/opac/webapp/__init__.py:128 opac/webapp/__init__.py:128
 msgid "Auditoria: Páginas"
 msgstr ""
 
-#: opac/webapp/__init__.py:129 opac/webapp/admin/views.py:896
+#: build/lib/opac/webapp/__init__.py:129
+#: build/lib/opac/webapp/admin/views.py:896 opac/webapp/__init__.py:129
+#: opac/webapp/admin/views.py:896
 msgid "Usuário"
 msgstr ""
 
-#: opac/webapp/choices.py:7
+#: build/lib/opac/webapp/choices.py:7 opac/webapp/choices.py:7
 msgid "Conteúdo temporariamente indisponível"
 msgstr ""
 
+#: build/lib/opac/webapp/choices.py:11 build/lib/opac/webapp/choices.py:23
+#: build/lib/opac/webapp/templates/article/includes/modal/download.html:26
 #: opac/webapp/choices.py:11 opac/webapp/choices.py:23
 #: opac/webapp/templates/article/includes/modal/download.html:26
 msgid "Português"
 msgstr ""
 
+#: build/lib/opac/webapp/choices.py:12 build/lib/opac/webapp/choices.py:24
+#: build/lib/opac/webapp/templates/article/includes/modal/download.html:24
 #: opac/webapp/choices.py:12 opac/webapp/choices.py:24
 #: opac/webapp/templates/article/includes/modal/download.html:24
 msgid "Inglês"
 msgstr ""
 
+#: build/lib/opac/webapp/choices.py:13 build/lib/opac/webapp/choices.py:25
+#: build/lib/opac/webapp/templates/article/includes/modal/download.html:22
 #: opac/webapp/choices.py:13 opac/webapp/choices.py:25
 #: opac/webapp/templates/article/includes/modal/download.html:22
 msgid "Espanhol"
 msgstr ""
 
-#: opac/webapp/choices.py:26
+#: build/lib/opac/webapp/choices.py:26 opac/webapp/choices.py:26
 msgid "Albanês"
 msgstr ""
 
+#: build/lib/opac/webapp/choices.py:27 build/lib/opac/webapp/choices.py:33
 #: opac/webapp/choices.py:27 opac/webapp/choices.py:33
 msgid "Chinês"
 msgstr ""
 
-#: opac/webapp/choices.py:28
+#: build/lib/opac/webapp/choices.py:28 opac/webapp/choices.py:28
 msgid "Romeno"
 msgstr ""
 
-#: opac/webapp/choices.py:29
+#: build/lib/opac/webapp/choices.py:29 opac/webapp/choices.py:29
 msgid "Francês"
 msgstr ""
 
-#: opac/webapp/choices.py:30
+#: build/lib/opac/webapp/choices.py:30 opac/webapp/choices.py:30
 msgid "Italiano"
 msgstr ""
 
-#: opac/webapp/choices.py:31
+#: build/lib/opac/webapp/choices.py:31 opac/webapp/choices.py:31
 msgid "Russo"
 msgstr ""
 
-#: opac/webapp/choices.py:32
+#: build/lib/opac/webapp/choices.py:32 opac/webapp/choices.py:32
 msgid "Árabe"
 msgstr ""
 
-#: opac/webapp/choices.py:37
+#: build/lib/opac/webapp/choices.py:37 opac/webapp/choices.py:37
 msgid "corrente"
 msgstr ""
 
-#: opac/webapp/choices.py:38
+#: build/lib/opac/webapp/choices.py:38 opac/webapp/choices.py:38
 msgid "terminado"
 msgstr ""
 
-#: opac/webapp/choices.py:39
+#: build/lib/opac/webapp/choices.py:39 opac/webapp/choices.py:39
 msgid "indexação interrompida"
 msgstr ""
 
-#: opac/webapp/choices.py:40
+#: build/lib/opac/webapp/choices.py:40 opac/webapp/choices.py:40
 msgid "indexação interrompida pelo Comitê"
 msgstr ""
 
-#: opac/webapp/choices.py:41
+#: build/lib/opac/webapp/choices.py:41 opac/webapp/choices.py:41
 msgid "publicação finalizada"
 msgstr ""
 
-#: opac/webapp/choices.py:45
+#: build/lib/opac/webapp/choices.py:45 opac/webapp/choices.py:45
 msgid "Ciências Agrárias"
 msgstr ""
 
-#: opac/webapp/choices.py:46
+#: build/lib/opac/webapp/choices.py:46 opac/webapp/choices.py:46
 msgid "Ciências Sociais Aplicadas"
 msgstr ""
 
-#: opac/webapp/choices.py:47
+#: build/lib/opac/webapp/choices.py:47 opac/webapp/choices.py:47
 msgid "Ciências Biológicas"
 msgstr ""
 
-#: opac/webapp/choices.py:48
+#: build/lib/opac/webapp/choices.py:48 opac/webapp/choices.py:48
 msgid "Engenharias"
 msgstr ""
 
-#: opac/webapp/choices.py:49
+#: build/lib/opac/webapp/choices.py:49 opac/webapp/choices.py:49
 msgid "Ciências Exatas e da Terra"
 msgstr ""
 
-#: opac/webapp/choices.py:50
+#: build/lib/opac/webapp/choices.py:50 opac/webapp/choices.py:50
 msgid "Ciências da Saúde"
 msgstr ""
 
-#: opac/webapp/choices.py:51
+#: build/lib/opac/webapp/choices.py:51 opac/webapp/choices.py:51
 msgid "Ciências Humanas"
 msgstr ""
 
+#: build/lib/opac/webapp/choices.py:52 build/lib/opac/webapp/choices.py:53
 #: opac/webapp/choices.py:52 opac/webapp/choices.py:53
 msgid "Lingüística, Letras e Artes"
 msgstr ""
 
-#: opac/webapp/controllers.py:353
+#: build/lib/opac/webapp/controllers.py:353 opac/webapp/controllers.py:353
 msgid "Lista Alfabética"
 msgstr ""
 
-#: opac/webapp/controllers.py:357
+#: build/lib/opac/webapp/controllers.py:357 opac/webapp/controllers.py:357
 msgid "Lista Temática"
 msgstr ""
 
-#: opac/webapp/controllers.py:361
+#: build/lib/opac/webapp/controllers.py:361 opac/webapp/controllers.py:361
 msgid "Lista Web of Science"
 msgstr ""
 
-#: opac/webapp/controllers.py:365
+#: build/lib/opac/webapp/controllers.py:365 opac/webapp/controllers.py:365
 msgid "Lista by Institution"
 msgstr ""
 
-#: opac/webapp/controllers.py:424
+#: build/lib/opac/webapp/controllers.py:424 opac/webapp/controllers.py:424
 msgid "Obrigatório um jid."
 msgstr ""
 
-#: opac/webapp/controllers.py:440
+#: build/lib/opac/webapp/controllers.py:440 opac/webapp/controllers.py:440
 msgid "Obrigatório um acronym."
 msgstr ""
 
-#: opac/webapp/controllers.py:456
+#: build/lib/opac/webapp/controllers.py:456 opac/webapp/controllers.py:456
 msgid "Obrigatório um url_seg."
 msgstr ""
 
-#: opac/webapp/controllers.py:472
+#: build/lib/opac/webapp/controllers.py:472 opac/webapp/controllers.py:472
 msgid "Obrigatório um issn."
 msgstr ""
 
-#: opac/webapp/controllers.py:487
+#: build/lib/opac/webapp/controllers.py:487 opac/webapp/controllers.py:487
 msgid "Obrigatório um title."
 msgstr ""
 
-#: opac/webapp/controllers.py:525 opac/webapp/controllers.py:669
-#: opac/webapp/controllers.py:830
+#: build/lib/opac/webapp/controllers.py:525
+#: build/lib/opac/webapp/controllers.py:669
+#: build/lib/opac/webapp/controllers.py:830 opac/webapp/controllers.py:525
+#: opac/webapp/controllers.py:669 opac/webapp/controllers.py:830
 msgid "Obrigatório uma lista de ids."
 msgstr ""
 
-#: opac/webapp/controllers.py:631 opac/webapp/controllers.py:851
+#: build/lib/opac/webapp/controllers.py:631
+#: build/lib/opac/webapp/controllers.py:851 opac/webapp/controllers.py:631
+#: opac/webapp/controllers.py:851
 msgid "Obrigatório um iid."
 msgstr ""
 
-#: opac/webapp/controllers.py:688
+#: build/lib/opac/webapp/controllers.py:688 opac/webapp/controllers.py:688
 msgid "Obrigatório um jacron e issue_label."
 msgstr ""
 
-#: opac/webapp/controllers.py:701
+#: build/lib/opac/webapp/controllers.py:701 opac/webapp/controllers.py:701
 msgid "Obrigatório um PID."
 msgstr ""
 
-#: opac/webapp/controllers.py:717
+#: build/lib/opac/webapp/controllers.py:717 opac/webapp/controllers.py:717
 msgid "Obrigatório um url_seg e url_seg_issue."
 msgstr ""
 
-#: opac/webapp/controllers.py:724
+#: build/lib/opac/webapp/controllers.py:724 opac/webapp/controllers.py:724
 msgid "Obrigatório um assets_code."
 msgstr ""
 
-#: opac/webapp/controllers.py:727
+#: build/lib/opac/webapp/controllers.py:727 opac/webapp/controllers.py:727
 msgid "Obrigatório um journal."
 msgstr ""
 
-#: opac/webapp/controllers.py:743
+#: build/lib/opac/webapp/controllers.py:743 opac/webapp/controllers.py:743
 msgid "Obrigatório um aid."
 msgstr ""
 
-#: opac/webapp/controllers.py:757
+#: build/lib/opac/webapp/controllers.py:757 opac/webapp/controllers.py:757
 msgid "Obrigatório um url_seg_article."
 msgstr ""
 
-#: opac/webapp/controllers.py:772
+#: build/lib/opac/webapp/controllers.py:772 opac/webapp/controllers.py:772
 msgid "Obrigatório um iid and url_seg_article."
 msgstr ""
 
-#: opac/webapp/controllers.py:788
+#: build/lib/opac/webapp/controllers.py:788 opac/webapp/controllers.py:788
 msgid "Obrigatório um jid, url_seg_issue and url_seg_article."
 msgstr ""
 
-#: opac/webapp/controllers.py:889
+#: build/lib/opac/webapp/controllers.py:889 opac/webapp/controllers.py:889
 msgid "Obrigatório um pid."
 msgstr ""
 
-#: opac/webapp/controllers.py:902
+#: build/lib/opac/webapp/controllers.py:902 opac/webapp/controllers.py:902
 msgid "Obrigatório um aop_pid."
 msgstr ""
 
-#: opac/webapp/controllers.py:913
+#: build/lib/opac/webapp/controllers.py:913 opac/webapp/controllers.py:913
 msgid "Parámetro obrigatório: issue_iid."
 msgstr ""
 
-#: opac/webapp/controllers.py:961
+#: build/lib/opac/webapp/controllers.py:961 opac/webapp/controllers.py:961
 msgid "Parâmetro email deve ser uma string"
 msgstr ""
 
-#: opac/webapp/controllers.py:972
+#: build/lib/opac/webapp/controllers.py:972 opac/webapp/controllers.py:972
 msgid "Parâmetro email deve ser uma inteiro"
 msgstr ""
 
-#: opac/webapp/controllers.py:984 opac/webapp/controllers.py:998
+#: build/lib/opac/webapp/controllers.py:984
+#: build/lib/opac/webapp/controllers.py:998 opac/webapp/controllers.py:984
+#: opac/webapp/controllers.py:998
 #, python-format
 msgid "Usuário deve ser do tipo %s"
 msgstr ""
 
-#: opac/webapp/controllers.py:1054
+#: build/lib/opac/webapp/controllers.py:1054 opac/webapp/controllers.py:1054
 msgid "Compartilhamento de link SciELO"
 msgstr ""
 
-#: opac/webapp/controllers.py:1055
+#: build/lib/opac/webapp/controllers.py:1055 opac/webapp/controllers.py:1055
 #, python-format
 msgid "O usuário %s compartilha este link: %s, da SciELO"
 msgstr ""
 
-#: opac/webapp/controllers.py:1063 opac/webapp/controllers.py:1099
-#: opac/webapp/controllers.py:1121
+#: build/lib/opac/webapp/controllers.py:1063
+#: build/lib/opac/webapp/controllers.py:1099
+#: build/lib/opac/webapp/controllers.py:1121 opac/webapp/controllers.py:1063
+#: opac/webapp/controllers.py:1099 opac/webapp/controllers.py:1121
 msgid "Mensagem enviada!"
 msgstr ""
 
-#: opac/webapp/controllers.py:1080
+#: build/lib/opac/webapp/controllers.py:1080 opac/webapp/controllers.py:1080
 msgid "[Erro] Erro informado pelo usuário no site SciELO"
 msgstr ""
 
-#: opac/webapp/controllers.py:1083
+#: build/lib/opac/webapp/controllers.py:1083 opac/webapp/controllers.py:1083
 msgid "aplicação"
 msgstr ""
 
-#: opac/webapp/controllers.py:1085
+#: build/lib/opac/webapp/controllers.py:1085 opac/webapp/controllers.py:1085
 msgid "conteúdo"
 msgstr ""
 
-#: opac/webapp/controllers.py:1090
+#: build/lib/opac/webapp/controllers.py:1090 opac/webapp/controllers.py:1090
 #, python-format
 msgid ""
 "O usuário <b>%s</b> com e-mail: <b>%s</b>, informa que existe um erro na "
@@ -398,384 +483,430 @@ msgid ""
 " %s"
 msgstr ""
 
-#: opac/webapp/controllers.py:1111
+#: build/lib/opac/webapp/controllers.py:1111 opac/webapp/controllers.py:1111
 msgid "Contato de usuário via site SciELO"
 msgstr ""
 
-#: opac/webapp/controllers.py:1113
+#: build/lib/opac/webapp/controllers.py:1113 opac/webapp/controllers.py:1113
 #, python-format
 msgid "O usuário %s, com e-mail: %s, entra em contato com a seguinte mensagem:"
 msgstr ""
 
-#: opac/webapp/controllers.py:1145
+#: build/lib/opac/webapp/controllers.py:1145 opac/webapp/controllers.py:1145
 msgid "Obrigatório um slug_name."
 msgstr ""
 
-#: opac/webapp/forms.py:29
+#: build/lib/opac/webapp/forms.py:29 opac/webapp/forms.py:29
 msgid "Endereço de e-mail inválido."
 msgstr ""
 
-#: opac/webapp/admin/forms.py:9 opac/webapp/admin/forms.py:21
+#: build/lib/opac/webapp/admin/forms.py:9
+#: build/lib/opac/webapp/admin/forms.py:21 opac/webapp/admin/forms.py:9
+#: opac/webapp/admin/forms.py:21
 msgid "Email"
 msgstr ""
 
-#: opac/webapp/admin/forms.py:10 opac/webapp/admin/forms.py:25
+#: build/lib/opac/webapp/admin/forms.py:10
+#: build/lib/opac/webapp/admin/forms.py:25 opac/webapp/admin/forms.py:10
+#: opac/webapp/admin/forms.py:25
 msgid "Senha"
 msgstr ""
 
-#: opac/webapp/admin/forms.py:15
+#: build/lib/opac/webapp/admin/forms.py:15 opac/webapp/admin/forms.py:15
 msgid "Usuário inválido"
 msgstr ""
 
-#: opac/webapp/admin/forms.py:17
+#: build/lib/opac/webapp/admin/forms.py:17 opac/webapp/admin/forms.py:17
 msgid "Senha inválida"
 msgstr ""
 
-#: opac/webapp/admin/views.py:28
+#: build/lib/opac/webapp/admin/views.py:28 opac/webapp/admin/views.py:28
 msgid "Tem certeza que quer publicar os itens selecionados?"
 msgstr ""
 
-#: opac/webapp/admin/views.py:29
+#: build/lib/opac/webapp/admin/views.py:29 opac/webapp/admin/views.py:29
 msgid "Tem certeza que quer despublicar os itens selecionados?"
 msgstr ""
 
-#: opac/webapp/admin/views.py:30
+#: build/lib/opac/webapp/admin/views.py:30 opac/webapp/admin/views.py:30
 msgid "Tem certeza que quer reconstruir os artigos selecionados?"
 msgstr ""
 
-#: opac/webapp/admin/views.py:31
+#: build/lib/opac/webapp/admin/views.py:31 opac/webapp/admin/views.py:31
 msgid ""
 "Tem certeza que quer enviar email de confirmação aos usuários "
 "selecionados?"
 msgstr ""
 
-#: opac/webapp/admin/views.py:91 opac/webapp/admin/views.py:104
+#: build/lib/opac/webapp/admin/views.py:91
+#: build/lib/opac/webapp/admin/views.py:104 opac/webapp/admin/views.py:91
+#: opac/webapp/admin/views.py:104
 msgid "Usuário não encontrado"
 msgstr ""
 
-#: opac/webapp/admin/views.py:94
+#: build/lib/opac/webapp/admin/views.py:94 opac/webapp/admin/views.py:94
 #, python-format
 msgid "Email: %(email)s confirmado com sucesso!"
 msgstr ""
 
-#: opac/webapp/admin/views.py:110
+#: build/lib/opac/webapp/admin/views.py:110 opac/webapp/admin/views.py:110
 #, python-format
 msgid "Enviamos as instruções para recuperar a senha para: %(email)s"
 msgstr ""
 
-#: opac/webapp/admin/views.py:113
+#: build/lib/opac/webapp/admin/views.py:113 opac/webapp/admin/views.py:113
 #, python-format
 msgid ""
 "Ocorreu um erro no envio das instruções por email para: %(email)s. Erro: "
 "%(error)s"
 msgstr ""
 
-#: opac/webapp/admin/views.py:139
+#: build/lib/opac/webapp/admin/views.py:139 opac/webapp/admin/views.py:139
 msgid "Nova senha salva com sucesso!!"
 msgstr ""
 
-#: opac/webapp/admin/views.py:167 opac/webapp/admin/views.py:186
+#: build/lib/opac/webapp/admin/views.py:167
+#: build/lib/opac/webapp/admin/views.py:186 opac/webapp/admin/views.py:167
+#: opac/webapp/admin/views.py:186
 #, python-format
 msgid "Enviamos o email de confirmação para: %(email)s"
 msgstr ""
 
-#: opac/webapp/admin/views.py:170
+#: build/lib/opac/webapp/admin/views.py:170 opac/webapp/admin/views.py:170
 #, python-format
 msgid ""
 "Ocorreu um erro no envio do email de confirmação para: %(email)s "
 "%(error_msg)s"
 msgstr ""
 
-#: opac/webapp/admin/views.py:177
+#: build/lib/opac/webapp/admin/views.py:177 opac/webapp/admin/views.py:177
 msgid "Enviar email de confirmação"
 msgstr ""
 
-#: opac/webapp/admin/views.py:189
+#: build/lib/opac/webapp/admin/views.py:189 opac/webapp/admin/views.py:189
 #, python-format
 msgid "Ocorreu um erro no envio do email de confirmação para: %(email)s"
 msgstr ""
 
-#: opac/webapp/admin/views.py:193
+#: build/lib/opac/webapp/admin/views.py:193 opac/webapp/admin/views.py:193
 #, python-format
 msgid "%(count)s usuários foram notificados com sucesso!"
 msgstr ""
 
-#: opac/webapp/admin/views.py:196
+#: build/lib/opac/webapp/admin/views.py:196 opac/webapp/admin/views.py:196
 #, python-format
 msgid "Ocorreu um erro no envio do emails de confirmação. Erro: %(ex)s"
 msgstr ""
 
-#: opac/webapp/admin/views.py:231 opac/webapp/admin/views.py:265
-#: opac/webapp/admin/views.py:363 opac/webapp/admin/views.py:393
-#: opac/webapp/admin/views.py:677
+#: build/lib/opac/webapp/admin/views.py:231
+#: build/lib/opac/webapp/admin/views.py:265
+#: build/lib/opac/webapp/admin/views.py:363
+#: build/lib/opac/webapp/admin/views.py:393
+#: build/lib/opac/webapp/admin/views.py:677 opac/webapp/admin/views.py:231
+#: opac/webapp/admin/views.py:265 opac/webapp/admin/views.py:363
+#: opac/webapp/admin/views.py:393 opac/webapp/admin/views.py:677
 msgid "Nome"
 msgstr ""
 
-#: opac/webapp/admin/views.py:232 opac/webapp/admin/views.py:267
+#: build/lib/opac/webapp/admin/views.py:232
+#: build/lib/opac/webapp/admin/views.py:267 opac/webapp/admin/views.py:232
+#: opac/webapp/admin/views.py:267
 msgid "Link"
 msgstr ""
 
-#: opac/webapp/admin/views.py:233 opac/webapp/admin/views.py:268
-#: opac/webapp/admin/views.py:678
+#: build/lib/opac/webapp/admin/views.py:233
+#: build/lib/opac/webapp/admin/views.py:268
+#: build/lib/opac/webapp/admin/views.py:678 opac/webapp/admin/views.py:233
+#: opac/webapp/admin/views.py:268 opac/webapp/admin/views.py:678
 msgid "Idioma"
 msgstr ""
 
-#: opac/webapp/admin/views.py:266
+#: build/lib/opac/webapp/admin/views.py:266 opac/webapp/admin/views.py:266
 msgid "Previsualização"
 msgstr ""
 
-#: opac/webapp/admin/views.py:362 opac/webapp/admin/views.py:547
-#: opac/webapp/admin/views.py:627
+#: build/lib/opac/webapp/admin/views.py:362
+#: build/lib/opac/webapp/admin/views.py:547
+#: build/lib/opac/webapp/admin/views.py:627 opac/webapp/admin/views.py:362
+#: opac/webapp/admin/views.py:547 opac/webapp/admin/views.py:627
 msgid "Ordem"
 msgstr ""
 
-#: opac/webapp/admin/views.py:364
+#: build/lib/opac/webapp/admin/views.py:364 opac/webapp/admin/views.py:364
 msgid "URL"
 msgstr ""
 
-#: opac/webapp/admin/views.py:365
+#: build/lib/opac/webapp/admin/views.py:365 opac/webapp/admin/views.py:365
 msgid "URL da logomarca"
 msgstr ""
 
-#: opac/webapp/admin/views.py:375
+#: build/lib/opac/webapp/admin/views.py:375 opac/webapp/admin/views.py:375
 msgid "Financiador com Ordem ou Nome já cadastrado!"
 msgstr ""
 
-#: opac/webapp/admin/views.py:394
+#: build/lib/opac/webapp/admin/views.py:394 opac/webapp/admin/views.py:394
 msgid "Acerca de"
 msgstr ""
 
-#: opac/webapp/admin/views.py:395 opac/webapp/admin/views.py:462
+#: build/lib/opac/webapp/admin/views.py:395
+#: build/lib/opac/webapp/admin/views.py:462 opac/webapp/admin/views.py:395
+#: opac/webapp/admin/views.py:462
 msgid "Acrônimo"
 msgstr ""
 
-#: opac/webapp/admin/views.py:396
+#: build/lib/opac/webapp/admin/views.py:396 opac/webapp/admin/views.py:396
 msgid "Endereço principal"
 msgstr ""
 
-#: opac/webapp/admin/views.py:397
+#: build/lib/opac/webapp/admin/views.py:397 opac/webapp/admin/views.py:397
 msgid "Endereço secundário"
 msgstr ""
 
-#: opac/webapp/admin/views.py:398
+#: build/lib/opac/webapp/admin/views.py:398 opac/webapp/admin/views.py:398
 msgid "Logo da Home (PT)"
 msgstr ""
 
-#: opac/webapp/admin/views.py:399
+#: build/lib/opac/webapp/admin/views.py:399 opac/webapp/admin/views.py:399
 msgid "Logo da Home (EN)"
 msgstr ""
 
-#: opac/webapp/admin/views.py:400
+#: build/lib/opac/webapp/admin/views.py:400 opac/webapp/admin/views.py:400
 msgid "Logo da Home (ES)"
 msgstr ""
 
-#: opac/webapp/admin/views.py:401
+#: build/lib/opac/webapp/admin/views.py:401 opac/webapp/admin/views.py:401
 msgid "Logo do cabeçalho (PT)"
 msgstr ""
 
-#: opac/webapp/admin/views.py:402
+#: build/lib/opac/webapp/admin/views.py:402 opac/webapp/admin/views.py:402
 msgid "Logo do cabeçalho (EN)"
 msgstr ""
 
-#: opac/webapp/admin/views.py:403
+#: build/lib/opac/webapp/admin/views.py:403 opac/webapp/admin/views.py:403
 msgid "Logo do cabeçalho (ES)"
 msgstr ""
 
-#: opac/webapp/admin/views.py:404
+#: build/lib/opac/webapp/admin/views.py:404 opac/webapp/admin/views.py:404
 msgid "Logo do menu (PT)"
 msgstr ""
 
-#: opac/webapp/admin/views.py:405 opac/webapp/admin/views.py:406
+#: build/lib/opac/webapp/admin/views.py:405
+#: build/lib/opac/webapp/admin/views.py:406 opac/webapp/admin/views.py:405
+#: opac/webapp/admin/views.py:406
 msgid "Logo do menu (ES)"
 msgstr ""
 
-#: opac/webapp/admin/views.py:407
+#: build/lib/opac/webapp/admin/views.py:407 opac/webapp/admin/views.py:407
 msgid "Logo do menu (drop)"
 msgstr ""
 
-#: opac/webapp/admin/views.py:408
+#: build/lib/opac/webapp/admin/views.py:408 opac/webapp/admin/views.py:408
 msgid "Logo do rodapé"
 msgstr ""
 
-#: opac/webapp/admin/views.py:451
+#: build/lib/opac/webapp/admin/views.py:451 opac/webapp/admin/views.py:451
 msgid "Id Periódico"
 msgstr ""
 
-#: opac/webapp/admin/views.py:453
+#: build/lib/opac/webapp/admin/views.py:453 opac/webapp/admin/views.py:453
 msgid "Linha do tempo"
 msgstr ""
 
-#: opac/webapp/admin/views.py:454
+#: build/lib/opac/webapp/admin/views.py:454 opac/webapp/admin/views.py:454
 msgid "Categorias de assunto"
 msgstr ""
 
-#: opac/webapp/admin/views.py:455
+#: build/lib/opac/webapp/admin/views.py:455 opac/webapp/admin/views.py:455
 msgid "Áreas de estudo"
 msgstr ""
 
-#: opac/webapp/admin/views.py:456
+#: build/lib/opac/webapp/admin/views.py:456 opac/webapp/admin/views.py:456
 msgid "Redes sociais"
 msgstr ""
 
+#: build/lib/opac/webapp/admin/views.py:457
+#: build/lib/opac/webapp/admin/views.py:611
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:30
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:73
 #: opac/webapp/admin/views.py:457 opac/webapp/admin/views.py:611
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:30
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:73
 msgid "Título"
 msgstr ""
 
-#: opac/webapp/admin/views.py:458
+#: build/lib/opac/webapp/admin/views.py:458 opac/webapp/admin/views.py:458
 msgid "Título ISO"
 msgstr ""
 
-#: opac/webapp/admin/views.py:459
+#: build/lib/opac/webapp/admin/views.py:459 opac/webapp/admin/views.py:459
 msgid "Título curto"
 msgstr ""
 
-#: opac/webapp/admin/views.py:460 opac/webapp/admin/views.py:538
-#: opac/webapp/admin/views.py:614
+#: build/lib/opac/webapp/admin/views.py:460
+#: build/lib/opac/webapp/admin/views.py:538
+#: build/lib/opac/webapp/admin/views.py:614 opac/webapp/admin/views.py:460
+#: opac/webapp/admin/views.py:538 opac/webapp/admin/views.py:614
 msgid "Criado"
 msgstr ""
 
-#: opac/webapp/admin/views.py:461 opac/webapp/admin/views.py:539
-#: opac/webapp/admin/views.py:615
+#: build/lib/opac/webapp/admin/views.py:461
+#: build/lib/opac/webapp/admin/views.py:539
+#: build/lib/opac/webapp/admin/views.py:615 opac/webapp/admin/views.py:461
+#: opac/webapp/admin/views.py:539 opac/webapp/admin/views.py:615
 msgid "Atualizado"
 msgstr ""
 
-#: opac/webapp/admin/views.py:463
+#: build/lib/opac/webapp/admin/views.py:463 opac/webapp/admin/views.py:463
 msgid "ISSN SciELO"
 msgstr ""
 
-#: opac/webapp/admin/views.py:464
+#: build/lib/opac/webapp/admin/views.py:464 opac/webapp/admin/views.py:464
 msgid "ISSN impresso"
 msgstr ""
 
-#: opac/webapp/admin/views.py:465
+#: build/lib/opac/webapp/admin/views.py:465 opac/webapp/admin/views.py:465
 msgid "ISSN eletrônico"
 msgstr ""
 
-#: opac/webapp/admin/views.py:466
+#: build/lib/opac/webapp/admin/views.py:466 opac/webapp/admin/views.py:466
 msgid "Descritores de assunto"
 msgstr ""
 
-#: opac/webapp/admin/views.py:467
+#: build/lib/opac/webapp/admin/views.py:467 opac/webapp/admin/views.py:467
 msgid "Url da submissão online"
 msgstr ""
 
-#: opac/webapp/admin/views.py:468
+#: build/lib/opac/webapp/admin/views.py:468 opac/webapp/admin/views.py:468
 msgid "Url do capa"
 msgstr ""
 
-#: opac/webapp/admin/views.py:469
+#: build/lib/opac/webapp/admin/views.py:469 opac/webapp/admin/views.py:469
 msgid "Url do logotipo"
 msgstr ""
 
-#: opac/webapp/admin/views.py:470
+#: build/lib/opac/webapp/admin/views.py:470 opac/webapp/admin/views.py:470
 msgid "Outros títulos"
 msgstr ""
 
-#: opac/webapp/admin/views.py:471
+#: build/lib/opac/webapp/admin/views.py:471 opac/webapp/admin/views.py:471
 msgid "Nome da editora"
 msgstr ""
 
-#: opac/webapp/admin/views.py:472
+#: build/lib/opac/webapp/admin/views.py:472 opac/webapp/admin/views.py:472
 msgid "País da editora"
 msgstr ""
 
-#: opac/webapp/admin/views.py:473
+#: build/lib/opac/webapp/admin/views.py:473 opac/webapp/admin/views.py:473
 msgid "Estado da editora"
 msgstr ""
 
-#: opac/webapp/admin/views.py:474
+#: build/lib/opac/webapp/admin/views.py:474 opac/webapp/admin/views.py:474
 msgid "Cidade da editora"
 msgstr ""
 
-#: opac/webapp/admin/views.py:475
+#: build/lib/opac/webapp/admin/views.py:475 opac/webapp/admin/views.py:475
 msgid "Endereço da editora"
 msgstr ""
 
-#: opac/webapp/admin/views.py:476
+#: build/lib/opac/webapp/admin/views.py:476 opac/webapp/admin/views.py:476
 msgid "Telefone da editora"
 msgstr ""
 
-#: opac/webapp/admin/views.py:477
+#: build/lib/opac/webapp/admin/views.py:477 opac/webapp/admin/views.py:477
 msgid "Missão"
 msgstr ""
 
-#: opac/webapp/admin/views.py:478
+#: build/lib/opac/webapp/admin/views.py:478 opac/webapp/admin/views.py:478
 msgid "No índice"
 msgstr ""
 
-#: opac/webapp/admin/views.py:479
+#: build/lib/opac/webapp/admin/views.py:479 opac/webapp/admin/views.py:479
 msgid "Patrocinadores"
 msgstr ""
 
-#: opac/webapp/admin/views.py:480
+#: build/lib/opac/webapp/admin/views.py:480 opac/webapp/admin/views.py:480
 msgid "Ref periódico anterior"
 msgstr ""
 
-#: opac/webapp/admin/views.py:481
+#: build/lib/opac/webapp/admin/views.py:481 opac/webapp/admin/views.py:481
 msgid "Situação atual"
 msgstr ""
 
-#: opac/webapp/admin/views.py:482
+#: build/lib/opac/webapp/admin/views.py:482 opac/webapp/admin/views.py:482
 msgid "Total de números"
 msgstr ""
 
-#: opac/webapp/admin/views.py:483 opac/webapp/admin/views.py:548
-#: opac/webapp/admin/views.py:618
+#: build/lib/opac/webapp/admin/views.py:483
+#: build/lib/opac/webapp/admin/views.py:548
+#: build/lib/opac/webapp/admin/views.py:618 opac/webapp/admin/views.py:483
+#: opac/webapp/admin/views.py:548 opac/webapp/admin/views.py:618
 msgid "Publicado?"
 msgstr ""
 
-#: opac/webapp/admin/views.py:484 opac/webapp/admin/views.py:549
-#: opac/webapp/admin/views.py:619
+#: build/lib/opac/webapp/admin/views.py:484
+#: build/lib/opac/webapp/admin/views.py:549
+#: build/lib/opac/webapp/admin/views.py:619 opac/webapp/admin/views.py:484
+#: opac/webapp/admin/views.py:549 opac/webapp/admin/views.py:619
 msgid "Motivo de despublicação"
 msgstr ""
 
-#: opac/webapp/admin/views.py:485 opac/webapp/admin/views.py:551
-#: opac/webapp/admin/views.py:620
+#: build/lib/opac/webapp/admin/views.py:485
+#: build/lib/opac/webapp/admin/views.py:551
+#: build/lib/opac/webapp/admin/views.py:620 opac/webapp/admin/views.py:485
+#: opac/webapp/admin/views.py:551 opac/webapp/admin/views.py:620
 msgid "Segmento de URL"
 msgstr ""
 
-#: opac/webapp/admin/views.py:488 opac/webapp/admin/views.py:554
-#: opac/webapp/admin/views.py:633
+#: build/lib/opac/webapp/admin/views.py:488
+#: build/lib/opac/webapp/admin/views.py:554
+#: build/lib/opac/webapp/admin/views.py:633 opac/webapp/admin/views.py:488
+#: opac/webapp/admin/views.py:554 opac/webapp/admin/views.py:633
 msgid "Publicar"
 msgstr ""
 
-#: opac/webapp/admin/views.py:493
+#: build/lib/opac/webapp/admin/views.py:493 opac/webapp/admin/views.py:493
 msgid "Periódico(s) publicado(s) com sucesso!!"
 msgstr ""
 
-#: opac/webapp/admin/views.py:495
+#: build/lib/opac/webapp/admin/views.py:495 opac/webapp/admin/views.py:495
 msgid "Ocorreu um erro tentando publicar o(s) periódico(s)!!"
 msgstr ""
 
-#: opac/webapp/admin/views.py:501
+#: build/lib/opac/webapp/admin/views.py:501 opac/webapp/admin/views.py:501
 msgid "Periódico(s) despublicado com sucesso!!"
 msgstr ""
 
-#: opac/webapp/admin/views.py:504
+#: build/lib/opac/webapp/admin/views.py:504 opac/webapp/admin/views.py:504
 #, python-format
 msgid "Ocorreu um erro tentando despublicar o(s) periódico(s)!!. Erro: %(ex)s"
 msgstr ""
 
-#: opac/webapp/admin/views.py:508 opac/webapp/admin/views.py:576
-#: opac/webapp/admin/views.py:656
+#: build/lib/opac/webapp/admin/views.py:508
+#: build/lib/opac/webapp/admin/views.py:576
+#: build/lib/opac/webapp/admin/views.py:656 opac/webapp/admin/views.py:508
+#: opac/webapp/admin/views.py:576 opac/webapp/admin/views.py:656
 #, python-format
 msgid "Despublicar por %s"
 msgstr ""
 
-#: opac/webapp/admin/views.py:532
+#: build/lib/opac/webapp/admin/views.py:532 opac/webapp/admin/views.py:532
 msgid "Id Número"
 msgstr ""
 
-#: opac/webapp/admin/views.py:534 opac/webapp/admin/views.py:624
+#: build/lib/opac/webapp/admin/views.py:534
+#: build/lib/opac/webapp/admin/views.py:624 opac/webapp/admin/views.py:534
+#: opac/webapp/admin/views.py:624
 msgid "Seções"
 msgstr ""
 
-#: opac/webapp/admin/views.py:535
+#: build/lib/opac/webapp/admin/views.py:535 opac/webapp/admin/views.py:535
 msgid "Url da capa"
 msgstr ""
 
+#: build/lib/opac/webapp/admin/views.py:536
+#: build/lib/opac/webapp/templates/collection/list_feed_content.html:3
+#: build/lib/opac/webapp/templates/issue/grid.html:40
+#: build/lib/opac/webapp/templates/news/includes/issue_last_row.html:7
 #: opac/webapp/admin/views.py:536
 #: opac/webapp/templates/collection/list_feed_content.html:3
 #: opac/webapp/templates/issue/grid.html:40
@@ -783,26 +914,31 @@ msgstr ""
 msgid "Volume"
 msgstr ""
 
-#: opac/webapp/admin/views.py:540
+#: build/lib/opac/webapp/admin/views.py:540 opac/webapp/admin/views.py:540
 msgid "Tipo"
 msgstr ""
 
-#: opac/webapp/admin/views.py:541
+#: build/lib/opac/webapp/admin/views.py:541 opac/webapp/admin/views.py:541
 msgid "Texto do suplemento"
 msgstr ""
 
-#: opac/webapp/admin/views.py:542
+#: build/lib/opac/webapp/admin/views.py:542 opac/webapp/admin/views.py:542
 msgid "Texto do especial"
 msgstr ""
 
-#: opac/webapp/admin/views.py:543
+#: build/lib/opac/webapp/admin/views.py:543 opac/webapp/admin/views.py:543
 msgid "Mês inicial"
 msgstr ""
 
-#: opac/webapp/admin/views.py:544
+#: build/lib/opac/webapp/admin/views.py:544 opac/webapp/admin/views.py:544
 msgid "Mês final"
 msgstr ""
 
+#: build/lib/opac/webapp/admin/views.py:545
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:25
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:68
+#: build/lib/opac/webapp/templates/issue/grid.html:39
+#: build/lib/opac/webapp/templates/news/includes/issue_last_row.html:5
 #: opac/webapp/admin/views.py:545
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:25
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:68
@@ -811,64 +947,74 @@ msgstr ""
 msgid "Ano"
 msgstr ""
 
-#: opac/webapp/admin/views.py:546
+#: build/lib/opac/webapp/admin/views.py:546 opac/webapp/admin/views.py:546
 msgid "Etiqueta"
 msgstr ""
 
-#: opac/webapp/admin/views.py:550 opac/webapp/admin/views.py:621
+#: build/lib/opac/webapp/admin/views.py:550
+#: build/lib/opac/webapp/admin/views.py:621 opac/webapp/admin/views.py:550
+#: opac/webapp/admin/views.py:621
 msgid "PID"
 msgstr ""
 
-#: opac/webapp/admin/views.py:559
+#: build/lib/opac/webapp/admin/views.py:559 opac/webapp/admin/views.py:559
 msgid "Número(s) publicado(s) com sucesso!!"
 msgstr ""
 
-#: opac/webapp/admin/views.py:562 opac/webapp/admin/views.py:642
+#: build/lib/opac/webapp/admin/views.py:562
+#: build/lib/opac/webapp/admin/views.py:642 opac/webapp/admin/views.py:562
+#: opac/webapp/admin/views.py:642
 #, python-format
 msgid "Ocorreu um erro tentando publicar o(s) número(s)!!. Erro: %(ex)s"
 msgstr ""
 
-#: opac/webapp/admin/views.py:569
+#: build/lib/opac/webapp/admin/views.py:569 opac/webapp/admin/views.py:569
 msgid "Número(s) despublicado(s) com sucesso!!"
 msgstr ""
 
-#: opac/webapp/admin/views.py:572 opac/webapp/admin/views.py:652
+#: build/lib/opac/webapp/admin/views.py:572
+#: build/lib/opac/webapp/admin/views.py:652 opac/webapp/admin/views.py:572
+#: opac/webapp/admin/views.py:652
 #, python-format
 msgid "Ocorreu um erro tentando despublicar o(s) número(s)!!. Erro: %(ex)s"
 msgstr ""
 
-#: opac/webapp/admin/views.py:608
+#: build/lib/opac/webapp/admin/views.py:608 opac/webapp/admin/views.py:608
 msgid "Id Artigo"
 msgstr ""
 
-#: opac/webapp/admin/views.py:612
+#: build/lib/opac/webapp/admin/views.py:612 opac/webapp/admin/views.py:612
 msgid "Seção"
 msgstr ""
 
-#: opac/webapp/admin/views.py:613
+#: build/lib/opac/webapp/admin/views.py:613 opac/webapp/admin/views.py:613
 msgid "É Ahead of Print?"
 msgstr ""
 
-#: opac/webapp/admin/views.py:616
+#: build/lib/opac/webapp/admin/views.py:616 opac/webapp/admin/views.py:616
 msgid "HTML's"
 msgstr ""
 
-#: opac/webapp/admin/views.py:617
+#: build/lib/opac/webapp/admin/views.py:617 opac/webapp/admin/views.py:617
 msgid "Chave de domínio"
 msgstr ""
 
-#: opac/webapp/admin/views.py:622
+#: build/lib/opac/webapp/admin/views.py:622 opac/webapp/admin/views.py:622
 msgid "Idioma original"
 msgstr ""
 
-#: opac/webapp/admin/views.py:623
+#: build/lib/opac/webapp/admin/views.py:623 opac/webapp/admin/views.py:623
 msgid "Idiomas das traduções"
 msgstr ""
 
-#: opac/webapp/admin/views.py:625
+#: build/lib/opac/webapp/admin/views.py:625 opac/webapp/admin/views.py:625
 msgid "Autores"
 msgstr ""
 
+#: build/lib/opac/webapp/admin/views.py:626
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:29
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:72
+#: build/lib/opac/webapp/templates/issue/toc.html:176
 #: opac/webapp/admin/views.py:626
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:29
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:72
@@ -876,198 +1022,230 @@ msgstr ""
 msgid "Resumo"
 msgstr ""
 
-#: opac/webapp/admin/views.py:628
+#: build/lib/opac/webapp/admin/views.py:628 opac/webapp/admin/views.py:628
 msgid "DOI"
 msgstr ""
 
-#: opac/webapp/admin/views.py:629
+#: build/lib/opac/webapp/admin/views.py:629 opac/webapp/admin/views.py:629
 msgid "Idiomas"
 msgstr ""
 
-#: opac/webapp/admin/views.py:630
+#: build/lib/opac/webapp/admin/views.py:630 opac/webapp/admin/views.py:630
 msgid "Idiomas dos resumos"
 msgstr ""
 
-#: opac/webapp/admin/views.py:638
+#: build/lib/opac/webapp/admin/views.py:638 opac/webapp/admin/views.py:638
 msgid "Artigo(s) publicado com sucesso!!"
 msgstr ""
 
-#: opac/webapp/admin/views.py:649
+#: build/lib/opac/webapp/admin/views.py:649 opac/webapp/admin/views.py:649
 msgid "Artigo(s) despublicado com sucesso!!"
 msgstr ""
 
-#: opac/webapp/admin/views.py:679
+#: build/lib/opac/webapp/admin/views.py:679 opac/webapp/admin/views.py:679
 msgid "Conteúdo"
 msgstr ""
 
-#: opac/webapp/admin/views.py:681 opac/webapp/admin/views.py:901
+#: build/lib/opac/webapp/admin/views.py:681
+#: build/lib/opac/webapp/admin/views.py:901 opac/webapp/admin/views.py:681
+#: opac/webapp/admin/views.py:901
 msgid "Descrição"
 msgstr ""
 
-#: opac/webapp/admin/views.py:682 opac/webapp/admin/views.py:898
+#: build/lib/opac/webapp/admin/views.py:682
+#: build/lib/opac/webapp/admin/views.py:898 opac/webapp/admin/views.py:682
+#: opac/webapp/admin/views.py:898
 msgid "Data de Criação"
 msgstr ""
 
-#: opac/webapp/admin/views.py:683
+#: build/lib/opac/webapp/admin/views.py:683 opac/webapp/admin/views.py:683
 msgid "Data de Atualização"
 msgstr ""
 
-#: opac/webapp/admin/views.py:897
+#: build/lib/opac/webapp/admin/views.py:897 opac/webapp/admin/views.py:897
 msgid "Ação"
 msgstr ""
 
-#: opac/webapp/admin/views.py:899
+#: build/lib/opac/webapp/admin/views.py:899 opac/webapp/admin/views.py:899
 msgid "Modelo Auditado"
 msgstr ""
 
-#: opac/webapp/admin/views.py:900
+#: build/lib/opac/webapp/admin/views.py:900 opac/webapp/admin/views.py:900
 msgid "Id Auditado"
 msgstr ""
 
-#: opac/webapp/admin/views.py:902
+#: build/lib/opac/webapp/admin/views.py:902 opac/webapp/admin/views.py:902
 msgid "Dados dos campos"
 msgstr ""
 
-#: opac/webapp/main/views.py:29
+#: build/lib/opac/webapp/main/views.py:34 opac/webapp/main/views.py:34
 msgid "O periódico está indisponível por motivo de: "
 msgstr ""
 
-#: opac/webapp/main/views.py:30
+#: build/lib/opac/webapp/main/views.py:35 opac/webapp/main/views.py:35
 msgid "O número está indisponível por motivo de: "
 msgstr ""
 
-#: opac/webapp/main/views.py:31
+#: build/lib/opac/webapp/main/views.py:36 opac/webapp/main/views.py:36
 msgid "O artigo está indisponível por motivo de: "
 msgstr ""
 
-#: opac/webapp/main/views.py:78
+#: build/lib/opac/webapp/main/views.py:127 opac/webapp/main/views.py:127
 msgid "Código de idioma inválido"
 msgstr ""
 
-#: opac/webapp/main/views.py:148
+#: build/lib/opac/webapp/main/views.py:197 opac/webapp/main/views.py:197
 msgid "Últimos periódicos inseridos na coleção"
 msgstr ""
 
-#: opac/webapp/main/views.py:149
+#: build/lib/opac/webapp/main/views.py:198 opac/webapp/main/views.py:198
 #, python-format
 msgid "10 últimos periódicos inseridos na coleção %s"
 msgstr ""
 
-#: opac/webapp/main/views.py:208
+#: build/lib/opac/webapp/main/views.py:257 opac/webapp/main/views.py:257
 msgid "Página não encontrada"
 msgstr ""
 
-#: opac/webapp/main/views.py:232 opac/webapp/main/views.py:322
+#: build/lib/opac/webapp/main/views.py:281
+#: build/lib/opac/webapp/main/views.py:371 opac/webapp/main/views.py:281
+#: opac/webapp/main/views.py:371
 #, python-format
 msgid "Requsição inválida ao tentar acessar o artigo com pid: %s"
 msgstr ""
 
-#: opac/webapp/main/views.py:240 opac/webapp/main/views.py:290
-#: opac/webapp/main/views.py:334 opac/webapp/main/views.py:403
-#: opac/webapp/main/views.py:450 opac/webapp/main/views.py:597
-#: opac/webapp/main/views.py:614 opac/webapp/main/views.py:1055
+#: build/lib/opac/webapp/main/views.py:289
+#: build/lib/opac/webapp/main/views.py:339
+#: build/lib/opac/webapp/main/views.py:383
+#: build/lib/opac/webapp/main/views.py:452
+#: build/lib/opac/webapp/main/views.py:500
+#: build/lib/opac/webapp/main/views.py:647
+#: build/lib/opac/webapp/main/views.py:664
+#: build/lib/opac/webapp/main/views.py:1127 opac/webapp/main/views.py:289
+#: opac/webapp/main/views.py:339 opac/webapp/main/views.py:383
+#: opac/webapp/main/views.py:452 opac/webapp/main/views.py:500
+#: opac/webapp/main/views.py:647 opac/webapp/main/views.py:664
+#: opac/webapp/main/views.py:1127
 msgid "Periódico não encontrado"
 msgstr ""
 
-#: opac/webapp/main/views.py:252 opac/webapp/main/views.py:664
-#: opac/webapp/main/views.py:723 opac/webapp/main/views.py:1064
+#: build/lib/opac/webapp/main/views.py:301
+#: build/lib/opac/webapp/main/views.py:714
+#: build/lib/opac/webapp/main/views.py:773
+#: build/lib/opac/webapp/main/views.py:1136 opac/webapp/main/views.py:301
+#: opac/webapp/main/views.py:714 opac/webapp/main/views.py:773
+#: opac/webapp/main/views.py:1136
 msgid "Número não encontrado"
 msgstr ""
 
-#: opac/webapp/main/views.py:270 opac/webapp/main/views.py:305
-#: opac/webapp/main/views.py:774 opac/webapp/main/views.py:805
-#: opac/webapp/main/views.py:881 opac/webapp/main/views.py:884
-#: opac/webapp/main/views.py:988
+#: build/lib/opac/webapp/main/views.py:319
+#: build/lib/opac/webapp/main/views.py:354
+#: build/lib/opac/webapp/main/views.py:825
+#: build/lib/opac/webapp/main/views.py:910
+#: build/lib/opac/webapp/main/views.py:1060 opac/webapp/main/views.py:319
+#: opac/webapp/main/views.py:354 opac/webapp/main/views.py:825
+#: opac/webapp/main/views.py:910 opac/webapp/main/views.py:1060
 msgid "Artigo não encontrado"
 msgstr ""
 
-#: opac/webapp/main/views.py:427
+#: build/lib/opac/webapp/main/views.py:476 opac/webapp/main/views.py:476
 msgid "Artigo sem título"
 msgstr ""
 
-#: opac/webapp/main/views.py:498 opac/webapp/main/views.py:515
+#: build/lib/opac/webapp/main/views.py:548
+#: build/lib/opac/webapp/main/views.py:565 opac/webapp/main/views.py:548
+#: opac/webapp/main/views.py:565
 msgid "Requisição inválida. Deve ser por ajax"
 msgstr ""
 
-#: opac/webapp/main/views.py:531
+#: build/lib/opac/webapp/main/views.py:581 opac/webapp/main/views.py:581
 msgid ""
 "Parámetro \"filter\" é inválido, deve ser \"areas\", \"wos\" ou "
 "\"publisher\"."
 msgstr ""
 
-#: opac/webapp/main/views.py:540
+#: build/lib/opac/webapp/main/views.py:590 opac/webapp/main/views.py:590
 msgid "Parámetro \"extension\" é inválido, deve ser \"csv\" ou \"xls\"."
 msgstr ""
 
-#: opac/webapp/main/views.py:542
+#: build/lib/opac/webapp/main/views.py:592 opac/webapp/main/views.py:592
 msgid ""
 "Parámetro \"list_type\" é inválido, deve ser: \"alpha\", \"areas\", "
 "\"wos\" ou \"publisher\"."
 msgstr ""
 
-#: opac/webapp/main/views.py:563
+#: build/lib/opac/webapp/main/views.py:613 opac/webapp/main/views.py:613
 msgid "Requisição inválida, deve ser ajax."
 msgstr ""
 
-#: opac/webapp/main/views.py:572
+#: build/lib/opac/webapp/main/views.py:622 opac/webapp/main/views.py:622
 msgid "Periódico não permite envio de email."
 msgstr ""
 
-#: opac/webapp/main/views.py:590
+#: build/lib/opac/webapp/main/views.py:640 opac/webapp/main/views.py:640
 msgid "Requisição inválida, captcha inválido."
 msgstr ""
 
-#: opac/webapp/main/views.py:796 opac/webapp/main/views.py:983
+#: build/lib/opac/webapp/main/views.py:901
+#: build/lib/opac/webapp/main/views.py:1055 opac/webapp/main/views.py:901
+#: opac/webapp/main/views.py:1055
 msgid "Issue não encontrado"
 msgstr ""
 
-#: opac/webapp/main/views.py:841 opac/webapp/main/views.py:847
-#: opac/webapp/main/views.py:1020 opac/webapp/main/views.py:1028
-#: opac/webapp/main/views.py:1030
+#: build/lib/opac/webapp/main/views.py:943
+#: build/lib/opac/webapp/main/views.py:949
+#: build/lib/opac/webapp/main/views.py:1092
+#: build/lib/opac/webapp/main/views.py:1100
+#: build/lib/opac/webapp/main/views.py:1102 opac/webapp/main/views.py:943
+#: opac/webapp/main/views.py:949 opac/webapp/main/views.py:1092
+#: opac/webapp/main/views.py:1100 opac/webapp/main/views.py:1102
 msgid "PDF do Artigo não encontrado"
 msgstr ""
 
-#: opac/webapp/main/views.py:857
-msgid "HTML do Artigo não encontrado"
-msgstr ""
-
-#: opac/webapp/main/views.py:871
+#: build/lib/opac/webapp/main/views.py:954 opac/webapp/main/views.py:954
 msgid "HTML do Artigo não encontrado ou indisponível"
 msgstr ""
 
-#: opac/webapp/main/views.py:930
+#: build/lib/opac/webapp/main/views.py:1001 opac/webapp/main/views.py:1001
 msgid "Parâmetros insuficientes para obter o EPDF do artigo"
 msgstr ""
 
-#: opac/webapp/main/views.py:947
+#: build/lib/opac/webapp/main/views.py:1022 opac/webapp/main/views.py:1022
 msgid "Recruso não encontrado"
 msgstr ""
 
-#: opac/webapp/main/views.py:952
-msgid "Recurso não encontrado"
-msgstr ""
-
-#: opac/webapp/main/views.py:969
+#: build/lib/opac/webapp/main/views.py:1041 opac/webapp/main/views.py:1041
 msgid "Recurso do Artigo não encontrado. Caminho inválido!"
 msgstr ""
 
-#: opac/webapp/main/views.py:1082
+#: build/lib/opac/webapp/main/views.py:1154 opac/webapp/main/views.py:1154
 msgid "PDF do artigo não foi encontrado"
 msgstr ""
 
-#: opac/webapp/main/views.py:1110 opac/webapp/main/views.py:1141
+#: build/lib/opac/webapp/main/views.py:1169
+#: build/lib/opac/webapp/main/views.py:1200 opac/webapp/main/views.py:1169
+#: opac/webapp/main/views.py:1200
 msgid "Requisição inválida."
 msgstr ""
 
+#: build/lib/opac/webapp/templates/admin/index.html:7
 #: opac/webapp/templates/admin/index.html:7
 msgid "da coleção"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/admin/index.html:12
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu.html:31
 #: opac/webapp/templates/admin/index.html:12
 #: opac/webapp/templates/collection/includes/levelMenu.html:31
 msgid "Periódicos"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/admin/index.html:15
+#: build/lib/opac/webapp/templates/admin/index.html:22
+#: build/lib/opac/webapp/templates/admin/index.html:35
+#: build/lib/opac/webapp/templates/admin/index.html:42
+#: build/lib/opac/webapp/templates/admin/index.html:55
+#: build/lib/opac/webapp/templates/admin/index.html:62
 #: opac/webapp/templates/admin/index.html:15
 #: opac/webapp/templates/admin/index.html:22
 #: opac/webapp/templates/admin/index.html:35
@@ -1077,6 +1255,12 @@ msgstr ""
 msgid "Publicados"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/admin/index.html:16
+#: build/lib/opac/webapp/templates/admin/index.html:36
+#: build/lib/opac/webapp/templates/admin/index.html:56
+#: build/lib/opac/webapp/templates/admin/index.html:75
+#: build/lib/opac/webapp/templates/admin/index.html:85
+#: build/lib/opac/webapp/templates/admin/index.html:95
 #: opac/webapp/templates/admin/index.html:16
 #: opac/webapp/templates/admin/index.html:36
 #: opac/webapp/templates/admin/index.html:56
@@ -1086,58 +1270,78 @@ msgstr ""
 msgid "Total"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/admin/index.html:32
 #: opac/webapp/templates/admin/index.html:32
 msgid "Fascícluos"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/admin/index.html:52
 #: opac/webapp/templates/admin/index.html:52
 msgid "Artigos"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/admin/index.html:72
 #: opac/webapp/templates/admin/index.html:72
 msgid "News"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/admin/index.html:82
 #: opac/webapp/templates/admin/index.html:82
 msgid "Sponsors"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/admin/index.html:92
 #: opac/webapp/templates/admin/index.html:92
 msgid "Press Releases"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/admin/auth/reset.html:9
+#: build/lib/opac/webapp/templates/admin/auth/reset_with_token.html:9
+#: build/lib/opac/webapp/templates/admin/opac_base.html:13
 #: opac/webapp/templates/admin/auth/reset.html:9
 #: opac/webapp/templates/admin/auth/reset_with_token.html:9
 #: opac/webapp/templates/admin/opac_base.html:13
 msgid "Recuperar a senha"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/admin/opac_base.html:14
 #: opac/webapp/templates/admin/opac_base.html:14
 msgid "Terminar sessão"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/admin/auth/login.html:11
+#: build/lib/opac/webapp/templates/admin/auth/login.html:20
+#: build/lib/opac/webapp/templates/admin/opac_base.html:18
 #: opac/webapp/templates/admin/auth/login.html:11
 #: opac/webapp/templates/admin/auth/login.html:20
 #: opac/webapp/templates/admin/opac_base.html:18
 msgid "Iniciar sessão"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/admin/audit_log/fields_data_table.html:4
 #: opac/webapp/templates/admin/audit_log/fields_data_table.html:4
 msgid "Campo: "
 msgstr ""
 
+#: build/lib/opac/webapp/templates/admin/audit_log/fields_data_table.html:5
 #: opac/webapp/templates/admin/audit_log/fields_data_table.html:5
 msgid "Valor anterior: "
 msgstr ""
 
+#: build/lib/opac/webapp/templates/admin/audit_log/fields_data_table.html:6
 #: opac/webapp/templates/admin/audit_log/fields_data_table.html:6
 msgid "Valor novo: "
 msgstr ""
 
+#: build/lib/opac/webapp/templates/admin/auth/login.html:13
 #: opac/webapp/templates/admin/auth/login.html:13
 msgid "Você já iniciou sessão!"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/admin/auth/login.html:24
+#: build/lib/opac/webapp/templates/admin/auth/reset.html:13
+#: build/lib/opac/webapp/templates/admin/auth/reset_with_token.html:13
+#: build/lib/opac/webapp/templates/includes/error_form.html:60
 #: opac/webapp/templates/admin/auth/login.html:24
 #: opac/webapp/templates/admin/auth/reset.html:13
 #: opac/webapp/templates/admin/auth/reset_with_token.html:13
@@ -1145,14 +1349,17 @@ msgstr ""
 msgid "Enviar"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/admin/auth/login.html:28
 #: opac/webapp/templates/admin/auth/login.html:28
 msgid "Esqueci a senha?"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/admin/auth/unconfirm_email.html:7
 #: opac/webapp/templates/admin/auth/unconfirm_email.html:7
 msgid "Email não confirmado!"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/admin/auth/unconfirm_email.html:9
 #: opac/webapp/templates/admin/auth/unconfirm_email.html:9
 msgid ""
 "Você <strong>deve</strong> confirmar seu email.<br>\n"
@@ -1160,6 +1367,7 @@ msgid ""
 "administrador.</strong>"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/admin/pages/edit.html:7
 #: opac/webapp/templates/admin/pages/edit.html:7
 msgid ""
 "<strong>Atenção:</strong> ao selecionar um <strong>periódico</strong> "
@@ -1168,6 +1376,11 @@ msgid ""
 "<em>Sobre o SciELO</em>. "
 msgstr ""
 
+#: build/lib/opac/webapp/templates/article/includes/alternative_header.html:7
+#: build/lib/opac/webapp/templates/collection/includes/header.html:7
+#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:7
+#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:7
+#: build/lib/opac/webapp/templates/journal/includes/header.html:8
 #: opac/webapp/templates/article/includes/alternative_header.html:7
 #: opac/webapp/templates/collection/includes/header.html:7
 #: opac/webapp/templates/issue/includes/alternative_header.html:7
@@ -1176,6 +1389,10 @@ msgstr ""
 msgid "Abrir menu"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/article/includes/alternative_header.html:9
+#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:9
+#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:9
+#: build/lib/opac/webapp/templates/journal/includes/header.html:10
 #: opac/webapp/templates/article/includes/alternative_header.html:9
 #: opac/webapp/templates/issue/includes/alternative_header.html:9
 #: opac/webapp/templates/journal/includes/alternative_header.html:9
@@ -1183,6 +1400,11 @@ msgstr ""
 msgid "Ir para a homepage da coleção: "
 msgstr ""
 
+#: build/lib/opac/webapp/templates/article/includes/alternative_header.html:42
+#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:7
+#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:121
+#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:117
+#: build/lib/opac/webapp/templates/journal/includes/header.html:118
 #: opac/webapp/templates/article/includes/alternative_header.html:42
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:7
 #: opac/webapp/templates/issue/includes/alternative_header.html:121
@@ -1191,6 +1413,11 @@ msgstr ""
 msgid "Submissão de manuscritos"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/article/includes/alternative_header.html:48
+#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:16
+#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:127
+#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:123
+#: build/lib/opac/webapp/templates/journal/includes/header.html:124
 #: opac/webapp/templates/article/includes/alternative_header.html:48
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:16
 #: opac/webapp/templates/issue/includes/alternative_header.html:127
@@ -1199,6 +1426,11 @@ msgstr ""
 msgid "Sobre o periódico"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/article/includes/alternative_header.html:53
+#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:10
+#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:132
+#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:128
+#: build/lib/opac/webapp/templates/journal/includes/header.html:129
 #: opac/webapp/templates/article/includes/alternative_header.html:53
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:10
 #: opac/webapp/templates/issue/includes/alternative_header.html:132
@@ -1207,6 +1439,11 @@ msgstr ""
 msgid "Corpo Editorial"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/article/includes/alternative_header.html:58
+#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:13
+#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:137
+#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:133
+#: build/lib/opac/webapp/templates/journal/includes/header.html:134
 #: opac/webapp/templates/article/includes/alternative_header.html:58
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:13
 #: opac/webapp/templates/issue/includes/alternative_header.html:137
@@ -1215,6 +1452,11 @@ msgstr ""
 msgid "Instruções aos autores"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/article/includes/alternative_header.html:63
+#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:19
+#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:142
+#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:138
+#: build/lib/opac/webapp/templates/journal/includes/header.html:140
 #: opac/webapp/templates/article/includes/alternative_header.html:63
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:19
 #: opac/webapp/templates/issue/includes/alternative_header.html:142
@@ -1223,56 +1465,81 @@ msgstr ""
 msgid "Contato"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:2
+#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:60
 #: opac/webapp/templates/article/includes/floating_menu.html:2
 #: opac/webapp/templates/article/includes/floating_menu.html:60
 msgid "Ir para o topo"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:6
+#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:65
 #: opac/webapp/templates/article/includes/floating_menu.html:6
 #: opac/webapp/templates/article/includes/floating_menu.html:65
 msgid "PDFs"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:26
+#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:77
 #: opac/webapp/templates/article/includes/floating_menu.html:26
 #: opac/webapp/templates/article/includes/floating_menu.html:77
 msgid "Figuras e tabelas"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:32
+#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:83
 #: opac/webapp/templates/article/includes/floating_menu.html:32
 #: opac/webapp/templates/article/includes/floating_menu.html:83
 msgid "Versões e traduções"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:37
+#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:88
 #: opac/webapp/templates/article/includes/floating_menu.html:37
 #: opac/webapp/templates/article/includes/floating_menu.html:88
 msgid "Como citar este artigo"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:42
+#: build/lib/opac/webapp/templates/article/includes/modal/related_article.html:9
 #: opac/webapp/templates/article/includes/floating_menu.html:42
 #: opac/webapp/templates/article/includes/modal/related_article.html:9
 msgid "Artigos relacionados"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:93
 #: opac/webapp/templates/article/includes/floating_menu.html:93
 msgid "Artigos e similares"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:9
 #: opac/webapp/templates/article/includes/levelMenu.html:9
 msgid "home do periodico"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:17
+#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:70
+#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:123
 #: opac/webapp/templates/article/includes/levelMenu.html:17
 #: opac/webapp/templates/article/includes/levelMenu.html:70
 #: opac/webapp/templates/article/includes/levelMenu.html:123
 msgid "sumário"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:30
+#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:75
+#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:71
 #: opac/webapp/templates/article/includes/levelMenu.html:30
 #: opac/webapp/templates/issue/includes/alternative_header.html:75
 #: opac/webapp/templates/journal/includes/alternative_header.html:71
 msgid "anterior"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:35
+#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:88
+#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:141
+#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:82
+#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:78
 #: opac/webapp/templates/article/includes/levelMenu.html:35
 #: opac/webapp/templates/article/includes/levelMenu.html:88
 #: opac/webapp/templates/article/includes/levelMenu.html:141
@@ -1281,10 +1548,15 @@ msgstr ""
 msgid "atual"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:48
 #: opac/webapp/templates/article/includes/levelMenu.html:48
 msgid "seguinte"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:193
+#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:219
+#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:264
+#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:290
 #: opac/webapp/templates/article/includes/levelMenu.html:193
 #: opac/webapp/templates/article/includes/levelMenu.html:219
 #: opac/webapp/templates/article/includes/levelMenu.html:264
@@ -1292,6 +1564,10 @@ msgstr ""
 msgid "Download PDF (Espanhol)"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:195
+#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:221
+#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:266
+#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:292
 #: opac/webapp/templates/article/includes/levelMenu.html:195
 #: opac/webapp/templates/article/includes/levelMenu.html:221
 #: opac/webapp/templates/article/includes/levelMenu.html:266
@@ -1299,6 +1575,10 @@ msgstr ""
 msgid "Download PDF (Inglês)"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:197
+#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:223
+#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:268
+#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:294
 #: opac/webapp/templates/article/includes/levelMenu.html:197
 #: opac/webapp/templates/article/includes/levelMenu.html:223
 #: opac/webapp/templates/article/includes/levelMenu.html:268
@@ -1306,6 +1586,13 @@ msgstr ""
 msgid "Download PDF (Português)"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:310
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu.html:38
+#: build/lib/opac/webapp/templates/collection/includes/list_journals_section_title.html:14
+#: build/lib/opac/webapp/templates/issue/grid.html:14
+#: build/lib/opac/webapp/templates/issue/toc.html:13
+#: build/lib/opac/webapp/templates/journal/about.html:16
+#: build/lib/opac/webapp/templates/journal/detail.html:11
 #: opac/webapp/templates/article/includes/levelMenu.html:310
 #: opac/webapp/templates/collection/includes/levelMenu.html:38
 #: opac/webapp/templates/collection/includes/list_journals_section_title.html:14
@@ -1316,6 +1603,11 @@ msgstr ""
 msgid "Compartilhe"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:311
+#: build/lib/opac/webapp/templates/collection/includes/list_journals_section_title.html:16
+#: build/lib/opac/webapp/templates/issue/toc.html:14
+#: build/lib/opac/webapp/templates/journal/about.html:17
+#: build/lib/opac/webapp/templates/journal/detail.html:12
 #: opac/webapp/templates/article/includes/levelMenu.html:311
 #: opac/webapp/templates/collection/includes/list_journals_section_title.html:16
 #: opac/webapp/templates/issue/toc.html:14
@@ -1324,6 +1616,11 @@ msgstr ""
 msgid "Enviar link por e-mail"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:314
+#: build/lib/opac/webapp/templates/collection/includes/list_journals_section_title.html:19
+#: build/lib/opac/webapp/templates/issue/toc.html:15
+#: build/lib/opac/webapp/templates/journal/about.html:18
+#: build/lib/opac/webapp/templates/journal/detail.html:13
 #: opac/webapp/templates/article/includes/levelMenu.html:314
 #: opac/webapp/templates/collection/includes/list_journals_section_title.html:19
 #: opac/webapp/templates/issue/toc.html:15
@@ -1332,6 +1629,11 @@ msgstr ""
 msgid "Compartilhar no Facebook"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:317
+#: build/lib/opac/webapp/templates/collection/includes/list_journals_section_title.html:22
+#: build/lib/opac/webapp/templates/issue/toc.html:16
+#: build/lib/opac/webapp/templates/journal/about.html:19
+#: build/lib/opac/webapp/templates/journal/detail.html:14
 #: opac/webapp/templates/article/includes/levelMenu.html:317
 #: opac/webapp/templates/collection/includes/list_journals_section_title.html:22
 #: opac/webapp/templates/issue/toc.html:16
@@ -1340,6 +1642,18 @@ msgstr ""
 msgid "Compartilhar no Twitter"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:320
+#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:325
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu.html:46
+#: build/lib/opac/webapp/templates/collection/includes/list_journals_section_title.html:25
+#: build/lib/opac/webapp/templates/collection/includes/list_journals_section_title.html:30
+#: build/lib/opac/webapp/templates/issue/grid.html:20
+#: build/lib/opac/webapp/templates/issue/toc.html:17
+#: build/lib/opac/webapp/templates/issue/toc.html:19
+#: build/lib/opac/webapp/templates/journal/about.html:20
+#: build/lib/opac/webapp/templates/journal/about.html:22
+#: build/lib/opac/webapp/templates/journal/detail.html:15
+#: build/lib/opac/webapp/templates/journal/detail.html:17
 #: opac/webapp/templates/article/includes/levelMenu.html:320
 #: opac/webapp/templates/article/includes/levelMenu.html:325
 #: opac/webapp/templates/collection/includes/levelMenu.html:46
@@ -1355,16 +1669,24 @@ msgstr ""
 msgid "Outras redes sociais"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/article/includes/recent_articles_row.html:6
+#: build/lib/opac/webapp/templates/issue/toc.html:149
 #: opac/webapp/templates/article/includes/recent_articles_row.html:6
 #: opac/webapp/templates/issue/toc.html:149
 msgid "Documento sem título"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/article/includes/recent_articles_row.html:13
+#: build/lib/opac/webapp/templates/news/includes/journal_news_row.html:14
 #: opac/webapp/templates/article/includes/recent_articles_row.html:13
-#: opac/webapp/templates/news/includes/journal_news_row.html:9
+#: opac/webapp/templates/news/includes/journal_news_row.html:14
 msgid "Continue lendo"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/article/includes/modal/download.html:6
+#: build/lib/opac/webapp/templates/article/includes/modal/related_article.html:7
+#: build/lib/opac/webapp/templates/email/email_form.html:7
+#: build/lib/opac/webapp/templates/includes/metric_modal.html:6
 #: opac/webapp/templates/article/includes/modal/download.html:6
 #: opac/webapp/templates/article/includes/modal/related_article.html:7
 #: opac/webapp/templates/email/email_form.html:7
@@ -1372,607 +1694,791 @@ msgstr ""
 msgid "Fechar"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/article/includes/modal/download.html:8
 #: opac/webapp/templates/article/includes/modal/download.html:8
 msgid "Versão para download de PDF"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/article/includes/modal/translate_version.html:6
 #: opac/webapp/templates/article/includes/modal/translate_version.html:6
 msgid "Versões e tradução automática"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/article/includes/modal/translate_version.html:11
 #: opac/webapp/templates/article/includes/modal/translate_version.html:11
 msgid "Versão original do texto"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/about.html:23
+#: build/lib/opac/webapp/templates/collection/pages.html:21
 #: opac/webapp/templates/collection/about.html:23
+#: opac/webapp/templates/collection/pages.html:21
 #, python-format
 msgid " %(page)s "
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/about.html:38
+#: build/lib/opac/webapp/templates/collection/pages.html:36
 #: opac/webapp/templates/collection/about.html:38
+#: opac/webapp/templates/collection/pages.html:36
 msgid " Conteúdo não cadastrado "
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/index.html:17
 #: opac/webapp/templates/collection/index.html:17
 msgid "em números | Métricas"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/index.html:27
 #: opac/webapp/templates/collection/index.html:27
 msgid "períodicos"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:31
+#: build/lib/opac/webapp/templates/collection/index.html:31
+#: build/lib/opac/webapp/templates/collection/list_feed_content.html:7
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:31
 #: opac/webapp/templates/collection/index.html:31
 #: opac/webapp/templates/collection/list_feed_content.html:7
 msgid "números"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/index.html:35
+#: build/lib/opac/webapp/templates/issue/grid.html:68
 #: opac/webapp/templates/collection/index.html:35
 #: opac/webapp/templates/issue/grid.html:68
 msgid "artigos"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/index.html:39
 #: opac/webapp/templates/collection/index.html:39
 msgid "referências"
 msgstr "referencias"
 
+#: build/lib/opac/webapp/templates/collection/index.html:45
 #: opac/webapp/templates/collection/index.html:45
 msgid "Downloads"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/index.html:48
 #: opac/webapp/templates/collection/index.html:48
 msgid "Citações"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/index.html:51
 #: opac/webapp/templates/collection/index.html:51
 msgid "Outros indicadores"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/index.html:62
+#: build/lib/opac/webapp/templates/collection/list_journal.html:3
 #: opac/webapp/templates/collection/index.html:62
 #: opac/webapp/templates/collection/list_journal.html:3
 msgid "Lista de periódicos"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/index.html:66
+#: build/lib/opac/webapp/templates/collection/list_journal.html:21
 #: opac/webapp/templates/collection/index.html:66
 #: opac/webapp/templates/collection/list_journal.html:21
 msgid "Alfabética"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/index.html:69
+#: build/lib/opac/webapp/templates/collection/list_journal.html:24
 #: opac/webapp/templates/collection/index.html:69
 #: opac/webapp/templates/collection/list_journal.html:24
 msgid "Temática"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/index.html:77
 #: opac/webapp/templates/collection/index.html:77
 msgid "Busca por periódicos"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/index.html:105
 #: opac/webapp/templates/collection/index.html:105
 msgid "Números <span>mais recentes</span>"
 msgstr "Números <span>más recientes</span>"
 
+#: build/lib/opac/webapp/templates/collection/index.html:149
 #: opac/webapp/templates/collection/index.html:149
 msgid "em perspectiva"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/list_feed_content.html:1
 #: opac/webapp/templates/collection/list_feed_content.html:1
 msgid "Último número"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/list_feed_content.html:4
 #: opac/webapp/templates/collection/list_feed_content.html:4
 msgid "Nº"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/list_feed_content.html:6
 #: opac/webapp/templates/collection/list_feed_content.html:6
 msgid "descontinuado"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/list_feed_content.html:7
 #: opac/webapp/templates/collection/list_feed_content.html:7
 msgid "de"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu.html:11
+#: build/lib/opac/webapp/templates/collection/list_journal.html:16
 #: opac/webapp/templates/collection/includes/levelMenu.html:11
 #: opac/webapp/templates/collection/list_journal.html:16
 msgid "Home"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_grouper_table_container.html:14
+#: build/lib/opac/webapp/templates/collection/list_journal.html:52
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_grouper_table_container.html:14
 #: opac/webapp/templates/collection/list_journal.html:52
 msgid "download da lista"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_grouper_table_container.html:15
+#: build/lib/opac/webapp/templates/collection/list_journal.html:53
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_grouper_table_container.html:15
 #: opac/webapp/templates/collection/list_journal.html:53
 msgid "Lista em arquivo para Excel"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_grouper_table_container.html:18
+#: build/lib/opac/webapp/templates/collection/list_journal.html:56
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_grouper_table_container.html:18
 #: opac/webapp/templates/collection/list_journal.html:56
 msgid "Lista em arquivo CSV"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/list_journal.html:80
+#: build/lib/opac/webapp/templates/collection/list_journal.html:84
 #: opac/webapp/templates/collection/list_journal.html:80
 #: opac/webapp/templates/collection/list_journal.html:84
 msgid "Grandes áreas do conhecimento"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/list_journal.html:85
 #: opac/webapp/templates/collection/list_journal.html:85
 msgid "Áreas temáticas do Web of Science"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/list_journal.html:222
 #: opac/webapp/templates/collection/list_journal.html:222
 msgid "grandes áreas"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/list_journal.html:236
 #: opac/webapp/templates/collection/list_journal.html:236
 msgid "áreas WOS"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/list_journal.html:248
 #: opac/webapp/templates/collection/list_journal.html:248
 msgid "Editoras"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/list_journal.html:249
 #: opac/webapp/templates/collection/list_journal.html:249
 msgid "editoras"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:7
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:7
 msgid "Sobre o"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:19
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:62
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:19
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:62
 msgid "Entre uma ou mais palavras"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:24
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:67
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:24
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:67
 msgid "Todos os índices"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:26
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:69
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:26
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:69
 msgid "Autor"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:38
+#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:95
+#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:91
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:38
 #: opac/webapp/templates/issue/includes/alternative_header.html:95
 #: opac/webapp/templates/journal/includes/alternative_header.html:91
 msgid "Buscar"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:44
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:44
 msgid "Adicionar outro campo"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:49
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:49
 msgid "Apagar campo"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:63
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:63
 msgid "Limpar expressão"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:92
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:92
 msgid "Sem resultados"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:96
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:96
 msgid "Não foram encontrados documentos para sua pesquisa"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/includes/list_journals_search_input.html:5
 #: opac/webapp/templates/collection/includes/list_journals_search_input.html:5
 msgid "Todos"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/includes/list_journals_search_input.html:9
 #: opac/webapp/templates/collection/includes/list_journals_search_input.html:9
 msgid "Periódicos ativos"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/includes/list_journals_search_input.html:13
 #: opac/webapp/templates/collection/includes/list_journals_search_input.html:13
 msgid "Periódicos descontinuados"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/includes/list_journals_search_input.html:24
 #: opac/webapp/templates/collection/includes/list_journals_search_input.html:24
 msgid "Digite uma ou mais palavras para filtrar a lista"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/includes/nav.html:22
+#: build/lib/opac/webapp/templates/collection/includes/nav.html:64
 #: opac/webapp/templates/collection/includes/nav.html:22
 #: opac/webapp/templates/collection/includes/nav.html:64
 msgid "Busca"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/includes/nav.html:32
 #: opac/webapp/templates/collection/includes/nav.html:32
 msgid "Sobre:"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/includes/nav.html:44
 #: opac/webapp/templates/collection/includes/nav.html:44
 msgid "SciELO.org - Rede SciELO"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/includes/nav.html:95
 #: opac/webapp/templates/collection/includes/nav.html:95
 msgid "Blog SciELO em Perspectiva"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_empty.html:3
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_empty.html:3
 msgid "Nenhum periódico encontrado."
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_error.html:3
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_error.html:3
 msgid "Ocorreu um erro obtendo a lista de periódicos."
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_grouper_table_container.html:10
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_grouper_table_container.html:10
 msgid "periódicos"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:3
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:3
 msgid "Homepage"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:25
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:25
 msgid "Título do periódico"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:29
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:29
 msgid "Grade de número"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:36
+#: build/lib/opac/webapp/templates/journal/detail.html:89
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:36
 #: opac/webapp/templates/journal/detail.html:89
 msgid "Número mais recente"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:37
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:37
 msgid "Último"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:45
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:45
 msgid "Continua como "
 msgstr ""
 
+#: build/lib/opac/webapp/templates/email/email_form.html:10
 #: opac/webapp/templates/email/email_form.html:10
 msgid "Enviar página por e-mail"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/email/email_form.html:18
+#: build/lib/opac/webapp/templates/includes/error_form.html:26
+#: build/lib/opac/webapp/templates/journal/includes/contact_form.html:20
 #: opac/webapp/templates/email/email_form.html:18
 #: opac/webapp/templates/includes/error_form.html:26
 #: opac/webapp/templates/journal/includes/contact_form.html:20
 msgid "Seu e-mail"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/email/email_form.html:23
 #: opac/webapp/templates/email/email_form.html:23
 msgid "Para"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/email/email_form.html:27
 #: opac/webapp/templates/email/email_form.html:27
 msgid "Utilize ; (ponto e vírgula) para inserir mais emails."
 msgstr ""
 
+#: build/lib/opac/webapp/templates/email/email_form.html:36
 #: opac/webapp/templates/email/email_form.html:36
 msgid "Alterar assunto e comentários"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/email/email_form.html:41
 #: opac/webapp/templates/email/email_form.html:41
 msgid "Assunto"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/email/email_form.html:45
 #: opac/webapp/templates/email/email_form.html:45
 msgid "Comentário"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/email/email_form.html:49
 #: opac/webapp/templates/email/email_form.html:49
 msgid "Remover remetente, assunto e comentários"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/email/email_form.html:75
 #: opac/webapp/templates/email/email_form.html:75
 msgid "Email enviado com sucesso."
 msgstr ""
 
+#: build/lib/opac/webapp/templates/email/email_form.html:76
+#: build/lib/opac/webapp/templates/includes/error_form.html:86
+#: build/lib/opac/webapp/templates/journal/includes/contact_form.html:77
 #: opac/webapp/templates/email/email_form.html:76
 #: opac/webapp/templates/includes/error_form.html:86
 #: opac/webapp/templates/journal/includes/contact_form.html:77
 msgid "Erro ao tentar enviar e-mail, por favor tente mais tarde."
 msgstr ""
 
+#: build/lib/opac/webapp/templates/errors/400.html:7
 #: opac/webapp/templates/errors/400.html:7
 msgid "Ação inválida"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/errors/403.html:7
 #: opac/webapp/templates/errors/403.html:7
 msgid "Acesso não autorizado!"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/errors/404.html:7
 #: opac/webapp/templates/errors/404.html:7
 msgid ""
 "A URL solicitada não foi encontrada no servidor. Se você digitou a URL "
 "manualmente, por favor verifique e tente novamente."
 msgstr ""
 
+#: build/lib/opac/webapp/templates/errors/500.html:5
 #: opac/webapp/templates/errors/500.html:5
 msgid ""
 "Erro interno do servidor. Tente novamente mais tarde. Nossos engenheiros "
 "foram notificados."
 msgstr ""
 
+#: build/lib/opac/webapp/templates/errors/500.html:9
 #: opac/webapp/templates/errors/500.html:9
 msgid "Id. do erro"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/errors/base.html:24
 #: opac/webapp/templates/errors/base.html:24
 msgid "Erro"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/errors/base.html:27
 #: opac/webapp/templates/errors/base.html:27
 msgid "Qualquer dúvida, por favor entre em contato com o administrador"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/includes/error_form.html:5
 #: opac/webapp/templates/includes/error_form.html:5
 msgid " Reportar erro "
 msgstr ""
 
+#: build/lib/opac/webapp/templates/includes/error_form.html:20
+#: build/lib/opac/webapp/templates/journal/includes/contact_form.html:14
 #: opac/webapp/templates/includes/error_form.html:20
 #: opac/webapp/templates/journal/includes/contact_form.html:14
 msgid "Seu Nome"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/includes/error_form.html:21
 #: opac/webapp/templates/includes/error_form.html:21
 msgid "Digite seu Nome"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/includes/error_form.html:32
 #: opac/webapp/templates/includes/error_form.html:32
 msgid "Erro referente"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/includes/error_form.html:35
 #: opac/webapp/templates/includes/error_form.html:35
 msgid "ao conteúdo"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/includes/error_form.html:39
 #: opac/webapp/templates/includes/error_form.html:39
 msgid "à aplicação"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/includes/error_form.html:46
 #: opac/webapp/templates/includes/error_form.html:46
 msgid "Descrição do erro"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/includes/error_form.html:47
 #: opac/webapp/templates/includes/error_form.html:47
 msgid "Digite sua mensagem"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/includes/error_form.html:49
 #: opac/webapp/templates/includes/error_form.html:49
 msgid "Obs.: Link e título da página são enviados automaticamente"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/includes/error_form.html:85
 #: opac/webapp/templates/includes/error_form.html:85
 msgid "Email de erro enviado com sucesso."
 msgstr ""
 
+#: build/lib/opac/webapp/templates/includes/footer.html:36
 #: opac/webapp/templates/includes/footer.html:36
 msgid "Open Access"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/includes/footer.html:38
 #: opac/webapp/templates/includes/footer.html:38
 msgid "Leia"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/includes/footer.html:38
 #: opac/webapp/templates/includes/footer.html:38
 msgid "a Declaração de Acesso Aberto"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/issue/grid.html:4
 #: opac/webapp/templates/issue/grid.html:4
 msgid "Fascículos"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/issue/grid.html:33
 #: opac/webapp/templates/issue/grid.html:33
 msgid "Todos os números"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/issue/grid.html:79
 #: opac/webapp/templates/issue/grid.html:79
 msgid "supl."
 msgstr ""
 
+#: build/lib/opac/webapp/templates/issue/grid.html:98
 #: opac/webapp/templates/issue/grid.html:98
 msgid "Nenhum número encontrado para esse periódico"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/issue/grid.html:101
 #: opac/webapp/templates/issue/grid.html:101
 msgid "Histórico deste periódico na coleção"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/issue/grid.html:105
 #: opac/webapp/templates/issue/grid.html:105
 msgid " admitido na coleção da SciELO"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/issue/toc.html:10
+#: build/lib/opac/webapp/templates/journal/detail.html:8
 #: opac/webapp/templates/issue/toc.html:10
 #: opac/webapp/templates/journal/detail.html:8
 msgid "Imprimir"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/issue/toc.html:41
 #: opac/webapp/templates/issue/toc.html:41
 msgid "Editor científico"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/issue/toc.html:45
 #: opac/webapp/templates/issue/toc.html:45
 msgid "Editores associados"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/issue/toc.html:52
 #: opac/webapp/templates/issue/toc.html:52
 msgid "Veja toda a equipe editorial"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/issue/toc.html:63
 #: opac/webapp/templates/issue/toc.html:63
 msgid "Expandir/recolher conteúdo"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/issue/toc.html:72
+#: build/lib/opac/webapp/templates/journal/detail.html:96
 #: opac/webapp/templates/issue/toc.html:72
 #: opac/webapp/templates/journal/detail.html:96
 msgid "Sumário"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/issue/toc.html:79
 #: opac/webapp/templates/issue/toc.html:79
 msgid "Ordenar publicações por"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/issue/toc.html:82
 #: opac/webapp/templates/issue/toc.html:82
 msgid "Ordem do fascículo"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/issue/toc.html:83
 #: opac/webapp/templates/issue/toc.html:83
 msgid "Mais novos primeiro"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/issue/toc.html:84
 #: opac/webapp/templates/issue/toc.html:84
 msgid "Mais antigos primeiro"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/issue/toc.html:102
+#: build/lib/opac/webapp/templates/issue/toc.html:104
 #: opac/webapp/templates/issue/toc.html:102
 #: opac/webapp/templates/issue/toc.html:104
 msgid "Todas as seções"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/issue/toc.html:187
 #: opac/webapp/templates/issue/toc.html:187
 msgid "Texto"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/issue/toc.html:214
 #: opac/webapp/templates/issue/toc.html:214
 msgid "Resumo em"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:31
+#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:31
 #: opac/webapp/templates/issue/includes/alternative_header.html:31
 #: opac/webapp/templates/journal/includes/alternative_header.html:31
 msgid "Número atual"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:51
+#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:47
 #: opac/webapp/templates/issue/includes/alternative_header.html:51
 #: opac/webapp/templates/journal/includes/alternative_header.html:47
 msgid "Homepage do periódico"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:62
+#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:58
 #: opac/webapp/templates/issue/includes/alternative_header.html:62
 #: opac/webapp/templates/journal/includes/alternative_header.html:58
 msgid "Números"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:68
+#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:64
+#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:90
 #: opac/webapp/templates/issue/includes/alternative_header.html:68
 #: opac/webapp/templates/journal/includes/alternative_header.html:64
 #: opac/webapp/templates/journal/includes/levelMenu.html:90
 msgid "todos"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:89
+#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:85
 #: opac/webapp/templates/issue/includes/alternative_header.html:89
 #: opac/webapp/templates/journal/includes/alternative_header.html:85
 msgid "próximo"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/journal/about.html:39
 #: opac/webapp/templates/journal/about.html:39
 msgid "Conteúdo não cadastrado"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/journal/about.html:55
+#: build/lib/opac/webapp/templates/journal/includes/contact_footer.html:48
 #: opac/webapp/templates/journal/about.html:55
 #: opac/webapp/templates/journal/includes/contact_footer.html:48
 msgid "Siga este periódico nas redes sociais"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/journal/detail.html:32
 #: opac/webapp/templates/journal/detail.html:32
 msgid "Nossa Missão"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/journal/detail.html:34
 #: opac/webapp/templates/journal/detail.html:34
 msgid "Periódico sem missão cadastrada"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/journal/detail.html:42
 #: opac/webapp/templates/journal/detail.html:42
 msgid "Métricas deste periódico"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/journal/detail.html:52
 #: opac/webapp/templates/journal/detail.html:52
 msgid "Índice h5"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/journal/detail.html:54
+#: build/lib/opac/webapp/templates/journal/detail.html:66
 #: opac/webapp/templates/journal/detail.html:54
 #: opac/webapp/templates/journal/detail.html:66
 msgid "ano"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/journal/detail.html:58
+#: build/lib/opac/webapp/templates/journal/detail.html:70
 #: opac/webapp/templates/journal/detail.html:58
 #: opac/webapp/templates/journal/detail.html:70
 msgid "Não possui"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/journal/detail.html:63
 #: opac/webapp/templates/journal/detail.html:63
 msgid "Mediana h5"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/journal/detail.html:86
 #: opac/webapp/templates/journal/detail.html:86
 msgid "Capa do número mais recente"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/journal/detail.html:138
 #: opac/webapp/templates/journal/detail.html:138
 msgid "Artigos mais recentes"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/journal/includes/contact_footer.html:57
 #: opac/webapp/templates/journal/includes/contact_footer.html:57
 msgid "Acompanhe os números deste periódico no seu leitor de RSS"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/journal/includes/contact_form.html:26
 #: opac/webapp/templates/journal/includes/contact_form.html:26
 msgid "Mensagem"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/journal/includes/contact_form.html:76
 #: opac/webapp/templates/journal/includes/contact_form.html:76
 msgid "Email enviado para "
 msgstr ""
 
+#: build/lib/opac/webapp/templates/journal/includes/contact_form.html:76
 #: opac/webapp/templates/journal/includes/contact_form.html:76
 msgid "com sucesso."
 msgstr ""
 
+#: build/lib/opac/webapp/templates/journal/includes/header.html:42
 #: opac/webapp/templates/journal/includes/header.html:42
 msgid "Publicação de:"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/journal/includes/header.html:47
 #: opac/webapp/templates/journal/includes/header.html:47
 msgid "Área:"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/journal/includes/header.html:51
 #: opac/webapp/templates/journal/includes/header.html:51
-msgid "Multidiciplinar"
+msgid "Multidisciplinar"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/journal/includes/header.html:60
 #: opac/webapp/templates/journal/includes/header.html:60
 msgid "Versão impressa ISSN:"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/journal/includes/header.html:67
 #: opac/webapp/templates/journal/includes/header.html:67
 msgid "Versão on-line ISSN:"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/journal/includes/header.html:76
 #: opac/webapp/templates/journal/includes/header.html:76
 msgid "Novo título:"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/journal/includes/header.html:93
 #: opac/webapp/templates/journal/includes/header.html:93
 msgid "Título anterior:"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/journal/includes/header.html:148
 #: opac/webapp/templates/journal/includes/header.html:148
 msgid "Siga-nos"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:10
 #: opac/webapp/templates/journal/includes/levelMenu.html:10
 msgid "home do periódico"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:19
 #: opac/webapp/templates/journal/includes/levelMenu.html:19
 msgid "todos os números"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:25
+#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:29
 #: opac/webapp/templates/journal/includes/levelMenu.html:25
 #: opac/webapp/templates/journal/includes/levelMenu.html:29
 msgid "número anterior"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:36
+#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:40
+#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:107
+#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:111
 #: opac/webapp/templates/journal/includes/levelMenu.html:36
 #: opac/webapp/templates/journal/includes/levelMenu.html:40
 #: opac/webapp/templates/journal/includes/levelMenu.html:107
@@ -1980,16 +2486,24 @@ msgstr ""
 msgid "número atual"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:47
+#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:51
 #: opac/webapp/templates/journal/includes/levelMenu.html:47
 #: opac/webapp/templates/journal/includes/levelMenu.html:51
 msgid "número seguinte"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:59
+#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:130
 #: opac/webapp/templates/journal/includes/levelMenu.html:59
 #: opac/webapp/templates/journal/includes/levelMenu.html:130
 msgid "buscar"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:65
+#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:69
+#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:136
+#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:140
 #: opac/webapp/templates/journal/includes/levelMenu.html:65
 #: opac/webapp/templates/journal/includes/levelMenu.html:69
 #: opac/webapp/templates/journal/includes/levelMenu.html:136
@@ -1997,22 +2511,27 @@ msgstr ""
 msgid "métricas"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/macros/issue.html:5
 #: opac/webapp/templates/macros/issue.html:5
 msgid " número especial "
 msgstr ""
 
+#: build/lib/opac/webapp/templates/macros/issue.html:10
 #: opac/webapp/templates/macros/issue.html:10
 msgid "número especial"
 msgstr ""
 
-#: opac/webapp/templates/news/includes/collection_news_row.html:11
+#: build/lib/opac/webapp/templates/news/includes/collection_news_row.html:16
+#: opac/webapp/templates/news/includes/collection_news_row.html:16
 msgid "continue lendo"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/news/includes/issue_last_row.html:15
 #: opac/webapp/templates/news/includes/issue_last_row.html:15
 msgid "Suplemento"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/news/includes/issue_last_row.html:20
 #: opac/webapp/templates/news/includes/issue_last_row.html:20
 msgid "Ver"
 msgstr ""
@@ -2258,5 +2777,11 @@ msgstr ""
 #~ msgstr ""
 
 #~ msgid "LINGUISTICS, LITERATURE AND ARTS"
+#~ msgstr ""
+
+#~ msgid "HTML do Artigo não encontrado"
+#~ msgstr ""
+
+#~ msgid "Recurso não encontrado"
 #~ msgstr ""
 

--- a/opac/webapp/translations/messages.pot
+++ b/opac/webapp/translations/messages.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-03-15 11:46+0000\n"
+"POT-Creation-Date: 2019-05-09 17:02-0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,6 +17,23 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.6.0\n"
 
+#: build/lib/opac/tests/test_admin_custom_filters.py:100
+#: build/lib/opac/tests/test_admin_custom_filters.py:114
+#: build/lib/opac/tests/test_admin_custom_filters.py:129
+#: build/lib/opac/tests/test_admin_custom_filters.py:144
+#: build/lib/opac/tests/test_admin_custom_filters.py:158
+#: build/lib/opac/webapp/__init__.py:119
+#: build/lib/opac/webapp/admin/views.py:533
+#: build/lib/opac/webapp/admin/views.py:610
+#: build/lib/opac/webapp/admin/views.py:680
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:28
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:71
+#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_grouper_table_row.html:15
+#: build/lib/opac/webapp/templates/collection/list_journal.html:49
+#: build/lib/opac/webapp/templates/collection/list_journal.html:221
+#: build/lib/opac/webapp/templates/collection/list_journal.html:235
+#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:116
+#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:112
 #: opac/tests/test_admin_custom_filters.py:100
 #: opac/tests/test_admin_custom_filters.py:114
 #: opac/tests/test_admin_custom_filters.py:129
@@ -35,21 +52,38 @@ msgstr ""
 msgid "Periódico"
 msgstr ""
 
+#: build/lib/opac/tests/test_interface_menu.py:51
 #: opac/tests/test_interface_menu.py:51
 msgid "NOME DA COLEÇÃO!!"
 msgstr ""
 
-#: opac/tests/test_interface_menu.py:53 opac/tests/test_interface_menu.py:72
+#: build/lib/opac/tests/test_interface_menu.py:53
+#: build/lib/opac/tests/test_interface_menu.py:75
+#: build/lib/opac/webapp/templates/collection/includes/nav.html:12
+#: build/lib/opac/webapp/templates/collection/includes/nav.html:54
+#: opac/tests/test_interface_menu.py:53 opac/tests/test_interface_menu.py:75
 #: opac/webapp/templates/collection/includes/nav.html:12
 #: opac/webapp/templates/collection/includes/nav.html:54
 msgid "Lista alfabética de periódicos"
 msgstr ""
 
+#: build/lib/opac/tests/test_interface_menu.py:55
+#: build/lib/opac/webapp/templates/collection/includes/nav.html:17
 #: opac/tests/test_interface_menu.py:55
 #: opac/webapp/templates/collection/includes/nav.html:17
 msgid "Lista temática de periódicos"
 msgstr ""
 
+#: build/lib/opac/tests/test_interface_menu.py:61
+#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:11
+#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:70
+#: build/lib/opac/webapp/templates/collection/includes/nav.html:27
+#: build/lib/opac/webapp/templates/collection/includes/nav.html:69
+#: build/lib/opac/webapp/templates/includes/metric_modal.html:7
+#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:101
+#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:105
+#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:97
+#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:101
 #: opac/tests/test_interface_menu.py:61
 #: opac/webapp/templates/article/includes/floating_menu.html:11
 #: opac/webapp/templates/article/includes/floating_menu.html:70
@@ -63,332 +97,383 @@ msgstr ""
 msgid "Métricas"
 msgstr ""
 
+#: build/lib/opac/tests/test_interface_menu.py:63
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu.html:12
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu.html:29
 #: opac/tests/test_interface_menu.py:63
 #: opac/webapp/templates/collection/includes/levelMenu.html:12
 #: opac/webapp/templates/collection/includes/levelMenu.html:29
 msgid "Sobre o SciELO"
 msgstr ""
 
-#: opac/tests/test_interface_menu.py:65 opac/tests/test_interface_menu.py:84
+#: build/lib/opac/tests/test_interface_menu.py:65
+#: build/lib/opac/tests/test_interface_menu.py:99
+#: build/lib/opac/webapp/templates/collection/includes/nav.html:37
+#: build/lib/opac/webapp/templates/collection/includes/nav.html:84
+#: opac/tests/test_interface_menu.py:65 opac/tests/test_interface_menu.py:99
 #: opac/webapp/templates/collection/includes/nav.html:37
 #: opac/webapp/templates/collection/includes/nav.html:84
 msgid "Contatos"
 msgstr ""
 
+#: build/lib/opac/tests/test_interface_menu.py:67
 #: opac/tests/test_interface_menu.py:67
 msgid "Rede SciELO"
 msgstr ""
 
-#: opac/tests/test_interface_menu.py:70
+#: build/lib/opac/tests/test_interface_menu.py:71
+#: build/lib/opac/webapp/templates/collection/includes/nav.html:49
+#: opac/tests/test_interface_menu.py:71
 #: opac/webapp/templates/collection/includes/nav.html:49
 msgid "Coleções nacionais e temáticas"
 msgstr ""
 
-#: opac/tests/test_interface_menu.py:74
+#: build/lib/opac/tests/test_interface_menu.py:79
+#: build/lib/opac/webapp/templates/collection/includes/nav.html:59
+#: opac/tests/test_interface_menu.py:79
 #: opac/webapp/templates/collection/includes/nav.html:59
 msgid "Lista de periódicos por assunto"
 msgstr ""
 
-#: opac/tests/test_interface_menu.py:80
+#: build/lib/opac/tests/test_interface_menu.py:91
+#: build/lib/opac/webapp/templates/collection/includes/nav.html:74
+#: opac/tests/test_interface_menu.py:91
 #: opac/webapp/templates/collection/includes/nav.html:74
 msgid "Acesso OAI e RSS"
 msgstr ""
 
-#: opac/tests/test_interface_menu.py:82
+#: build/lib/opac/tests/test_interface_menu.py:95
+#: build/lib/opac/webapp/templates/collection/includes/nav.html:79
+#: opac/tests/test_interface_menu.py:95
 #: opac/webapp/templates/collection/includes/nav.html:79
 msgid "Sobre a Rede SciELO"
 msgstr ""
 
-#: opac/tests/test_main_errors.py:8
+#: build/lib/opac/tests/test_main_errors.py:8 opac/tests/test_main_errors.py:8
 msgid "Mensagem de erro explicativo para o usuário"
 msgstr ""
 
+#: build/lib/opac/webapp/__init__.py:118 build/lib/opac/webapp/__init__.py:119
+#: build/lib/opac/webapp/__init__.py:120 build/lib/opac/webapp/__init__.py:121
+#: build/lib/opac/webapp/__init__.py:122 build/lib/opac/webapp/__init__.py:123
 #: opac/webapp/__init__.py:118 opac/webapp/__init__.py:119
 #: opac/webapp/__init__.py:120 opac/webapp/__init__.py:121
 #: opac/webapp/__init__.py:122 opac/webapp/__init__.py:123
 msgid "Catálogo"
 msgstr ""
 
-#: opac/webapp/__init__.py:118 opac/webapp/admin/views.py:452
+#: build/lib/opac/webapp/__init__.py:118
+#: build/lib/opac/webapp/admin/views.py:452 opac/webapp/__init__.py:118
+#: opac/webapp/admin/views.py:452
 msgid "Coleção"
 msgstr ""
 
+#: build/lib/opac/webapp/__init__.py:120
+#: build/lib/opac/webapp/admin/views.py:537
+#: build/lib/opac/webapp/admin/views.py:609
+#: build/lib/opac/webapp/templates/issue/grid.html:41
+#: build/lib/opac/webapp/templates/news/includes/issue_last_row.html:11
 #: opac/webapp/__init__.py:120 opac/webapp/admin/views.py:537
 #: opac/webapp/admin/views.py:609 opac/webapp/templates/issue/grid.html:41
 #: opac/webapp/templates/news/includes/issue_last_row.html:11
 msgid "Número"
 msgstr ""
 
-#: opac/webapp/__init__.py:121
+#: build/lib/opac/webapp/__init__.py:121 opac/webapp/__init__.py:121
 msgid "Artigo"
 msgstr ""
 
+#: build/lib/opac/webapp/__init__.py:122
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:27
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:70
 #: opac/webapp/__init__.py:122
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:27
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:70
 msgid "Financiador"
 msgstr ""
 
-#: opac/webapp/__init__.py:123
+#: build/lib/opac/webapp/__init__.py:123 opac/webapp/__init__.py:123
 msgid "Press Release"
 msgstr ""
 
+#: build/lib/opac/webapp/__init__.py:124
+#: build/lib/opac/webapp/templates/journal/detail.html:160
 #: opac/webapp/__init__.py:124 opac/webapp/templates/journal/detail.html:160
 msgid "Notícias"
 msgstr ""
 
+#: build/lib/opac/webapp/__init__.py:125 build/lib/opac/webapp/__init__.py:126
 #: opac/webapp/__init__.py:125 opac/webapp/__init__.py:126
 msgid "Ativos"
 msgstr ""
 
-#: opac/webapp/__init__.py:127
+#: build/lib/opac/webapp/__init__.py:127 opac/webapp/__init__.py:127
 msgid "Páginas"
 msgstr ""
 
+#: build/lib/opac/webapp/__init__.py:128 build/lib/opac/webapp/__init__.py:129
 #: opac/webapp/__init__.py:128 opac/webapp/__init__.py:129
 msgid "Gestão"
 msgstr ""
 
-#: opac/webapp/__init__.py:128
+#: build/lib/opac/webapp/__init__.py:128 opac/webapp/__init__.py:128
 msgid "Auditoria: Páginas"
 msgstr ""
 
-#: opac/webapp/__init__.py:129 opac/webapp/admin/views.py:896
+#: build/lib/opac/webapp/__init__.py:129
+#: build/lib/opac/webapp/admin/views.py:896 opac/webapp/__init__.py:129
+#: opac/webapp/admin/views.py:896
 msgid "Usuário"
 msgstr ""
 
-#: opac/webapp/choices.py:7
+#: build/lib/opac/webapp/choices.py:7 opac/webapp/choices.py:7
 msgid "Conteúdo temporariamente indisponível"
 msgstr ""
 
+#: build/lib/opac/webapp/choices.py:11 build/lib/opac/webapp/choices.py:23
+#: build/lib/opac/webapp/templates/article/includes/modal/download.html:26
 #: opac/webapp/choices.py:11 opac/webapp/choices.py:23
 #: opac/webapp/templates/article/includes/modal/download.html:26
 msgid "Português"
 msgstr ""
 
+#: build/lib/opac/webapp/choices.py:12 build/lib/opac/webapp/choices.py:24
+#: build/lib/opac/webapp/templates/article/includes/modal/download.html:24
 #: opac/webapp/choices.py:12 opac/webapp/choices.py:24
 #: opac/webapp/templates/article/includes/modal/download.html:24
 msgid "Inglês"
 msgstr ""
 
+#: build/lib/opac/webapp/choices.py:13 build/lib/opac/webapp/choices.py:25
+#: build/lib/opac/webapp/templates/article/includes/modal/download.html:22
 #: opac/webapp/choices.py:13 opac/webapp/choices.py:25
 #: opac/webapp/templates/article/includes/modal/download.html:22
 msgid "Espanhol"
 msgstr ""
 
-#: opac/webapp/choices.py:26
+#: build/lib/opac/webapp/choices.py:26 opac/webapp/choices.py:26
 msgid "Albanês"
 msgstr ""
 
+#: build/lib/opac/webapp/choices.py:27 build/lib/opac/webapp/choices.py:33
 #: opac/webapp/choices.py:27 opac/webapp/choices.py:33
 msgid "Chinês"
 msgstr ""
 
-#: opac/webapp/choices.py:28
+#: build/lib/opac/webapp/choices.py:28 opac/webapp/choices.py:28
 msgid "Romeno"
 msgstr ""
 
-#: opac/webapp/choices.py:29
+#: build/lib/opac/webapp/choices.py:29 opac/webapp/choices.py:29
 msgid "Francês"
 msgstr ""
 
-#: opac/webapp/choices.py:30
+#: build/lib/opac/webapp/choices.py:30 opac/webapp/choices.py:30
 msgid "Italiano"
 msgstr ""
 
-#: opac/webapp/choices.py:31
+#: build/lib/opac/webapp/choices.py:31 opac/webapp/choices.py:31
 msgid "Russo"
 msgstr ""
 
-#: opac/webapp/choices.py:32
+#: build/lib/opac/webapp/choices.py:32 opac/webapp/choices.py:32
 msgid "Árabe"
 msgstr ""
 
-#: opac/webapp/choices.py:37
+#: build/lib/opac/webapp/choices.py:37 opac/webapp/choices.py:37
 msgid "corrente"
 msgstr ""
 
-#: opac/webapp/choices.py:38
+#: build/lib/opac/webapp/choices.py:38 opac/webapp/choices.py:38
 msgid "terminado"
 msgstr ""
 
-#: opac/webapp/choices.py:39
+#: build/lib/opac/webapp/choices.py:39 opac/webapp/choices.py:39
 msgid "indexação interrompida"
 msgstr ""
 
-#: opac/webapp/choices.py:40
+#: build/lib/opac/webapp/choices.py:40 opac/webapp/choices.py:40
 msgid "indexação interrompida pelo Comitê"
 msgstr ""
 
-#: opac/webapp/choices.py:41
+#: build/lib/opac/webapp/choices.py:41 opac/webapp/choices.py:41
 msgid "publicação finalizada"
 msgstr ""
 
-#: opac/webapp/choices.py:45
+#: build/lib/opac/webapp/choices.py:45 opac/webapp/choices.py:45
 msgid "Ciências Agrárias"
 msgstr ""
 
-#: opac/webapp/choices.py:46
+#: build/lib/opac/webapp/choices.py:46 opac/webapp/choices.py:46
 msgid "Ciências Sociais Aplicadas"
 msgstr ""
 
-#: opac/webapp/choices.py:47
+#: build/lib/opac/webapp/choices.py:47 opac/webapp/choices.py:47
 msgid "Ciências Biológicas"
 msgstr ""
 
-#: opac/webapp/choices.py:48
+#: build/lib/opac/webapp/choices.py:48 opac/webapp/choices.py:48
 msgid "Engenharias"
 msgstr ""
 
-#: opac/webapp/choices.py:49
+#: build/lib/opac/webapp/choices.py:49 opac/webapp/choices.py:49
 msgid "Ciências Exatas e da Terra"
 msgstr ""
 
-#: opac/webapp/choices.py:50
+#: build/lib/opac/webapp/choices.py:50 opac/webapp/choices.py:50
 msgid "Ciências da Saúde"
 msgstr ""
 
-#: opac/webapp/choices.py:51
+#: build/lib/opac/webapp/choices.py:51 opac/webapp/choices.py:51
 msgid "Ciências Humanas"
 msgstr ""
 
+#: build/lib/opac/webapp/choices.py:52 build/lib/opac/webapp/choices.py:53
 #: opac/webapp/choices.py:52 opac/webapp/choices.py:53
 msgid "Lingüística, Letras e Artes"
 msgstr ""
 
-#: opac/webapp/controllers.py:353
+#: build/lib/opac/webapp/controllers.py:353 opac/webapp/controllers.py:353
 msgid "Lista Alfabética"
 msgstr ""
 
-#: opac/webapp/controllers.py:357
+#: build/lib/opac/webapp/controllers.py:357 opac/webapp/controllers.py:357
 msgid "Lista Temática"
 msgstr ""
 
-#: opac/webapp/controllers.py:361
+#: build/lib/opac/webapp/controllers.py:361 opac/webapp/controllers.py:361
 msgid "Lista Web of Science"
 msgstr ""
 
-#: opac/webapp/controllers.py:365
+#: build/lib/opac/webapp/controllers.py:365 opac/webapp/controllers.py:365
 msgid "Lista by Institution"
 msgstr ""
 
-#: opac/webapp/controllers.py:424
+#: build/lib/opac/webapp/controllers.py:424 opac/webapp/controllers.py:424
 msgid "Obrigatório um jid."
 msgstr ""
 
-#: opac/webapp/controllers.py:440
+#: build/lib/opac/webapp/controllers.py:440 opac/webapp/controllers.py:440
 msgid "Obrigatório um acronym."
 msgstr ""
 
-#: opac/webapp/controllers.py:456
+#: build/lib/opac/webapp/controllers.py:456 opac/webapp/controllers.py:456
 msgid "Obrigatório um url_seg."
 msgstr ""
 
-#: opac/webapp/controllers.py:472
+#: build/lib/opac/webapp/controllers.py:472 opac/webapp/controllers.py:472
 msgid "Obrigatório um issn."
 msgstr ""
 
-#: opac/webapp/controllers.py:487
+#: build/lib/opac/webapp/controllers.py:487 opac/webapp/controllers.py:487
 msgid "Obrigatório um title."
 msgstr ""
 
-#: opac/webapp/controllers.py:525 opac/webapp/controllers.py:669
-#: opac/webapp/controllers.py:830
+#: build/lib/opac/webapp/controllers.py:525
+#: build/lib/opac/webapp/controllers.py:669
+#: build/lib/opac/webapp/controllers.py:830 opac/webapp/controllers.py:525
+#: opac/webapp/controllers.py:669 opac/webapp/controllers.py:830
 msgid "Obrigatório uma lista de ids."
 msgstr ""
 
-#: opac/webapp/controllers.py:631 opac/webapp/controllers.py:851
+#: build/lib/opac/webapp/controllers.py:631
+#: build/lib/opac/webapp/controllers.py:851 opac/webapp/controllers.py:631
+#: opac/webapp/controllers.py:851
 msgid "Obrigatório um iid."
 msgstr ""
 
-#: opac/webapp/controllers.py:688
+#: build/lib/opac/webapp/controllers.py:688 opac/webapp/controllers.py:688
 msgid "Obrigatório um jacron e issue_label."
 msgstr ""
 
-#: opac/webapp/controllers.py:701
+#: build/lib/opac/webapp/controllers.py:701 opac/webapp/controllers.py:701
 msgid "Obrigatório um PID."
 msgstr ""
 
-#: opac/webapp/controllers.py:717
+#: build/lib/opac/webapp/controllers.py:717 opac/webapp/controllers.py:717
 msgid "Obrigatório um url_seg e url_seg_issue."
 msgstr ""
 
-#: opac/webapp/controllers.py:724
+#: build/lib/opac/webapp/controllers.py:724 opac/webapp/controllers.py:724
 msgid "Obrigatório um assets_code."
 msgstr ""
 
-#: opac/webapp/controllers.py:727
+#: build/lib/opac/webapp/controllers.py:727 opac/webapp/controllers.py:727
 msgid "Obrigatório um journal."
 msgstr ""
 
-#: opac/webapp/controllers.py:743
+#: build/lib/opac/webapp/controllers.py:743 opac/webapp/controllers.py:743
 msgid "Obrigatório um aid."
 msgstr ""
 
-#: opac/webapp/controllers.py:757
+#: build/lib/opac/webapp/controllers.py:757 opac/webapp/controllers.py:757
 msgid "Obrigatório um url_seg_article."
 msgstr ""
 
-#: opac/webapp/controllers.py:772
+#: build/lib/opac/webapp/controllers.py:772 opac/webapp/controllers.py:772
 msgid "Obrigatório um iid and url_seg_article."
 msgstr ""
 
-#: opac/webapp/controllers.py:788
+#: build/lib/opac/webapp/controllers.py:788 opac/webapp/controllers.py:788
 msgid "Obrigatório um jid, url_seg_issue and url_seg_article."
 msgstr ""
 
-#: opac/webapp/controllers.py:889
+#: build/lib/opac/webapp/controllers.py:889 opac/webapp/controllers.py:889
 msgid "Obrigatório um pid."
 msgstr ""
 
-#: opac/webapp/controllers.py:902
+#: build/lib/opac/webapp/controllers.py:902 opac/webapp/controllers.py:902
 msgid "Obrigatório um aop_pid."
 msgstr ""
 
-#: opac/webapp/controllers.py:913
+#: build/lib/opac/webapp/controllers.py:913 opac/webapp/controllers.py:913
 msgid "Parámetro obrigatório: issue_iid."
 msgstr ""
 
-#: opac/webapp/controllers.py:961
+#: build/lib/opac/webapp/controllers.py:961 opac/webapp/controllers.py:961
 msgid "Parâmetro email deve ser uma string"
 msgstr ""
 
-#: opac/webapp/controllers.py:972
+#: build/lib/opac/webapp/controllers.py:972 opac/webapp/controllers.py:972
 msgid "Parâmetro email deve ser uma inteiro"
 msgstr ""
 
-#: opac/webapp/controllers.py:984 opac/webapp/controllers.py:998
+#: build/lib/opac/webapp/controllers.py:984
+#: build/lib/opac/webapp/controllers.py:998 opac/webapp/controllers.py:984
+#: opac/webapp/controllers.py:998
 #, python-format
 msgid "Usuário deve ser do tipo %s"
 msgstr ""
 
-#: opac/webapp/controllers.py:1054
+#: build/lib/opac/webapp/controllers.py:1054 opac/webapp/controllers.py:1054
 msgid "Compartilhamento de link SciELO"
 msgstr ""
 
-#: opac/webapp/controllers.py:1055
+#: build/lib/opac/webapp/controllers.py:1055 opac/webapp/controllers.py:1055
 #, python-format
 msgid "O usuário %s compartilha este link: %s, da SciELO"
 msgstr ""
 
-#: opac/webapp/controllers.py:1063 opac/webapp/controllers.py:1099
-#: opac/webapp/controllers.py:1121
+#: build/lib/opac/webapp/controllers.py:1063
+#: build/lib/opac/webapp/controllers.py:1099
+#: build/lib/opac/webapp/controllers.py:1121 opac/webapp/controllers.py:1063
+#: opac/webapp/controllers.py:1099 opac/webapp/controllers.py:1121
 msgid "Mensagem enviada!"
 msgstr ""
 
-#: opac/webapp/controllers.py:1080
+#: build/lib/opac/webapp/controllers.py:1080 opac/webapp/controllers.py:1080
 msgid "[Erro] Erro informado pelo usuário no site SciELO"
 msgstr ""
 
-#: opac/webapp/controllers.py:1083
+#: build/lib/opac/webapp/controllers.py:1083 opac/webapp/controllers.py:1083
 msgid "aplicação"
 msgstr ""
 
-#: opac/webapp/controllers.py:1085
+#: build/lib/opac/webapp/controllers.py:1085 opac/webapp/controllers.py:1085
 msgid "conteúdo"
 msgstr ""
 
-#: opac/webapp/controllers.py:1090
+#: build/lib/opac/webapp/controllers.py:1090 opac/webapp/controllers.py:1090
 #, python-format
 msgid ""
 "O usuário <b>%s</b> com e-mail: <b>%s</b>, informa que existe um erro na "
@@ -396,384 +481,430 @@ msgid ""
 " %s"
 msgstr ""
 
-#: opac/webapp/controllers.py:1111
+#: build/lib/opac/webapp/controllers.py:1111 opac/webapp/controllers.py:1111
 msgid "Contato de usuário via site SciELO"
 msgstr ""
 
-#: opac/webapp/controllers.py:1113
+#: build/lib/opac/webapp/controllers.py:1113 opac/webapp/controllers.py:1113
 #, python-format
 msgid "O usuário %s, com e-mail: %s, entra em contato com a seguinte mensagem:"
 msgstr ""
 
-#: opac/webapp/controllers.py:1145
+#: build/lib/opac/webapp/controllers.py:1145 opac/webapp/controllers.py:1145
 msgid "Obrigatório um slug_name."
 msgstr ""
 
-#: opac/webapp/forms.py:29
+#: build/lib/opac/webapp/forms.py:29 opac/webapp/forms.py:29
 msgid "Endereço de e-mail inválido."
 msgstr ""
 
-#: opac/webapp/admin/forms.py:9 opac/webapp/admin/forms.py:21
+#: build/lib/opac/webapp/admin/forms.py:9
+#: build/lib/opac/webapp/admin/forms.py:21 opac/webapp/admin/forms.py:9
+#: opac/webapp/admin/forms.py:21
 msgid "Email"
 msgstr ""
 
-#: opac/webapp/admin/forms.py:10 opac/webapp/admin/forms.py:25
+#: build/lib/opac/webapp/admin/forms.py:10
+#: build/lib/opac/webapp/admin/forms.py:25 opac/webapp/admin/forms.py:10
+#: opac/webapp/admin/forms.py:25
 msgid "Senha"
 msgstr ""
 
-#: opac/webapp/admin/forms.py:15
+#: build/lib/opac/webapp/admin/forms.py:15 opac/webapp/admin/forms.py:15
 msgid "Usuário inválido"
 msgstr ""
 
-#: opac/webapp/admin/forms.py:17
+#: build/lib/opac/webapp/admin/forms.py:17 opac/webapp/admin/forms.py:17
 msgid "Senha inválida"
 msgstr ""
 
-#: opac/webapp/admin/views.py:28
+#: build/lib/opac/webapp/admin/views.py:28 opac/webapp/admin/views.py:28
 msgid "Tem certeza que quer publicar os itens selecionados?"
 msgstr ""
 
-#: opac/webapp/admin/views.py:29
+#: build/lib/opac/webapp/admin/views.py:29 opac/webapp/admin/views.py:29
 msgid "Tem certeza que quer despublicar os itens selecionados?"
 msgstr ""
 
-#: opac/webapp/admin/views.py:30
+#: build/lib/opac/webapp/admin/views.py:30 opac/webapp/admin/views.py:30
 msgid "Tem certeza que quer reconstruir os artigos selecionados?"
 msgstr ""
 
-#: opac/webapp/admin/views.py:31
+#: build/lib/opac/webapp/admin/views.py:31 opac/webapp/admin/views.py:31
 msgid ""
 "Tem certeza que quer enviar email de confirmação aos usuários "
 "selecionados?"
 msgstr ""
 
-#: opac/webapp/admin/views.py:91 opac/webapp/admin/views.py:104
+#: build/lib/opac/webapp/admin/views.py:91
+#: build/lib/opac/webapp/admin/views.py:104 opac/webapp/admin/views.py:91
+#: opac/webapp/admin/views.py:104
 msgid "Usuário não encontrado"
 msgstr ""
 
-#: opac/webapp/admin/views.py:94
+#: build/lib/opac/webapp/admin/views.py:94 opac/webapp/admin/views.py:94
 #, python-format
 msgid "Email: %(email)s confirmado com sucesso!"
 msgstr ""
 
-#: opac/webapp/admin/views.py:110
+#: build/lib/opac/webapp/admin/views.py:110 opac/webapp/admin/views.py:110
 #, python-format
 msgid "Enviamos as instruções para recuperar a senha para: %(email)s"
 msgstr ""
 
-#: opac/webapp/admin/views.py:113
+#: build/lib/opac/webapp/admin/views.py:113 opac/webapp/admin/views.py:113
 #, python-format
 msgid ""
 "Ocorreu um erro no envio das instruções por email para: %(email)s. Erro: "
 "%(error)s"
 msgstr ""
 
-#: opac/webapp/admin/views.py:139
+#: build/lib/opac/webapp/admin/views.py:139 opac/webapp/admin/views.py:139
 msgid "Nova senha salva com sucesso!!"
 msgstr ""
 
-#: opac/webapp/admin/views.py:167 opac/webapp/admin/views.py:186
+#: build/lib/opac/webapp/admin/views.py:167
+#: build/lib/opac/webapp/admin/views.py:186 opac/webapp/admin/views.py:167
+#: opac/webapp/admin/views.py:186
 #, python-format
 msgid "Enviamos o email de confirmação para: %(email)s"
 msgstr ""
 
-#: opac/webapp/admin/views.py:170
+#: build/lib/opac/webapp/admin/views.py:170 opac/webapp/admin/views.py:170
 #, python-format
 msgid ""
 "Ocorreu um erro no envio do email de confirmação para: %(email)s "
 "%(error_msg)s"
 msgstr ""
 
-#: opac/webapp/admin/views.py:177
+#: build/lib/opac/webapp/admin/views.py:177 opac/webapp/admin/views.py:177
 msgid "Enviar email de confirmação"
 msgstr ""
 
-#: opac/webapp/admin/views.py:189
+#: build/lib/opac/webapp/admin/views.py:189 opac/webapp/admin/views.py:189
 #, python-format
 msgid "Ocorreu um erro no envio do email de confirmação para: %(email)s"
 msgstr ""
 
-#: opac/webapp/admin/views.py:193
+#: build/lib/opac/webapp/admin/views.py:193 opac/webapp/admin/views.py:193
 #, python-format
 msgid "%(count)s usuários foram notificados com sucesso!"
 msgstr ""
 
-#: opac/webapp/admin/views.py:196
+#: build/lib/opac/webapp/admin/views.py:196 opac/webapp/admin/views.py:196
 #, python-format
 msgid "Ocorreu um erro no envio do emails de confirmação. Erro: %(ex)s"
 msgstr ""
 
-#: opac/webapp/admin/views.py:231 opac/webapp/admin/views.py:265
-#: opac/webapp/admin/views.py:363 opac/webapp/admin/views.py:393
-#: opac/webapp/admin/views.py:677
+#: build/lib/opac/webapp/admin/views.py:231
+#: build/lib/opac/webapp/admin/views.py:265
+#: build/lib/opac/webapp/admin/views.py:363
+#: build/lib/opac/webapp/admin/views.py:393
+#: build/lib/opac/webapp/admin/views.py:677 opac/webapp/admin/views.py:231
+#: opac/webapp/admin/views.py:265 opac/webapp/admin/views.py:363
+#: opac/webapp/admin/views.py:393 opac/webapp/admin/views.py:677
 msgid "Nome"
 msgstr ""
 
-#: opac/webapp/admin/views.py:232 opac/webapp/admin/views.py:267
+#: build/lib/opac/webapp/admin/views.py:232
+#: build/lib/opac/webapp/admin/views.py:267 opac/webapp/admin/views.py:232
+#: opac/webapp/admin/views.py:267
 msgid "Link"
 msgstr ""
 
-#: opac/webapp/admin/views.py:233 opac/webapp/admin/views.py:268
-#: opac/webapp/admin/views.py:678
+#: build/lib/opac/webapp/admin/views.py:233
+#: build/lib/opac/webapp/admin/views.py:268
+#: build/lib/opac/webapp/admin/views.py:678 opac/webapp/admin/views.py:233
+#: opac/webapp/admin/views.py:268 opac/webapp/admin/views.py:678
 msgid "Idioma"
 msgstr ""
 
-#: opac/webapp/admin/views.py:266
+#: build/lib/opac/webapp/admin/views.py:266 opac/webapp/admin/views.py:266
 msgid "Previsualização"
 msgstr ""
 
-#: opac/webapp/admin/views.py:362 opac/webapp/admin/views.py:547
-#: opac/webapp/admin/views.py:627
+#: build/lib/opac/webapp/admin/views.py:362
+#: build/lib/opac/webapp/admin/views.py:547
+#: build/lib/opac/webapp/admin/views.py:627 opac/webapp/admin/views.py:362
+#: opac/webapp/admin/views.py:547 opac/webapp/admin/views.py:627
 msgid "Ordem"
 msgstr ""
 
-#: opac/webapp/admin/views.py:364
+#: build/lib/opac/webapp/admin/views.py:364 opac/webapp/admin/views.py:364
 msgid "URL"
 msgstr ""
 
-#: opac/webapp/admin/views.py:365
+#: build/lib/opac/webapp/admin/views.py:365 opac/webapp/admin/views.py:365
 msgid "URL da logomarca"
 msgstr ""
 
-#: opac/webapp/admin/views.py:375
+#: build/lib/opac/webapp/admin/views.py:375 opac/webapp/admin/views.py:375
 msgid "Financiador com Ordem ou Nome já cadastrado!"
 msgstr ""
 
-#: opac/webapp/admin/views.py:394
+#: build/lib/opac/webapp/admin/views.py:394 opac/webapp/admin/views.py:394
 msgid "Acerca de"
 msgstr ""
 
-#: opac/webapp/admin/views.py:395 opac/webapp/admin/views.py:462
+#: build/lib/opac/webapp/admin/views.py:395
+#: build/lib/opac/webapp/admin/views.py:462 opac/webapp/admin/views.py:395
+#: opac/webapp/admin/views.py:462
 msgid "Acrônimo"
 msgstr ""
 
-#: opac/webapp/admin/views.py:396
+#: build/lib/opac/webapp/admin/views.py:396 opac/webapp/admin/views.py:396
 msgid "Endereço principal"
 msgstr ""
 
-#: opac/webapp/admin/views.py:397
+#: build/lib/opac/webapp/admin/views.py:397 opac/webapp/admin/views.py:397
 msgid "Endereço secundário"
 msgstr ""
 
-#: opac/webapp/admin/views.py:398
+#: build/lib/opac/webapp/admin/views.py:398 opac/webapp/admin/views.py:398
 msgid "Logo da Home (PT)"
 msgstr ""
 
-#: opac/webapp/admin/views.py:399
+#: build/lib/opac/webapp/admin/views.py:399 opac/webapp/admin/views.py:399
 msgid "Logo da Home (EN)"
 msgstr ""
 
-#: opac/webapp/admin/views.py:400
+#: build/lib/opac/webapp/admin/views.py:400 opac/webapp/admin/views.py:400
 msgid "Logo da Home (ES)"
 msgstr ""
 
-#: opac/webapp/admin/views.py:401
+#: build/lib/opac/webapp/admin/views.py:401 opac/webapp/admin/views.py:401
 msgid "Logo do cabeçalho (PT)"
 msgstr ""
 
-#: opac/webapp/admin/views.py:402
+#: build/lib/opac/webapp/admin/views.py:402 opac/webapp/admin/views.py:402
 msgid "Logo do cabeçalho (EN)"
 msgstr ""
 
-#: opac/webapp/admin/views.py:403
+#: build/lib/opac/webapp/admin/views.py:403 opac/webapp/admin/views.py:403
 msgid "Logo do cabeçalho (ES)"
 msgstr ""
 
-#: opac/webapp/admin/views.py:404
+#: build/lib/opac/webapp/admin/views.py:404 opac/webapp/admin/views.py:404
 msgid "Logo do menu (PT)"
 msgstr ""
 
-#: opac/webapp/admin/views.py:405 opac/webapp/admin/views.py:406
+#: build/lib/opac/webapp/admin/views.py:405
+#: build/lib/opac/webapp/admin/views.py:406 opac/webapp/admin/views.py:405
+#: opac/webapp/admin/views.py:406
 msgid "Logo do menu (ES)"
 msgstr ""
 
-#: opac/webapp/admin/views.py:407
+#: build/lib/opac/webapp/admin/views.py:407 opac/webapp/admin/views.py:407
 msgid "Logo do menu (drop)"
 msgstr ""
 
-#: opac/webapp/admin/views.py:408
+#: build/lib/opac/webapp/admin/views.py:408 opac/webapp/admin/views.py:408
 msgid "Logo do rodapé"
 msgstr ""
 
-#: opac/webapp/admin/views.py:451
+#: build/lib/opac/webapp/admin/views.py:451 opac/webapp/admin/views.py:451
 msgid "Id Periódico"
 msgstr ""
 
-#: opac/webapp/admin/views.py:453
+#: build/lib/opac/webapp/admin/views.py:453 opac/webapp/admin/views.py:453
 msgid "Linha do tempo"
 msgstr ""
 
-#: opac/webapp/admin/views.py:454
+#: build/lib/opac/webapp/admin/views.py:454 opac/webapp/admin/views.py:454
 msgid "Categorias de assunto"
 msgstr ""
 
-#: opac/webapp/admin/views.py:455
+#: build/lib/opac/webapp/admin/views.py:455 opac/webapp/admin/views.py:455
 msgid "Áreas de estudo"
 msgstr ""
 
-#: opac/webapp/admin/views.py:456
+#: build/lib/opac/webapp/admin/views.py:456 opac/webapp/admin/views.py:456
 msgid "Redes sociais"
 msgstr ""
 
+#: build/lib/opac/webapp/admin/views.py:457
+#: build/lib/opac/webapp/admin/views.py:611
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:30
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:73
 #: opac/webapp/admin/views.py:457 opac/webapp/admin/views.py:611
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:30
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:73
 msgid "Título"
 msgstr ""
 
-#: opac/webapp/admin/views.py:458
+#: build/lib/opac/webapp/admin/views.py:458 opac/webapp/admin/views.py:458
 msgid "Título ISO"
 msgstr ""
 
-#: opac/webapp/admin/views.py:459
+#: build/lib/opac/webapp/admin/views.py:459 opac/webapp/admin/views.py:459
 msgid "Título curto"
 msgstr ""
 
-#: opac/webapp/admin/views.py:460 opac/webapp/admin/views.py:538
-#: opac/webapp/admin/views.py:614
+#: build/lib/opac/webapp/admin/views.py:460
+#: build/lib/opac/webapp/admin/views.py:538
+#: build/lib/opac/webapp/admin/views.py:614 opac/webapp/admin/views.py:460
+#: opac/webapp/admin/views.py:538 opac/webapp/admin/views.py:614
 msgid "Criado"
 msgstr ""
 
-#: opac/webapp/admin/views.py:461 opac/webapp/admin/views.py:539
-#: opac/webapp/admin/views.py:615
+#: build/lib/opac/webapp/admin/views.py:461
+#: build/lib/opac/webapp/admin/views.py:539
+#: build/lib/opac/webapp/admin/views.py:615 opac/webapp/admin/views.py:461
+#: opac/webapp/admin/views.py:539 opac/webapp/admin/views.py:615
 msgid "Atualizado"
 msgstr ""
 
-#: opac/webapp/admin/views.py:463
+#: build/lib/opac/webapp/admin/views.py:463 opac/webapp/admin/views.py:463
 msgid "ISSN SciELO"
 msgstr ""
 
-#: opac/webapp/admin/views.py:464
+#: build/lib/opac/webapp/admin/views.py:464 opac/webapp/admin/views.py:464
 msgid "ISSN impresso"
 msgstr ""
 
-#: opac/webapp/admin/views.py:465
+#: build/lib/opac/webapp/admin/views.py:465 opac/webapp/admin/views.py:465
 msgid "ISSN eletrônico"
 msgstr ""
 
-#: opac/webapp/admin/views.py:466
+#: build/lib/opac/webapp/admin/views.py:466 opac/webapp/admin/views.py:466
 msgid "Descritores de assunto"
 msgstr ""
 
-#: opac/webapp/admin/views.py:467
+#: build/lib/opac/webapp/admin/views.py:467 opac/webapp/admin/views.py:467
 msgid "Url da submissão online"
 msgstr ""
 
-#: opac/webapp/admin/views.py:468
+#: build/lib/opac/webapp/admin/views.py:468 opac/webapp/admin/views.py:468
 msgid "Url do capa"
 msgstr ""
 
-#: opac/webapp/admin/views.py:469
+#: build/lib/opac/webapp/admin/views.py:469 opac/webapp/admin/views.py:469
 msgid "Url do logotipo"
 msgstr ""
 
-#: opac/webapp/admin/views.py:470
+#: build/lib/opac/webapp/admin/views.py:470 opac/webapp/admin/views.py:470
 msgid "Outros títulos"
 msgstr ""
 
-#: opac/webapp/admin/views.py:471
+#: build/lib/opac/webapp/admin/views.py:471 opac/webapp/admin/views.py:471
 msgid "Nome da editora"
 msgstr ""
 
-#: opac/webapp/admin/views.py:472
+#: build/lib/opac/webapp/admin/views.py:472 opac/webapp/admin/views.py:472
 msgid "País da editora"
 msgstr ""
 
-#: opac/webapp/admin/views.py:473
+#: build/lib/opac/webapp/admin/views.py:473 opac/webapp/admin/views.py:473
 msgid "Estado da editora"
 msgstr ""
 
-#: opac/webapp/admin/views.py:474
+#: build/lib/opac/webapp/admin/views.py:474 opac/webapp/admin/views.py:474
 msgid "Cidade da editora"
 msgstr ""
 
-#: opac/webapp/admin/views.py:475
+#: build/lib/opac/webapp/admin/views.py:475 opac/webapp/admin/views.py:475
 msgid "Endereço da editora"
 msgstr ""
 
-#: opac/webapp/admin/views.py:476
+#: build/lib/opac/webapp/admin/views.py:476 opac/webapp/admin/views.py:476
 msgid "Telefone da editora"
 msgstr ""
 
-#: opac/webapp/admin/views.py:477
+#: build/lib/opac/webapp/admin/views.py:477 opac/webapp/admin/views.py:477
 msgid "Missão"
 msgstr ""
 
-#: opac/webapp/admin/views.py:478
+#: build/lib/opac/webapp/admin/views.py:478 opac/webapp/admin/views.py:478
 msgid "No índice"
 msgstr ""
 
-#: opac/webapp/admin/views.py:479
+#: build/lib/opac/webapp/admin/views.py:479 opac/webapp/admin/views.py:479
 msgid "Patrocinadores"
 msgstr ""
 
-#: opac/webapp/admin/views.py:480
+#: build/lib/opac/webapp/admin/views.py:480 opac/webapp/admin/views.py:480
 msgid "Ref periódico anterior"
 msgstr ""
 
-#: opac/webapp/admin/views.py:481
+#: build/lib/opac/webapp/admin/views.py:481 opac/webapp/admin/views.py:481
 msgid "Situação atual"
 msgstr ""
 
-#: opac/webapp/admin/views.py:482
+#: build/lib/opac/webapp/admin/views.py:482 opac/webapp/admin/views.py:482
 msgid "Total de números"
 msgstr ""
 
-#: opac/webapp/admin/views.py:483 opac/webapp/admin/views.py:548
-#: opac/webapp/admin/views.py:618
+#: build/lib/opac/webapp/admin/views.py:483
+#: build/lib/opac/webapp/admin/views.py:548
+#: build/lib/opac/webapp/admin/views.py:618 opac/webapp/admin/views.py:483
+#: opac/webapp/admin/views.py:548 opac/webapp/admin/views.py:618
 msgid "Publicado?"
 msgstr ""
 
-#: opac/webapp/admin/views.py:484 opac/webapp/admin/views.py:549
-#: opac/webapp/admin/views.py:619
+#: build/lib/opac/webapp/admin/views.py:484
+#: build/lib/opac/webapp/admin/views.py:549
+#: build/lib/opac/webapp/admin/views.py:619 opac/webapp/admin/views.py:484
+#: opac/webapp/admin/views.py:549 opac/webapp/admin/views.py:619
 msgid "Motivo de despublicação"
 msgstr ""
 
-#: opac/webapp/admin/views.py:485 opac/webapp/admin/views.py:551
-#: opac/webapp/admin/views.py:620
+#: build/lib/opac/webapp/admin/views.py:485
+#: build/lib/opac/webapp/admin/views.py:551
+#: build/lib/opac/webapp/admin/views.py:620 opac/webapp/admin/views.py:485
+#: opac/webapp/admin/views.py:551 opac/webapp/admin/views.py:620
 msgid "Segmento de URL"
 msgstr ""
 
-#: opac/webapp/admin/views.py:488 opac/webapp/admin/views.py:554
-#: opac/webapp/admin/views.py:633
+#: build/lib/opac/webapp/admin/views.py:488
+#: build/lib/opac/webapp/admin/views.py:554
+#: build/lib/opac/webapp/admin/views.py:633 opac/webapp/admin/views.py:488
+#: opac/webapp/admin/views.py:554 opac/webapp/admin/views.py:633
 msgid "Publicar"
 msgstr ""
 
-#: opac/webapp/admin/views.py:493
+#: build/lib/opac/webapp/admin/views.py:493 opac/webapp/admin/views.py:493
 msgid "Periódico(s) publicado(s) com sucesso!!"
 msgstr ""
 
-#: opac/webapp/admin/views.py:495
+#: build/lib/opac/webapp/admin/views.py:495 opac/webapp/admin/views.py:495
 msgid "Ocorreu um erro tentando publicar o(s) periódico(s)!!"
 msgstr ""
 
-#: opac/webapp/admin/views.py:501
+#: build/lib/opac/webapp/admin/views.py:501 opac/webapp/admin/views.py:501
 msgid "Periódico(s) despublicado com sucesso!!"
 msgstr ""
 
-#: opac/webapp/admin/views.py:504
+#: build/lib/opac/webapp/admin/views.py:504 opac/webapp/admin/views.py:504
 #, python-format
 msgid "Ocorreu um erro tentando despublicar o(s) periódico(s)!!. Erro: %(ex)s"
 msgstr ""
 
-#: opac/webapp/admin/views.py:508 opac/webapp/admin/views.py:576
-#: opac/webapp/admin/views.py:656
+#: build/lib/opac/webapp/admin/views.py:508
+#: build/lib/opac/webapp/admin/views.py:576
+#: build/lib/opac/webapp/admin/views.py:656 opac/webapp/admin/views.py:508
+#: opac/webapp/admin/views.py:576 opac/webapp/admin/views.py:656
 #, python-format
 msgid "Despublicar por %s"
 msgstr ""
 
-#: opac/webapp/admin/views.py:532
+#: build/lib/opac/webapp/admin/views.py:532 opac/webapp/admin/views.py:532
 msgid "Id Número"
 msgstr ""
 
-#: opac/webapp/admin/views.py:534 opac/webapp/admin/views.py:624
+#: build/lib/opac/webapp/admin/views.py:534
+#: build/lib/opac/webapp/admin/views.py:624 opac/webapp/admin/views.py:534
+#: opac/webapp/admin/views.py:624
 msgid "Seções"
 msgstr ""
 
-#: opac/webapp/admin/views.py:535
+#: build/lib/opac/webapp/admin/views.py:535 opac/webapp/admin/views.py:535
 msgid "Url da capa"
 msgstr ""
 
+#: build/lib/opac/webapp/admin/views.py:536
+#: build/lib/opac/webapp/templates/collection/list_feed_content.html:3
+#: build/lib/opac/webapp/templates/issue/grid.html:40
+#: build/lib/opac/webapp/templates/news/includes/issue_last_row.html:7
 #: opac/webapp/admin/views.py:536
 #: opac/webapp/templates/collection/list_feed_content.html:3
 #: opac/webapp/templates/issue/grid.html:40
@@ -781,26 +912,31 @@ msgstr ""
 msgid "Volume"
 msgstr ""
 
-#: opac/webapp/admin/views.py:540
+#: build/lib/opac/webapp/admin/views.py:540 opac/webapp/admin/views.py:540
 msgid "Tipo"
 msgstr ""
 
-#: opac/webapp/admin/views.py:541
+#: build/lib/opac/webapp/admin/views.py:541 opac/webapp/admin/views.py:541
 msgid "Texto do suplemento"
 msgstr ""
 
-#: opac/webapp/admin/views.py:542
+#: build/lib/opac/webapp/admin/views.py:542 opac/webapp/admin/views.py:542
 msgid "Texto do especial"
 msgstr ""
 
-#: opac/webapp/admin/views.py:543
+#: build/lib/opac/webapp/admin/views.py:543 opac/webapp/admin/views.py:543
 msgid "Mês inicial"
 msgstr ""
 
-#: opac/webapp/admin/views.py:544
+#: build/lib/opac/webapp/admin/views.py:544 opac/webapp/admin/views.py:544
 msgid "Mês final"
 msgstr ""
 
+#: build/lib/opac/webapp/admin/views.py:545
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:25
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:68
+#: build/lib/opac/webapp/templates/issue/grid.html:39
+#: build/lib/opac/webapp/templates/news/includes/issue_last_row.html:5
 #: opac/webapp/admin/views.py:545
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:25
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:68
@@ -809,64 +945,74 @@ msgstr ""
 msgid "Ano"
 msgstr ""
 
-#: opac/webapp/admin/views.py:546
+#: build/lib/opac/webapp/admin/views.py:546 opac/webapp/admin/views.py:546
 msgid "Etiqueta"
 msgstr ""
 
-#: opac/webapp/admin/views.py:550 opac/webapp/admin/views.py:621
+#: build/lib/opac/webapp/admin/views.py:550
+#: build/lib/opac/webapp/admin/views.py:621 opac/webapp/admin/views.py:550
+#: opac/webapp/admin/views.py:621
 msgid "PID"
 msgstr ""
 
-#: opac/webapp/admin/views.py:559
+#: build/lib/opac/webapp/admin/views.py:559 opac/webapp/admin/views.py:559
 msgid "Número(s) publicado(s) com sucesso!!"
 msgstr ""
 
-#: opac/webapp/admin/views.py:562 opac/webapp/admin/views.py:642
+#: build/lib/opac/webapp/admin/views.py:562
+#: build/lib/opac/webapp/admin/views.py:642 opac/webapp/admin/views.py:562
+#: opac/webapp/admin/views.py:642
 #, python-format
 msgid "Ocorreu um erro tentando publicar o(s) número(s)!!. Erro: %(ex)s"
 msgstr ""
 
-#: opac/webapp/admin/views.py:569
+#: build/lib/opac/webapp/admin/views.py:569 opac/webapp/admin/views.py:569
 msgid "Número(s) despublicado(s) com sucesso!!"
 msgstr ""
 
-#: opac/webapp/admin/views.py:572 opac/webapp/admin/views.py:652
+#: build/lib/opac/webapp/admin/views.py:572
+#: build/lib/opac/webapp/admin/views.py:652 opac/webapp/admin/views.py:572
+#: opac/webapp/admin/views.py:652
 #, python-format
 msgid "Ocorreu um erro tentando despublicar o(s) número(s)!!. Erro: %(ex)s"
 msgstr ""
 
-#: opac/webapp/admin/views.py:608
+#: build/lib/opac/webapp/admin/views.py:608 opac/webapp/admin/views.py:608
 msgid "Id Artigo"
 msgstr ""
 
-#: opac/webapp/admin/views.py:612
+#: build/lib/opac/webapp/admin/views.py:612 opac/webapp/admin/views.py:612
 msgid "Seção"
 msgstr ""
 
-#: opac/webapp/admin/views.py:613
+#: build/lib/opac/webapp/admin/views.py:613 opac/webapp/admin/views.py:613
 msgid "É Ahead of Print?"
 msgstr ""
 
-#: opac/webapp/admin/views.py:616
+#: build/lib/opac/webapp/admin/views.py:616 opac/webapp/admin/views.py:616
 msgid "HTML's"
 msgstr ""
 
-#: opac/webapp/admin/views.py:617
+#: build/lib/opac/webapp/admin/views.py:617 opac/webapp/admin/views.py:617
 msgid "Chave de domínio"
 msgstr ""
 
-#: opac/webapp/admin/views.py:622
+#: build/lib/opac/webapp/admin/views.py:622 opac/webapp/admin/views.py:622
 msgid "Idioma original"
 msgstr ""
 
-#: opac/webapp/admin/views.py:623
+#: build/lib/opac/webapp/admin/views.py:623 opac/webapp/admin/views.py:623
 msgid "Idiomas das traduções"
 msgstr ""
 
-#: opac/webapp/admin/views.py:625
+#: build/lib/opac/webapp/admin/views.py:625 opac/webapp/admin/views.py:625
 msgid "Autores"
 msgstr ""
 
+#: build/lib/opac/webapp/admin/views.py:626
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:29
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:72
+#: build/lib/opac/webapp/templates/issue/toc.html:176
 #: opac/webapp/admin/views.py:626
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:29
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:72
@@ -874,198 +1020,230 @@ msgstr ""
 msgid "Resumo"
 msgstr ""
 
-#: opac/webapp/admin/views.py:628
+#: build/lib/opac/webapp/admin/views.py:628 opac/webapp/admin/views.py:628
 msgid "DOI"
 msgstr ""
 
-#: opac/webapp/admin/views.py:629
+#: build/lib/opac/webapp/admin/views.py:629 opac/webapp/admin/views.py:629
 msgid "Idiomas"
 msgstr ""
 
-#: opac/webapp/admin/views.py:630
+#: build/lib/opac/webapp/admin/views.py:630 opac/webapp/admin/views.py:630
 msgid "Idiomas dos resumos"
 msgstr ""
 
-#: opac/webapp/admin/views.py:638
+#: build/lib/opac/webapp/admin/views.py:638 opac/webapp/admin/views.py:638
 msgid "Artigo(s) publicado com sucesso!!"
 msgstr ""
 
-#: opac/webapp/admin/views.py:649
+#: build/lib/opac/webapp/admin/views.py:649 opac/webapp/admin/views.py:649
 msgid "Artigo(s) despublicado com sucesso!!"
 msgstr ""
 
-#: opac/webapp/admin/views.py:679
+#: build/lib/opac/webapp/admin/views.py:679 opac/webapp/admin/views.py:679
 msgid "Conteúdo"
 msgstr ""
 
-#: opac/webapp/admin/views.py:681 opac/webapp/admin/views.py:901
+#: build/lib/opac/webapp/admin/views.py:681
+#: build/lib/opac/webapp/admin/views.py:901 opac/webapp/admin/views.py:681
+#: opac/webapp/admin/views.py:901
 msgid "Descrição"
 msgstr ""
 
-#: opac/webapp/admin/views.py:682 opac/webapp/admin/views.py:898
+#: build/lib/opac/webapp/admin/views.py:682
+#: build/lib/opac/webapp/admin/views.py:898 opac/webapp/admin/views.py:682
+#: opac/webapp/admin/views.py:898
 msgid "Data de Criação"
 msgstr ""
 
-#: opac/webapp/admin/views.py:683
+#: build/lib/opac/webapp/admin/views.py:683 opac/webapp/admin/views.py:683
 msgid "Data de Atualização"
 msgstr ""
 
-#: opac/webapp/admin/views.py:897
+#: build/lib/opac/webapp/admin/views.py:897 opac/webapp/admin/views.py:897
 msgid "Ação"
 msgstr ""
 
-#: opac/webapp/admin/views.py:899
+#: build/lib/opac/webapp/admin/views.py:899 opac/webapp/admin/views.py:899
 msgid "Modelo Auditado"
 msgstr ""
 
-#: opac/webapp/admin/views.py:900
+#: build/lib/opac/webapp/admin/views.py:900 opac/webapp/admin/views.py:900
 msgid "Id Auditado"
 msgstr ""
 
-#: opac/webapp/admin/views.py:902
+#: build/lib/opac/webapp/admin/views.py:902 opac/webapp/admin/views.py:902
 msgid "Dados dos campos"
 msgstr ""
 
-#: opac/webapp/main/views.py:29
+#: build/lib/opac/webapp/main/views.py:34 opac/webapp/main/views.py:34
 msgid "O periódico está indisponível por motivo de: "
 msgstr ""
 
-#: opac/webapp/main/views.py:30
+#: build/lib/opac/webapp/main/views.py:35 opac/webapp/main/views.py:35
 msgid "O número está indisponível por motivo de: "
 msgstr ""
 
-#: opac/webapp/main/views.py:31
+#: build/lib/opac/webapp/main/views.py:36 opac/webapp/main/views.py:36
 msgid "O artigo está indisponível por motivo de: "
 msgstr ""
 
-#: opac/webapp/main/views.py:78
+#: build/lib/opac/webapp/main/views.py:127 opac/webapp/main/views.py:127
 msgid "Código de idioma inválido"
 msgstr ""
 
-#: opac/webapp/main/views.py:148
+#: build/lib/opac/webapp/main/views.py:197 opac/webapp/main/views.py:197
 msgid "Últimos periódicos inseridos na coleção"
 msgstr ""
 
-#: opac/webapp/main/views.py:149
+#: build/lib/opac/webapp/main/views.py:198 opac/webapp/main/views.py:198
 #, python-format
 msgid "10 últimos periódicos inseridos na coleção %s"
 msgstr ""
 
-#: opac/webapp/main/views.py:208
+#: build/lib/opac/webapp/main/views.py:257 opac/webapp/main/views.py:257
 msgid "Página não encontrada"
 msgstr ""
 
-#: opac/webapp/main/views.py:232 opac/webapp/main/views.py:322
+#: build/lib/opac/webapp/main/views.py:281
+#: build/lib/opac/webapp/main/views.py:371 opac/webapp/main/views.py:281
+#: opac/webapp/main/views.py:371
 #, python-format
 msgid "Requsição inválida ao tentar acessar o artigo com pid: %s"
 msgstr ""
 
-#: opac/webapp/main/views.py:240 opac/webapp/main/views.py:290
-#: opac/webapp/main/views.py:334 opac/webapp/main/views.py:403
-#: opac/webapp/main/views.py:450 opac/webapp/main/views.py:597
-#: opac/webapp/main/views.py:614 opac/webapp/main/views.py:1055
+#: build/lib/opac/webapp/main/views.py:289
+#: build/lib/opac/webapp/main/views.py:339
+#: build/lib/opac/webapp/main/views.py:383
+#: build/lib/opac/webapp/main/views.py:452
+#: build/lib/opac/webapp/main/views.py:500
+#: build/lib/opac/webapp/main/views.py:647
+#: build/lib/opac/webapp/main/views.py:664
+#: build/lib/opac/webapp/main/views.py:1127 opac/webapp/main/views.py:289
+#: opac/webapp/main/views.py:339 opac/webapp/main/views.py:383
+#: opac/webapp/main/views.py:452 opac/webapp/main/views.py:500
+#: opac/webapp/main/views.py:647 opac/webapp/main/views.py:664
+#: opac/webapp/main/views.py:1127
 msgid "Periódico não encontrado"
 msgstr ""
 
-#: opac/webapp/main/views.py:252 opac/webapp/main/views.py:664
-#: opac/webapp/main/views.py:723 opac/webapp/main/views.py:1064
+#: build/lib/opac/webapp/main/views.py:301
+#: build/lib/opac/webapp/main/views.py:714
+#: build/lib/opac/webapp/main/views.py:773
+#: build/lib/opac/webapp/main/views.py:1136 opac/webapp/main/views.py:301
+#: opac/webapp/main/views.py:714 opac/webapp/main/views.py:773
+#: opac/webapp/main/views.py:1136
 msgid "Número não encontrado"
 msgstr ""
 
-#: opac/webapp/main/views.py:270 opac/webapp/main/views.py:305
-#: opac/webapp/main/views.py:774 opac/webapp/main/views.py:805
-#: opac/webapp/main/views.py:881 opac/webapp/main/views.py:884
-#: opac/webapp/main/views.py:988
+#: build/lib/opac/webapp/main/views.py:319
+#: build/lib/opac/webapp/main/views.py:354
+#: build/lib/opac/webapp/main/views.py:825
+#: build/lib/opac/webapp/main/views.py:910
+#: build/lib/opac/webapp/main/views.py:1060 opac/webapp/main/views.py:319
+#: opac/webapp/main/views.py:354 opac/webapp/main/views.py:825
+#: opac/webapp/main/views.py:910 opac/webapp/main/views.py:1060
 msgid "Artigo não encontrado"
 msgstr ""
 
-#: opac/webapp/main/views.py:427
+#: build/lib/opac/webapp/main/views.py:476 opac/webapp/main/views.py:476
 msgid "Artigo sem título"
 msgstr ""
 
-#: opac/webapp/main/views.py:498 opac/webapp/main/views.py:515
+#: build/lib/opac/webapp/main/views.py:548
+#: build/lib/opac/webapp/main/views.py:565 opac/webapp/main/views.py:548
+#: opac/webapp/main/views.py:565
 msgid "Requisição inválida. Deve ser por ajax"
 msgstr ""
 
-#: opac/webapp/main/views.py:531
+#: build/lib/opac/webapp/main/views.py:581 opac/webapp/main/views.py:581
 msgid ""
 "Parámetro \"filter\" é inválido, deve ser \"areas\", \"wos\" ou "
 "\"publisher\"."
 msgstr ""
 
-#: opac/webapp/main/views.py:540
+#: build/lib/opac/webapp/main/views.py:590 opac/webapp/main/views.py:590
 msgid "Parámetro \"extension\" é inválido, deve ser \"csv\" ou \"xls\"."
 msgstr ""
 
-#: opac/webapp/main/views.py:542
+#: build/lib/opac/webapp/main/views.py:592 opac/webapp/main/views.py:592
 msgid ""
 "Parámetro \"list_type\" é inválido, deve ser: \"alpha\", \"areas\", "
 "\"wos\" ou \"publisher\"."
 msgstr ""
 
-#: opac/webapp/main/views.py:563
+#: build/lib/opac/webapp/main/views.py:613 opac/webapp/main/views.py:613
 msgid "Requisição inválida, deve ser ajax."
 msgstr ""
 
-#: opac/webapp/main/views.py:572
+#: build/lib/opac/webapp/main/views.py:622 opac/webapp/main/views.py:622
 msgid "Periódico não permite envio de email."
 msgstr ""
 
-#: opac/webapp/main/views.py:590
+#: build/lib/opac/webapp/main/views.py:640 opac/webapp/main/views.py:640
 msgid "Requisição inválida, captcha inválido."
 msgstr ""
 
-#: opac/webapp/main/views.py:796 opac/webapp/main/views.py:983
+#: build/lib/opac/webapp/main/views.py:901
+#: build/lib/opac/webapp/main/views.py:1055 opac/webapp/main/views.py:901
+#: opac/webapp/main/views.py:1055
 msgid "Issue não encontrado"
 msgstr ""
 
-#: opac/webapp/main/views.py:841 opac/webapp/main/views.py:847
-#: opac/webapp/main/views.py:1020 opac/webapp/main/views.py:1028
-#: opac/webapp/main/views.py:1030
+#: build/lib/opac/webapp/main/views.py:943
+#: build/lib/opac/webapp/main/views.py:949
+#: build/lib/opac/webapp/main/views.py:1092
+#: build/lib/opac/webapp/main/views.py:1100
+#: build/lib/opac/webapp/main/views.py:1102 opac/webapp/main/views.py:943
+#: opac/webapp/main/views.py:949 opac/webapp/main/views.py:1092
+#: opac/webapp/main/views.py:1100 opac/webapp/main/views.py:1102
 msgid "PDF do Artigo não encontrado"
 msgstr ""
 
-#: opac/webapp/main/views.py:857
-msgid "HTML do Artigo não encontrado"
-msgstr ""
-
-#: opac/webapp/main/views.py:871
+#: build/lib/opac/webapp/main/views.py:954 opac/webapp/main/views.py:954
 msgid "HTML do Artigo não encontrado ou indisponível"
 msgstr ""
 
-#: opac/webapp/main/views.py:930
+#: build/lib/opac/webapp/main/views.py:1001 opac/webapp/main/views.py:1001
 msgid "Parâmetros insuficientes para obter o EPDF do artigo"
 msgstr ""
 
-#: opac/webapp/main/views.py:947
+#: build/lib/opac/webapp/main/views.py:1022 opac/webapp/main/views.py:1022
 msgid "Recruso não encontrado"
 msgstr ""
 
-#: opac/webapp/main/views.py:952
-msgid "Recurso não encontrado"
-msgstr ""
-
-#: opac/webapp/main/views.py:969
+#: build/lib/opac/webapp/main/views.py:1041 opac/webapp/main/views.py:1041
 msgid "Recurso do Artigo não encontrado. Caminho inválido!"
 msgstr ""
 
-#: opac/webapp/main/views.py:1082
+#: build/lib/opac/webapp/main/views.py:1154 opac/webapp/main/views.py:1154
 msgid "PDF do artigo não foi encontrado"
 msgstr ""
 
-#: opac/webapp/main/views.py:1110 opac/webapp/main/views.py:1141
+#: build/lib/opac/webapp/main/views.py:1169
+#: build/lib/opac/webapp/main/views.py:1200 opac/webapp/main/views.py:1169
+#: opac/webapp/main/views.py:1200
 msgid "Requisição inválida."
 msgstr ""
 
+#: build/lib/opac/webapp/templates/admin/index.html:7
 #: opac/webapp/templates/admin/index.html:7
 msgid "da coleção"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/admin/index.html:12
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu.html:31
 #: opac/webapp/templates/admin/index.html:12
 #: opac/webapp/templates/collection/includes/levelMenu.html:31
 msgid "Periódicos"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/admin/index.html:15
+#: build/lib/opac/webapp/templates/admin/index.html:22
+#: build/lib/opac/webapp/templates/admin/index.html:35
+#: build/lib/opac/webapp/templates/admin/index.html:42
+#: build/lib/opac/webapp/templates/admin/index.html:55
+#: build/lib/opac/webapp/templates/admin/index.html:62
 #: opac/webapp/templates/admin/index.html:15
 #: opac/webapp/templates/admin/index.html:22
 #: opac/webapp/templates/admin/index.html:35
@@ -1075,6 +1253,12 @@ msgstr ""
 msgid "Publicados"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/admin/index.html:16
+#: build/lib/opac/webapp/templates/admin/index.html:36
+#: build/lib/opac/webapp/templates/admin/index.html:56
+#: build/lib/opac/webapp/templates/admin/index.html:75
+#: build/lib/opac/webapp/templates/admin/index.html:85
+#: build/lib/opac/webapp/templates/admin/index.html:95
 #: opac/webapp/templates/admin/index.html:16
 #: opac/webapp/templates/admin/index.html:36
 #: opac/webapp/templates/admin/index.html:56
@@ -1084,58 +1268,78 @@ msgstr ""
 msgid "Total"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/admin/index.html:32
 #: opac/webapp/templates/admin/index.html:32
 msgid "Fascícluos"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/admin/index.html:52
 #: opac/webapp/templates/admin/index.html:52
 msgid "Artigos"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/admin/index.html:72
 #: opac/webapp/templates/admin/index.html:72
 msgid "News"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/admin/index.html:82
 #: opac/webapp/templates/admin/index.html:82
 msgid "Sponsors"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/admin/index.html:92
 #: opac/webapp/templates/admin/index.html:92
 msgid "Press Releases"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/admin/auth/reset.html:9
+#: build/lib/opac/webapp/templates/admin/auth/reset_with_token.html:9
+#: build/lib/opac/webapp/templates/admin/opac_base.html:13
 #: opac/webapp/templates/admin/auth/reset.html:9
 #: opac/webapp/templates/admin/auth/reset_with_token.html:9
 #: opac/webapp/templates/admin/opac_base.html:13
 msgid "Recuperar a senha"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/admin/opac_base.html:14
 #: opac/webapp/templates/admin/opac_base.html:14
 msgid "Terminar sessão"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/admin/auth/login.html:11
+#: build/lib/opac/webapp/templates/admin/auth/login.html:20
+#: build/lib/opac/webapp/templates/admin/opac_base.html:18
 #: opac/webapp/templates/admin/auth/login.html:11
 #: opac/webapp/templates/admin/auth/login.html:20
 #: opac/webapp/templates/admin/opac_base.html:18
 msgid "Iniciar sessão"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/admin/audit_log/fields_data_table.html:4
 #: opac/webapp/templates/admin/audit_log/fields_data_table.html:4
 msgid "Campo: "
 msgstr ""
 
+#: build/lib/opac/webapp/templates/admin/audit_log/fields_data_table.html:5
 #: opac/webapp/templates/admin/audit_log/fields_data_table.html:5
 msgid "Valor anterior: "
 msgstr ""
 
+#: build/lib/opac/webapp/templates/admin/audit_log/fields_data_table.html:6
 #: opac/webapp/templates/admin/audit_log/fields_data_table.html:6
 msgid "Valor novo: "
 msgstr ""
 
+#: build/lib/opac/webapp/templates/admin/auth/login.html:13
 #: opac/webapp/templates/admin/auth/login.html:13
 msgid "Você já iniciou sessão!"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/admin/auth/login.html:24
+#: build/lib/opac/webapp/templates/admin/auth/reset.html:13
+#: build/lib/opac/webapp/templates/admin/auth/reset_with_token.html:13
+#: build/lib/opac/webapp/templates/includes/error_form.html:60
 #: opac/webapp/templates/admin/auth/login.html:24
 #: opac/webapp/templates/admin/auth/reset.html:13
 #: opac/webapp/templates/admin/auth/reset_with_token.html:13
@@ -1143,14 +1347,17 @@ msgstr ""
 msgid "Enviar"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/admin/auth/login.html:28
 #: opac/webapp/templates/admin/auth/login.html:28
 msgid "Esqueci a senha?"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/admin/auth/unconfirm_email.html:7
 #: opac/webapp/templates/admin/auth/unconfirm_email.html:7
 msgid "Email não confirmado!"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/admin/auth/unconfirm_email.html:9
 #: opac/webapp/templates/admin/auth/unconfirm_email.html:9
 msgid ""
 "Você <strong>deve</strong> confirmar seu email.<br>\n"
@@ -1158,6 +1365,7 @@ msgid ""
 "administrador.</strong>"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/admin/pages/edit.html:7
 #: opac/webapp/templates/admin/pages/edit.html:7
 msgid ""
 "<strong>Atenção:</strong> ao selecionar um <strong>periódico</strong> "
@@ -1166,6 +1374,11 @@ msgid ""
 "<em>Sobre o SciELO</em>. "
 msgstr ""
 
+#: build/lib/opac/webapp/templates/article/includes/alternative_header.html:7
+#: build/lib/opac/webapp/templates/collection/includes/header.html:7
+#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:7
+#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:7
+#: build/lib/opac/webapp/templates/journal/includes/header.html:8
 #: opac/webapp/templates/article/includes/alternative_header.html:7
 #: opac/webapp/templates/collection/includes/header.html:7
 #: opac/webapp/templates/issue/includes/alternative_header.html:7
@@ -1174,6 +1387,10 @@ msgstr ""
 msgid "Abrir menu"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/article/includes/alternative_header.html:9
+#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:9
+#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:9
+#: build/lib/opac/webapp/templates/journal/includes/header.html:10
 #: opac/webapp/templates/article/includes/alternative_header.html:9
 #: opac/webapp/templates/issue/includes/alternative_header.html:9
 #: opac/webapp/templates/journal/includes/alternative_header.html:9
@@ -1181,6 +1398,11 @@ msgstr ""
 msgid "Ir para a homepage da coleção: "
 msgstr ""
 
+#: build/lib/opac/webapp/templates/article/includes/alternative_header.html:42
+#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:7
+#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:121
+#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:117
+#: build/lib/opac/webapp/templates/journal/includes/header.html:118
 #: opac/webapp/templates/article/includes/alternative_header.html:42
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:7
 #: opac/webapp/templates/issue/includes/alternative_header.html:121
@@ -1189,6 +1411,11 @@ msgstr ""
 msgid "Submissão de manuscritos"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/article/includes/alternative_header.html:48
+#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:16
+#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:127
+#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:123
+#: build/lib/opac/webapp/templates/journal/includes/header.html:124
 #: opac/webapp/templates/article/includes/alternative_header.html:48
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:16
 #: opac/webapp/templates/issue/includes/alternative_header.html:127
@@ -1197,6 +1424,11 @@ msgstr ""
 msgid "Sobre o periódico"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/article/includes/alternative_header.html:53
+#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:10
+#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:132
+#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:128
+#: build/lib/opac/webapp/templates/journal/includes/header.html:129
 #: opac/webapp/templates/article/includes/alternative_header.html:53
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:10
 #: opac/webapp/templates/issue/includes/alternative_header.html:132
@@ -1205,6 +1437,11 @@ msgstr ""
 msgid "Corpo Editorial"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/article/includes/alternative_header.html:58
+#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:13
+#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:137
+#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:133
+#: build/lib/opac/webapp/templates/journal/includes/header.html:134
 #: opac/webapp/templates/article/includes/alternative_header.html:58
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:13
 #: opac/webapp/templates/issue/includes/alternative_header.html:137
@@ -1213,6 +1450,11 @@ msgstr ""
 msgid "Instruções aos autores"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/article/includes/alternative_header.html:63
+#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:19
+#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:142
+#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:138
+#: build/lib/opac/webapp/templates/journal/includes/header.html:140
 #: opac/webapp/templates/article/includes/alternative_header.html:63
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:19
 #: opac/webapp/templates/issue/includes/alternative_header.html:142
@@ -1221,56 +1463,81 @@ msgstr ""
 msgid "Contato"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:2
+#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:60
 #: opac/webapp/templates/article/includes/floating_menu.html:2
 #: opac/webapp/templates/article/includes/floating_menu.html:60
 msgid "Ir para o topo"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:6
+#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:65
 #: opac/webapp/templates/article/includes/floating_menu.html:6
 #: opac/webapp/templates/article/includes/floating_menu.html:65
 msgid "PDFs"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:26
+#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:77
 #: opac/webapp/templates/article/includes/floating_menu.html:26
 #: opac/webapp/templates/article/includes/floating_menu.html:77
 msgid "Figuras e tabelas"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:32
+#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:83
 #: opac/webapp/templates/article/includes/floating_menu.html:32
 #: opac/webapp/templates/article/includes/floating_menu.html:83
 msgid "Versões e traduções"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:37
+#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:88
 #: opac/webapp/templates/article/includes/floating_menu.html:37
 #: opac/webapp/templates/article/includes/floating_menu.html:88
 msgid "Como citar este artigo"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:42
+#: build/lib/opac/webapp/templates/article/includes/modal/related_article.html:9
 #: opac/webapp/templates/article/includes/floating_menu.html:42
 #: opac/webapp/templates/article/includes/modal/related_article.html:9
 msgid "Artigos relacionados"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:93
 #: opac/webapp/templates/article/includes/floating_menu.html:93
 msgid "Artigos e similares"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:9
 #: opac/webapp/templates/article/includes/levelMenu.html:9
 msgid "home do periodico"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:17
+#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:70
+#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:123
 #: opac/webapp/templates/article/includes/levelMenu.html:17
 #: opac/webapp/templates/article/includes/levelMenu.html:70
 #: opac/webapp/templates/article/includes/levelMenu.html:123
 msgid "sumário"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:30
+#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:75
+#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:71
 #: opac/webapp/templates/article/includes/levelMenu.html:30
 #: opac/webapp/templates/issue/includes/alternative_header.html:75
 #: opac/webapp/templates/journal/includes/alternative_header.html:71
 msgid "anterior"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:35
+#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:88
+#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:141
+#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:82
+#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:78
 #: opac/webapp/templates/article/includes/levelMenu.html:35
 #: opac/webapp/templates/article/includes/levelMenu.html:88
 #: opac/webapp/templates/article/includes/levelMenu.html:141
@@ -1279,10 +1546,15 @@ msgstr ""
 msgid "atual"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:48
 #: opac/webapp/templates/article/includes/levelMenu.html:48
 msgid "seguinte"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:193
+#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:219
+#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:264
+#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:290
 #: opac/webapp/templates/article/includes/levelMenu.html:193
 #: opac/webapp/templates/article/includes/levelMenu.html:219
 #: opac/webapp/templates/article/includes/levelMenu.html:264
@@ -1290,6 +1562,10 @@ msgstr ""
 msgid "Download PDF (Espanhol)"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:195
+#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:221
+#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:266
+#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:292
 #: opac/webapp/templates/article/includes/levelMenu.html:195
 #: opac/webapp/templates/article/includes/levelMenu.html:221
 #: opac/webapp/templates/article/includes/levelMenu.html:266
@@ -1297,6 +1573,10 @@ msgstr ""
 msgid "Download PDF (Inglês)"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:197
+#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:223
+#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:268
+#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:294
 #: opac/webapp/templates/article/includes/levelMenu.html:197
 #: opac/webapp/templates/article/includes/levelMenu.html:223
 #: opac/webapp/templates/article/includes/levelMenu.html:268
@@ -1304,6 +1584,13 @@ msgstr ""
 msgid "Download PDF (Português)"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:310
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu.html:38
+#: build/lib/opac/webapp/templates/collection/includes/list_journals_section_title.html:14
+#: build/lib/opac/webapp/templates/issue/grid.html:14
+#: build/lib/opac/webapp/templates/issue/toc.html:13
+#: build/lib/opac/webapp/templates/journal/about.html:16
+#: build/lib/opac/webapp/templates/journal/detail.html:11
 #: opac/webapp/templates/article/includes/levelMenu.html:310
 #: opac/webapp/templates/collection/includes/levelMenu.html:38
 #: opac/webapp/templates/collection/includes/list_journals_section_title.html:14
@@ -1314,6 +1601,11 @@ msgstr ""
 msgid "Compartilhe"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:311
+#: build/lib/opac/webapp/templates/collection/includes/list_journals_section_title.html:16
+#: build/lib/opac/webapp/templates/issue/toc.html:14
+#: build/lib/opac/webapp/templates/journal/about.html:17
+#: build/lib/opac/webapp/templates/journal/detail.html:12
 #: opac/webapp/templates/article/includes/levelMenu.html:311
 #: opac/webapp/templates/collection/includes/list_journals_section_title.html:16
 #: opac/webapp/templates/issue/toc.html:14
@@ -1322,6 +1614,11 @@ msgstr ""
 msgid "Enviar link por e-mail"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:314
+#: build/lib/opac/webapp/templates/collection/includes/list_journals_section_title.html:19
+#: build/lib/opac/webapp/templates/issue/toc.html:15
+#: build/lib/opac/webapp/templates/journal/about.html:18
+#: build/lib/opac/webapp/templates/journal/detail.html:13
 #: opac/webapp/templates/article/includes/levelMenu.html:314
 #: opac/webapp/templates/collection/includes/list_journals_section_title.html:19
 #: opac/webapp/templates/issue/toc.html:15
@@ -1330,6 +1627,11 @@ msgstr ""
 msgid "Compartilhar no Facebook"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:317
+#: build/lib/opac/webapp/templates/collection/includes/list_journals_section_title.html:22
+#: build/lib/opac/webapp/templates/issue/toc.html:16
+#: build/lib/opac/webapp/templates/journal/about.html:19
+#: build/lib/opac/webapp/templates/journal/detail.html:14
 #: opac/webapp/templates/article/includes/levelMenu.html:317
 #: opac/webapp/templates/collection/includes/list_journals_section_title.html:22
 #: opac/webapp/templates/issue/toc.html:16
@@ -1338,6 +1640,18 @@ msgstr ""
 msgid "Compartilhar no Twitter"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:320
+#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:325
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu.html:46
+#: build/lib/opac/webapp/templates/collection/includes/list_journals_section_title.html:25
+#: build/lib/opac/webapp/templates/collection/includes/list_journals_section_title.html:30
+#: build/lib/opac/webapp/templates/issue/grid.html:20
+#: build/lib/opac/webapp/templates/issue/toc.html:17
+#: build/lib/opac/webapp/templates/issue/toc.html:19
+#: build/lib/opac/webapp/templates/journal/about.html:20
+#: build/lib/opac/webapp/templates/journal/about.html:22
+#: build/lib/opac/webapp/templates/journal/detail.html:15
+#: build/lib/opac/webapp/templates/journal/detail.html:17
 #: opac/webapp/templates/article/includes/levelMenu.html:320
 #: opac/webapp/templates/article/includes/levelMenu.html:325
 #: opac/webapp/templates/collection/includes/levelMenu.html:46
@@ -1353,16 +1667,24 @@ msgstr ""
 msgid "Outras redes sociais"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/article/includes/recent_articles_row.html:6
+#: build/lib/opac/webapp/templates/issue/toc.html:149
 #: opac/webapp/templates/article/includes/recent_articles_row.html:6
 #: opac/webapp/templates/issue/toc.html:149
 msgid "Documento sem título"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/article/includes/recent_articles_row.html:13
+#: build/lib/opac/webapp/templates/news/includes/journal_news_row.html:14
 #: opac/webapp/templates/article/includes/recent_articles_row.html:13
-#: opac/webapp/templates/news/includes/journal_news_row.html:9
+#: opac/webapp/templates/news/includes/journal_news_row.html:14
 msgid "Continue lendo"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/article/includes/modal/download.html:6
+#: build/lib/opac/webapp/templates/article/includes/modal/related_article.html:7
+#: build/lib/opac/webapp/templates/email/email_form.html:7
+#: build/lib/opac/webapp/templates/includes/metric_modal.html:6
 #: opac/webapp/templates/article/includes/modal/download.html:6
 #: opac/webapp/templates/article/includes/modal/related_article.html:7
 #: opac/webapp/templates/email/email_form.html:7
@@ -1370,607 +1692,791 @@ msgstr ""
 msgid "Fechar"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/article/includes/modal/download.html:8
 #: opac/webapp/templates/article/includes/modal/download.html:8
 msgid "Versão para download de PDF"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/article/includes/modal/translate_version.html:6
 #: opac/webapp/templates/article/includes/modal/translate_version.html:6
 msgid "Versões e tradução automática"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/article/includes/modal/translate_version.html:11
 #: opac/webapp/templates/article/includes/modal/translate_version.html:11
 msgid "Versão original do texto"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/about.html:23
+#: build/lib/opac/webapp/templates/collection/pages.html:21
 #: opac/webapp/templates/collection/about.html:23
+#: opac/webapp/templates/collection/pages.html:21
 #, python-format
 msgid " %(page)s "
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/about.html:38
+#: build/lib/opac/webapp/templates/collection/pages.html:36
 #: opac/webapp/templates/collection/about.html:38
+#: opac/webapp/templates/collection/pages.html:36
 msgid " Conteúdo não cadastrado "
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/index.html:17
 #: opac/webapp/templates/collection/index.html:17
 msgid "em números | Métricas"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/index.html:27
 #: opac/webapp/templates/collection/index.html:27
 msgid "períodicos"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:31
+#: build/lib/opac/webapp/templates/collection/index.html:31
+#: build/lib/opac/webapp/templates/collection/list_feed_content.html:7
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:31
 #: opac/webapp/templates/collection/index.html:31
 #: opac/webapp/templates/collection/list_feed_content.html:7
 msgid "números"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/index.html:35
+#: build/lib/opac/webapp/templates/issue/grid.html:68
 #: opac/webapp/templates/collection/index.html:35
 #: opac/webapp/templates/issue/grid.html:68
 msgid "artigos"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/index.html:39
 #: opac/webapp/templates/collection/index.html:39
 msgid "referências"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/index.html:45
 #: opac/webapp/templates/collection/index.html:45
 msgid "Downloads"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/index.html:48
 #: opac/webapp/templates/collection/index.html:48
 msgid "Citações"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/index.html:51
 #: opac/webapp/templates/collection/index.html:51
 msgid "Outros indicadores"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/index.html:62
+#: build/lib/opac/webapp/templates/collection/list_journal.html:3
 #: opac/webapp/templates/collection/index.html:62
 #: opac/webapp/templates/collection/list_journal.html:3
 msgid "Lista de periódicos"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/index.html:66
+#: build/lib/opac/webapp/templates/collection/list_journal.html:21
 #: opac/webapp/templates/collection/index.html:66
 #: opac/webapp/templates/collection/list_journal.html:21
 msgid "Alfabética"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/index.html:69
+#: build/lib/opac/webapp/templates/collection/list_journal.html:24
 #: opac/webapp/templates/collection/index.html:69
 #: opac/webapp/templates/collection/list_journal.html:24
 msgid "Temática"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/index.html:77
 #: opac/webapp/templates/collection/index.html:77
 msgid "Busca por periódicos"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/index.html:105
 #: opac/webapp/templates/collection/index.html:105
 msgid "Números <span>mais recentes</span>"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/index.html:149
 #: opac/webapp/templates/collection/index.html:149
 msgid "em perspectiva"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/list_feed_content.html:1
 #: opac/webapp/templates/collection/list_feed_content.html:1
 msgid "Último número"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/list_feed_content.html:4
 #: opac/webapp/templates/collection/list_feed_content.html:4
 msgid "Nº"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/list_feed_content.html:6
 #: opac/webapp/templates/collection/list_feed_content.html:6
 msgid "descontinuado"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/list_feed_content.html:7
 #: opac/webapp/templates/collection/list_feed_content.html:7
 msgid "de"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu.html:11
+#: build/lib/opac/webapp/templates/collection/list_journal.html:16
 #: opac/webapp/templates/collection/includes/levelMenu.html:11
 #: opac/webapp/templates/collection/list_journal.html:16
 msgid "Home"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_grouper_table_container.html:14
+#: build/lib/opac/webapp/templates/collection/list_journal.html:52
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_grouper_table_container.html:14
 #: opac/webapp/templates/collection/list_journal.html:52
 msgid "download da lista"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_grouper_table_container.html:15
+#: build/lib/opac/webapp/templates/collection/list_journal.html:53
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_grouper_table_container.html:15
 #: opac/webapp/templates/collection/list_journal.html:53
 msgid "Lista em arquivo para Excel"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_grouper_table_container.html:18
+#: build/lib/opac/webapp/templates/collection/list_journal.html:56
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_grouper_table_container.html:18
 #: opac/webapp/templates/collection/list_journal.html:56
 msgid "Lista em arquivo CSV"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/list_journal.html:80
+#: build/lib/opac/webapp/templates/collection/list_journal.html:84
 #: opac/webapp/templates/collection/list_journal.html:80
 #: opac/webapp/templates/collection/list_journal.html:84
 msgid "Grandes áreas do conhecimento"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/list_journal.html:85
 #: opac/webapp/templates/collection/list_journal.html:85
 msgid "Áreas temáticas do Web of Science"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/list_journal.html:222
 #: opac/webapp/templates/collection/list_journal.html:222
 msgid "grandes áreas"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/list_journal.html:236
 #: opac/webapp/templates/collection/list_journal.html:236
 msgid "áreas WOS"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/list_journal.html:248
 #: opac/webapp/templates/collection/list_journal.html:248
 msgid "Editoras"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/list_journal.html:249
 #: opac/webapp/templates/collection/list_journal.html:249
 msgid "editoras"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:7
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:7
 msgid "Sobre o"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:19
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:62
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:19
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:62
 msgid "Entre uma ou mais palavras"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:24
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:67
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:24
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:67
 msgid "Todos os índices"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:26
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:69
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:26
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:69
 msgid "Autor"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:38
+#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:95
+#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:91
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:38
 #: opac/webapp/templates/issue/includes/alternative_header.html:95
 #: opac/webapp/templates/journal/includes/alternative_header.html:91
 msgid "Buscar"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:44
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:44
 msgid "Adicionar outro campo"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:49
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:49
 msgid "Apagar campo"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:63
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:63
 msgid "Limpar expressão"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:92
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:92
 msgid "Sem resultados"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:96
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:96
 msgid "Não foram encontrados documentos para sua pesquisa"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/includes/list_journals_search_input.html:5
 #: opac/webapp/templates/collection/includes/list_journals_search_input.html:5
 msgid "Todos"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/includes/list_journals_search_input.html:9
 #: opac/webapp/templates/collection/includes/list_journals_search_input.html:9
 msgid "Periódicos ativos"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/includes/list_journals_search_input.html:13
 #: opac/webapp/templates/collection/includes/list_journals_search_input.html:13
 msgid "Periódicos descontinuados"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/includes/list_journals_search_input.html:24
 #: opac/webapp/templates/collection/includes/list_journals_search_input.html:24
 msgid "Digite uma ou mais palavras para filtrar a lista"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/includes/nav.html:22
+#: build/lib/opac/webapp/templates/collection/includes/nav.html:64
 #: opac/webapp/templates/collection/includes/nav.html:22
 #: opac/webapp/templates/collection/includes/nav.html:64
 msgid "Busca"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/includes/nav.html:32
 #: opac/webapp/templates/collection/includes/nav.html:32
 msgid "Sobre:"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/includes/nav.html:44
 #: opac/webapp/templates/collection/includes/nav.html:44
 msgid "SciELO.org - Rede SciELO"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/includes/nav.html:95
 #: opac/webapp/templates/collection/includes/nav.html:95
 msgid "Blog SciELO em Perspectiva"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_empty.html:3
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_empty.html:3
 msgid "Nenhum periódico encontrado."
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_error.html:3
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_error.html:3
 msgid "Ocorreu um erro obtendo a lista de periódicos."
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_grouper_table_container.html:10
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_grouper_table_container.html:10
 msgid "periódicos"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:3
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:3
 msgid "Homepage"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:25
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:25
 msgid "Título do periódico"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:29
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:29
 msgid "Grade de número"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:36
+#: build/lib/opac/webapp/templates/journal/detail.html:89
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:36
 #: opac/webapp/templates/journal/detail.html:89
 msgid "Número mais recente"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:37
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:37
 msgid "Último"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:45
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:45
 msgid "Continua como "
 msgstr ""
 
+#: build/lib/opac/webapp/templates/email/email_form.html:10
 #: opac/webapp/templates/email/email_form.html:10
 msgid "Enviar página por e-mail"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/email/email_form.html:18
+#: build/lib/opac/webapp/templates/includes/error_form.html:26
+#: build/lib/opac/webapp/templates/journal/includes/contact_form.html:20
 #: opac/webapp/templates/email/email_form.html:18
 #: opac/webapp/templates/includes/error_form.html:26
 #: opac/webapp/templates/journal/includes/contact_form.html:20
 msgid "Seu e-mail"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/email/email_form.html:23
 #: opac/webapp/templates/email/email_form.html:23
 msgid "Para"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/email/email_form.html:27
 #: opac/webapp/templates/email/email_form.html:27
 msgid "Utilize ; (ponto e vírgula) para inserir mais emails."
 msgstr ""
 
+#: build/lib/opac/webapp/templates/email/email_form.html:36
 #: opac/webapp/templates/email/email_form.html:36
 msgid "Alterar assunto e comentários"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/email/email_form.html:41
 #: opac/webapp/templates/email/email_form.html:41
 msgid "Assunto"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/email/email_form.html:45
 #: opac/webapp/templates/email/email_form.html:45
 msgid "Comentário"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/email/email_form.html:49
 #: opac/webapp/templates/email/email_form.html:49
 msgid "Remover remetente, assunto e comentários"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/email/email_form.html:75
 #: opac/webapp/templates/email/email_form.html:75
 msgid "Email enviado com sucesso."
 msgstr ""
 
+#: build/lib/opac/webapp/templates/email/email_form.html:76
+#: build/lib/opac/webapp/templates/includes/error_form.html:86
+#: build/lib/opac/webapp/templates/journal/includes/contact_form.html:77
 #: opac/webapp/templates/email/email_form.html:76
 #: opac/webapp/templates/includes/error_form.html:86
 #: opac/webapp/templates/journal/includes/contact_form.html:77
 msgid "Erro ao tentar enviar e-mail, por favor tente mais tarde."
 msgstr ""
 
+#: build/lib/opac/webapp/templates/errors/400.html:7
 #: opac/webapp/templates/errors/400.html:7
 msgid "Ação inválida"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/errors/403.html:7
 #: opac/webapp/templates/errors/403.html:7
 msgid "Acesso não autorizado!"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/errors/404.html:7
 #: opac/webapp/templates/errors/404.html:7
 msgid ""
 "A URL solicitada não foi encontrada no servidor. Se você digitou a URL "
 "manualmente, por favor verifique e tente novamente."
 msgstr ""
 
+#: build/lib/opac/webapp/templates/errors/500.html:5
 #: opac/webapp/templates/errors/500.html:5
 msgid ""
 "Erro interno do servidor. Tente novamente mais tarde. Nossos engenheiros "
 "foram notificados."
 msgstr ""
 
+#: build/lib/opac/webapp/templates/errors/500.html:9
 #: opac/webapp/templates/errors/500.html:9
 msgid "Id. do erro"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/errors/base.html:24
 #: opac/webapp/templates/errors/base.html:24
 msgid "Erro"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/errors/base.html:27
 #: opac/webapp/templates/errors/base.html:27
 msgid "Qualquer dúvida, por favor entre em contato com o administrador"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/includes/error_form.html:5
 #: opac/webapp/templates/includes/error_form.html:5
 msgid " Reportar erro "
 msgstr ""
 
+#: build/lib/opac/webapp/templates/includes/error_form.html:20
+#: build/lib/opac/webapp/templates/journal/includes/contact_form.html:14
 #: opac/webapp/templates/includes/error_form.html:20
 #: opac/webapp/templates/journal/includes/contact_form.html:14
 msgid "Seu Nome"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/includes/error_form.html:21
 #: opac/webapp/templates/includes/error_form.html:21
 msgid "Digite seu Nome"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/includes/error_form.html:32
 #: opac/webapp/templates/includes/error_form.html:32
 msgid "Erro referente"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/includes/error_form.html:35
 #: opac/webapp/templates/includes/error_form.html:35
 msgid "ao conteúdo"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/includes/error_form.html:39
 #: opac/webapp/templates/includes/error_form.html:39
 msgid "à aplicação"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/includes/error_form.html:46
 #: opac/webapp/templates/includes/error_form.html:46
 msgid "Descrição do erro"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/includes/error_form.html:47
 #: opac/webapp/templates/includes/error_form.html:47
 msgid "Digite sua mensagem"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/includes/error_form.html:49
 #: opac/webapp/templates/includes/error_form.html:49
 msgid "Obs.: Link e título da página são enviados automaticamente"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/includes/error_form.html:85
 #: opac/webapp/templates/includes/error_form.html:85
 msgid "Email de erro enviado com sucesso."
 msgstr ""
 
+#: build/lib/opac/webapp/templates/includes/footer.html:36
 #: opac/webapp/templates/includes/footer.html:36
 msgid "Open Access"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/includes/footer.html:38
 #: opac/webapp/templates/includes/footer.html:38
 msgid "Leia"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/includes/footer.html:38
 #: opac/webapp/templates/includes/footer.html:38
 msgid "a Declaração de Acesso Aberto"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/issue/grid.html:4
 #: opac/webapp/templates/issue/grid.html:4
 msgid "Fascículos"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/issue/grid.html:33
 #: opac/webapp/templates/issue/grid.html:33
 msgid "Todos os números"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/issue/grid.html:79
 #: opac/webapp/templates/issue/grid.html:79
 msgid "supl."
 msgstr ""
 
+#: build/lib/opac/webapp/templates/issue/grid.html:98
 #: opac/webapp/templates/issue/grid.html:98
 msgid "Nenhum número encontrado para esse periódico"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/issue/grid.html:101
 #: opac/webapp/templates/issue/grid.html:101
 msgid "Histórico deste periódico na coleção"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/issue/grid.html:105
 #: opac/webapp/templates/issue/grid.html:105
 msgid " admitido na coleção da SciELO"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/issue/toc.html:10
+#: build/lib/opac/webapp/templates/journal/detail.html:8
 #: opac/webapp/templates/issue/toc.html:10
 #: opac/webapp/templates/journal/detail.html:8
 msgid "Imprimir"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/issue/toc.html:41
 #: opac/webapp/templates/issue/toc.html:41
 msgid "Editor científico"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/issue/toc.html:45
 #: opac/webapp/templates/issue/toc.html:45
 msgid "Editores associados"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/issue/toc.html:52
 #: opac/webapp/templates/issue/toc.html:52
 msgid "Veja toda a equipe editorial"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/issue/toc.html:63
 #: opac/webapp/templates/issue/toc.html:63
 msgid "Expandir/recolher conteúdo"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/issue/toc.html:72
+#: build/lib/opac/webapp/templates/journal/detail.html:96
 #: opac/webapp/templates/issue/toc.html:72
 #: opac/webapp/templates/journal/detail.html:96
 msgid "Sumário"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/issue/toc.html:79
 #: opac/webapp/templates/issue/toc.html:79
 msgid "Ordenar publicações por"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/issue/toc.html:82
 #: opac/webapp/templates/issue/toc.html:82
 msgid "Ordem do fascículo"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/issue/toc.html:83
 #: opac/webapp/templates/issue/toc.html:83
 msgid "Mais novos primeiro"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/issue/toc.html:84
 #: opac/webapp/templates/issue/toc.html:84
 msgid "Mais antigos primeiro"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/issue/toc.html:102
+#: build/lib/opac/webapp/templates/issue/toc.html:104
 #: opac/webapp/templates/issue/toc.html:102
 #: opac/webapp/templates/issue/toc.html:104
 msgid "Todas as seções"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/issue/toc.html:187
 #: opac/webapp/templates/issue/toc.html:187
 msgid "Texto"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/issue/toc.html:214
 #: opac/webapp/templates/issue/toc.html:214
 msgid "Resumo em"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:31
+#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:31
 #: opac/webapp/templates/issue/includes/alternative_header.html:31
 #: opac/webapp/templates/journal/includes/alternative_header.html:31
 msgid "Número atual"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:51
+#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:47
 #: opac/webapp/templates/issue/includes/alternative_header.html:51
 #: opac/webapp/templates/journal/includes/alternative_header.html:47
 msgid "Homepage do periódico"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:62
+#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:58
 #: opac/webapp/templates/issue/includes/alternative_header.html:62
 #: opac/webapp/templates/journal/includes/alternative_header.html:58
 msgid "Números"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:68
+#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:64
+#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:90
 #: opac/webapp/templates/issue/includes/alternative_header.html:68
 #: opac/webapp/templates/journal/includes/alternative_header.html:64
 #: opac/webapp/templates/journal/includes/levelMenu.html:90
 msgid "todos"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:89
+#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:85
 #: opac/webapp/templates/issue/includes/alternative_header.html:89
 #: opac/webapp/templates/journal/includes/alternative_header.html:85
 msgid "próximo"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/journal/about.html:39
 #: opac/webapp/templates/journal/about.html:39
 msgid "Conteúdo não cadastrado"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/journal/about.html:55
+#: build/lib/opac/webapp/templates/journal/includes/contact_footer.html:48
 #: opac/webapp/templates/journal/about.html:55
 #: opac/webapp/templates/journal/includes/contact_footer.html:48
 msgid "Siga este periódico nas redes sociais"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/journal/detail.html:32
 #: opac/webapp/templates/journal/detail.html:32
 msgid "Nossa Missão"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/journal/detail.html:34
 #: opac/webapp/templates/journal/detail.html:34
 msgid "Periódico sem missão cadastrada"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/journal/detail.html:42
 #: opac/webapp/templates/journal/detail.html:42
 msgid "Métricas deste periódico"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/journal/detail.html:52
 #: opac/webapp/templates/journal/detail.html:52
 msgid "Índice h5"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/journal/detail.html:54
+#: build/lib/opac/webapp/templates/journal/detail.html:66
 #: opac/webapp/templates/journal/detail.html:54
 #: opac/webapp/templates/journal/detail.html:66
 msgid "ano"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/journal/detail.html:58
+#: build/lib/opac/webapp/templates/journal/detail.html:70
 #: opac/webapp/templates/journal/detail.html:58
 #: opac/webapp/templates/journal/detail.html:70
 msgid "Não possui"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/journal/detail.html:63
 #: opac/webapp/templates/journal/detail.html:63
 msgid "Mediana h5"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/journal/detail.html:86
 #: opac/webapp/templates/journal/detail.html:86
 msgid "Capa do número mais recente"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/journal/detail.html:138
 #: opac/webapp/templates/journal/detail.html:138
 msgid "Artigos mais recentes"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/journal/includes/contact_footer.html:57
 #: opac/webapp/templates/journal/includes/contact_footer.html:57
 msgid "Acompanhe os números deste periódico no seu leitor de RSS"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/journal/includes/contact_form.html:26
 #: opac/webapp/templates/journal/includes/contact_form.html:26
 msgid "Mensagem"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/journal/includes/contact_form.html:76
 #: opac/webapp/templates/journal/includes/contact_form.html:76
 msgid "Email enviado para "
 msgstr ""
 
+#: build/lib/opac/webapp/templates/journal/includes/contact_form.html:76
 #: opac/webapp/templates/journal/includes/contact_form.html:76
 msgid "com sucesso."
 msgstr ""
 
+#: build/lib/opac/webapp/templates/journal/includes/header.html:42
 #: opac/webapp/templates/journal/includes/header.html:42
 msgid "Publicação de:"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/journal/includes/header.html:47
 #: opac/webapp/templates/journal/includes/header.html:47
 msgid "Área:"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/journal/includes/header.html:51
 #: opac/webapp/templates/journal/includes/header.html:51
-msgid "Multidiciplinar"
+msgid "Multidisciplinar"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/journal/includes/header.html:60
 #: opac/webapp/templates/journal/includes/header.html:60
 msgid "Versão impressa ISSN:"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/journal/includes/header.html:67
 #: opac/webapp/templates/journal/includes/header.html:67
 msgid "Versão on-line ISSN:"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/journal/includes/header.html:76
 #: opac/webapp/templates/journal/includes/header.html:76
 msgid "Novo título:"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/journal/includes/header.html:93
 #: opac/webapp/templates/journal/includes/header.html:93
 msgid "Título anterior:"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/journal/includes/header.html:148
 #: opac/webapp/templates/journal/includes/header.html:148
 msgid "Siga-nos"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:10
 #: opac/webapp/templates/journal/includes/levelMenu.html:10
 msgid "home do periódico"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:19
 #: opac/webapp/templates/journal/includes/levelMenu.html:19
 msgid "todos os números"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:25
+#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:29
 #: opac/webapp/templates/journal/includes/levelMenu.html:25
 #: opac/webapp/templates/journal/includes/levelMenu.html:29
 msgid "número anterior"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:36
+#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:40
+#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:107
+#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:111
 #: opac/webapp/templates/journal/includes/levelMenu.html:36
 #: opac/webapp/templates/journal/includes/levelMenu.html:40
 #: opac/webapp/templates/journal/includes/levelMenu.html:107
@@ -1978,16 +2484,24 @@ msgstr ""
 msgid "número atual"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:47
+#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:51
 #: opac/webapp/templates/journal/includes/levelMenu.html:47
 #: opac/webapp/templates/journal/includes/levelMenu.html:51
 msgid "número seguinte"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:59
+#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:130
 #: opac/webapp/templates/journal/includes/levelMenu.html:59
 #: opac/webapp/templates/journal/includes/levelMenu.html:130
 msgid "buscar"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:65
+#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:69
+#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:136
+#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:140
 #: opac/webapp/templates/journal/includes/levelMenu.html:65
 #: opac/webapp/templates/journal/includes/levelMenu.html:69
 #: opac/webapp/templates/journal/includes/levelMenu.html:136
@@ -1995,22 +2509,27 @@ msgstr ""
 msgid "métricas"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/macros/issue.html:5
 #: opac/webapp/templates/macros/issue.html:5
 msgid " número especial "
 msgstr ""
 
+#: build/lib/opac/webapp/templates/macros/issue.html:10
 #: opac/webapp/templates/macros/issue.html:10
 msgid "número especial"
 msgstr ""
 
-#: opac/webapp/templates/news/includes/collection_news_row.html:11
+#: build/lib/opac/webapp/templates/news/includes/collection_news_row.html:16
+#: opac/webapp/templates/news/includes/collection_news_row.html:16
 msgid "continue lendo"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/news/includes/issue_last_row.html:15
 #: opac/webapp/templates/news/includes/issue_last_row.html:15
 msgid "Suplemento"
 msgstr ""
 
+#: build/lib/opac/webapp/templates/news/includes/issue_last_row.html:20
 #: opac/webapp/templates/news/includes/issue_last_row.html:20
 msgid "Ver"
 msgstr ""


### PR DESCRIPTION


#### O que esse PR faz?
Corrige o valor de citation_language para ficar correspondente a citation_title.
Também corrige código de um teste que estava quebrado, por bug inserido em #1240

#### Onde a revisão poderia começar?
- `opac/webapp/templates/article/includes/meta.html:70-80`
- `opac/webapp/templates/journal/includes/header.html`:51

#### Como este poderia ser testado manualmente?
```
make dev_compose_exec_shell_webapp

export OPAC_CONFIG="config/templates/testing.template"

python opac/manager.py test -p test_main_views.py
```
No próprio site, abrir a página do artigo mudando de idioma e ver o código fonte. 
Os valores de `citation_title` e `citation_language` devem alterar de acordo com o idioma do texto.
Ex: 
https://new.scielo.br/article/aa/2019.v49n1/64-70/pt
https://new.scielo.br/article/aa/2019.v49n1/64-70/es

Sobre o termo Multidisciplinar, acessar a página
https://new.scielo.br/journal/aa
![Captura de Tela 2019-05-09 às 17 19 56](https://user-images.githubusercontent.com/505143/57484467-7ae8c900-727f-11e9-8c64-8eb1fea73b8f.png)



#### Algum cenário de contexto que queira dar?
N/A

### Screenshots
N/A

#### Quais são tickets relevantes?
#1283 e #1240 

### Referências
N/A
