### PR TITLE
Atualiza packtools para versão 2.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -32,4 +32,4 @@ rq-scheduler==0.8.2
 rq-scheduler-dashboard==0.0.2
 lxml==4.2.4
 Werkzeug==0.14.1
-packtools==2.4.3
+packtools==2.5


### PR DESCRIPTION
#### O que esse PR faz?
Atualiza o Packtools da versão 2.4.3 para 2.5, que corrige bugs na geração de HTMLs

#### Onde a revisão poderia começar?
Em `requirements.txt`.

#### Como este poderia ser testado manualmente?
Recompilar as imagens Docker do projeto, colocá-los no ar e acessar artigos XMLs.

#### Algum cenário de contexto que queira dar?
Nenhum.

### Screenshots
N/A

#### Quais são tickets relevantes?
#1180 
PR scieloorg/packtools#194
