### PR TITLE
Permite edição do campo logo_url do periódico e corrige custom field

### DIFF
--- a/opac/webapp/admin/custom_fields.py
+++ b/opac/webapp/admin/custom_fields.py
@@ -143,6 +143,12 @@ class MediaImageUploadField(ImageUploadField):
             endpoint=endpoint,
             **kwargs)
 
+    def _save_image(self, image, path, format='JPEG'):
+        if image.mode not in ('RGB', 'RGBA'):
+            image = image.convert('RGB')
+        with open(path, 'wb') as fp:
+            image.save(fp, format)
+
 
 class MediaFileUploadField(FileUploadField):
 

--- a/opac/webapp/admin/views.py
+++ b/opac/webapp/admin/views.py
@@ -414,7 +414,7 @@ class CollectionAdminView(OpacBaseAdminView):
 class JournalAdminView(OpacBaseAdminView):
     can_edit = True
 
-    form_columns = ('enable_contact', 'scimago_id', 'is_public')
+    form_columns = ('enable_contact', 'scimago_id', 'is_public', 'logo_url')
 
     form_overrides = {
         "enable_contact": custom_fields.RequiredBooleanField,


### PR DESCRIPTION
#### O que esse PR faz?
Abre o campo de logo do periódico para edição na interface de Admin. Assim, será possível que a produção faça atualização de logo pela interface de Admin diretamente no site.

Também efetua uma correção em `custom_fields.MediaImageUploadField`,
classe filha de `flask_admin.form.upload.ImageUploadField`, que contém
um bug na conversão de imagens para Jpeg.

#### Onde a revisão poderia começar?
Em `opac/webapp/admin/views.py`.

#### Como este poderia ser testado manualmente?
Para a edição da imagem:
1. Cadastrar logo de um periódico em Ativos > Imagem
2. Copiar a URL da imagem cadastrada
3. Alterar um periódico em Catálogo > Periódico
4. Colocar a URL copiada no passo 2 no campo de Logo Url e salvar.
5. Verificar na home do periódico. O Logo configurado deve aparecer.

Para a correção do bug da imagem:
1. Cadastrar uma nova imagem com formato RGBA (fundo transparente) em Ativos > Imagem
2. A imagem deve ser cadastrada com sucesso.

#### Algum cenário de contexto que queira dar?
Este PR visa resolver o problema reportado no ticket #1271.
Além disso, também foi necessário fazer uma alteração para resolver um problema no Flask-Admin que não prevê alteração na biblioteca Pillow desde a versão 4.2.0 ([ver release note aqui](https://github.com/python-pillow/Pillow/blob/master/docs/releasenotes/4.2.0.rst#removed-deprecated-items))

### Screenshots
<img width="1158" alt="Screen Shot 2019-05-29 at 15 37 34" src="https://user-images.githubusercontent.com/18053487/58582342-ea6f2a00-8227-11e9-8678-593e4137054e.png">

#### Quais são tickets relevantes?
#1271.

### Referências
https://github.com/python-pillow/Pillow/blob/master/docs/releasenotes/4.2.0.rst#removed-deprecated-items