### PR TITLE
Altera JournalAdminView para permitir que campo is_public seja alterado

### DIFF
--- a/opac/webapp/admin/views.py
+++ b/opac/webapp/admin/views.py
@@ -414,10 +414,11 @@ class CollectionAdminView(OpacBaseAdminView):
 class JournalAdminView(OpacBaseAdminView):
     can_edit = True
 
-    form_columns = ('enable_contact', 'scimago_id')
+    form_columns = ('enable_contact', 'scimago_id', 'is_public')
 
     form_overrides = {
         "enable_contact": custom_fields.RequiredBooleanField,
+        "is_public": custom_fields.RequiredBooleanField,
     }
 
     column_filters = [


### PR DESCRIPTION
#### O que esse PR faz?
Altera view de periódico no Admin para que permita que seja alterado o valor do campo `is_public` (Publicado?) pela interface.

#### Onde a revisão poderia começar?
Em `opac/webapp/admin/views.py`, na classe `JournalAdminView`.

#### Como este poderia ser testado manualmente?
Acessando `/admin`, Catálogo > Periódico, edite qualquer periódico. Deve ser possível alterar o valor do campo `Publicado?`.

#### Algum cenário de contexto que queira dar?
Para que seja possível criar páginas secundárias para periódicos que ainda não tem fascículos ou qualquer publicação, é necessário que os registros deles estejam disponíveis no site. Contudo, como não há documentos a serem publicados, o periódico deve permanecer despublicado. Caso haja necessidade de alteração deste status de publicação, agora será possível pela interface Admin.

### Screenshots
N/A.

#### Quais são tickets relevantes?
#1272 

### Referências
Nenhuma.
