### PR TITLE
Correção de tooltips dos botões RSS na homepage do periódico

### DIFF
--- a/opac/webapp/templates/journal/detail.html
+++ b/opac/webapp/templates/journal/detail.html
@@ -6,7 +6,7 @@
     <div class="container">
       <div class="col-md-4 col-md-offset-8 share">
         <a href="javascript:window.print();" class="sharePrint showTooltip" data-placement="top" title="{% trans %}Imprimir{% endtrans %}"><span class="glyphBtn print"></span></a>
-        <a href="{{ url_for('main.journal_feed', url_seg=journal.url_segment)}}" class="showTooltip" data-placement="top" title="Atom" target="_blank"><span class="glyphBtn rssMini"></span></a>
+        <a href="{{ url_for('main.journal_feed', url_seg=journal.url_segment)}}" class="showTooltip" data-placement="top" title="{% trans %}RSS do número mais recente do periódico{% endtrans %}" target="_blank"><span class="glyphBtn rssMini"></span></a>
         <span class="divisor"></span>
         {% trans %}Compartilhe{% endtrans %}
         <a href="" class="share_modal_id showTooltip" data-placement="top" title="{% trans %}Enviar link por e-mail{% endtrans %}"><span class="glyphBtn sendMail"></span></a>
@@ -114,9 +114,9 @@
               <h2>
                 Press-releases
                 {% if session.lang != "pt_BR" %}
-                  <a href="{{ config.URL_BLOG_PRESSRELEASE }}/{{ session.lang }}/blog/category/press-releases/{{ journal.acronym }}/feed/" target="_blank" data-toggle="tooltip" data-original-title="RSS"><span class="glyphBtn rssMini"></span></a>
+                  <a href="{{ config.URL_BLOG_PRESSRELEASE }}/{{ session.lang }}/blog/category/press-releases/{{ journal.acronym }}/feed/" target="_blank" data-toggle="tooltip" data-original-title="{% trans %}RSS dos Press Releases mais recentes desse periódico{% endtrans %}"><span class="glyphBtn rssMini"></span></a>
                 {% else %}
-                  <a href="{{ config.URL_BLOG_PRESSRELEASE }}/blog/category/press-releases/{{ journal.acronym }}/feed/" target="_blank" data-toggle="tooltip" data-original-title="RSS"><span class="glyphBtn rssMini"></span></a>
+                  <a href="{{ config.URL_BLOG_PRESSRELEASE }}/blog/category/press-releases/{{ journal.acronym }}/feed/" target="_blank" data-toggle="tooltip" data-original-title="{% trans %}RSS dos Press Releases mais recentes desse periódico{% endtrans %}"><span class="glyphBtn rssMini"></span></a>
                 {% endif %}
               </h2>
               <div class="slider" id="pressrelease">

--- a/opac/webapp/templates/journal/includes/contact_footer.html
+++ b/opac/webapp/templates/journal/includes/contact_footer.html
@@ -50,7 +50,7 @@
       {% endfor %}
     </div>
     <div class="col-md-3 col-sm-3 journalLinks">
-      <a href="{{ url_for('main.journal_feed', url_seg=journal.url_segment)}}" data-toggle="tooltip" title="Atom" target="_blank">
+      <a href="{{ url_for('main.journal_feed', url_seg=journal.url_segment)}}" data-toggle="tooltip" title="{% trans %}RSS do número mais recente do periódico{% endtrans %}" target="_blank">
         <span class="glyphBtn bigRSS"></span>
       </a>
       <span class="text" style="width: 70%;">

--- a/opac/webapp/translations/en/LC_MESSAGES/messages.po
+++ b/opac/webapp/translations/en/LC_MESSAGES/messages.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version:  OPAC\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-05-09 17:02-0300\n"
+"POT-Creation-Date: 2019-05-31 21:18+0000\n"
 "PO-Revision-Date: 2018-03-06 19:50+0000\n"
 "Last-Translator: jamil Atta <atta.jamil@gmail.com>\n"
 "Language: en\n"
@@ -23,30 +23,13 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.6.0\n"
 
-#: build/lib/opac/tests/test_admin_custom_filters.py:100
-#: build/lib/opac/tests/test_admin_custom_filters.py:114
-#: build/lib/opac/tests/test_admin_custom_filters.py:129
-#: build/lib/opac/tests/test_admin_custom_filters.py:144
-#: build/lib/opac/tests/test_admin_custom_filters.py:158
-#: build/lib/opac/webapp/__init__.py:119
-#: build/lib/opac/webapp/admin/views.py:533
-#: build/lib/opac/webapp/admin/views.py:610
-#: build/lib/opac/webapp/admin/views.py:680
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:28
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:71
-#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_grouper_table_row.html:15
-#: build/lib/opac/webapp/templates/collection/list_journal.html:49
-#: build/lib/opac/webapp/templates/collection/list_journal.html:221
-#: build/lib/opac/webapp/templates/collection/list_journal.html:235
-#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:116
-#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:112
 #: opac/tests/test_admin_custom_filters.py:100
 #: opac/tests/test_admin_custom_filters.py:114
 #: opac/tests/test_admin_custom_filters.py:129
 #: opac/tests/test_admin_custom_filters.py:144
 #: opac/tests/test_admin_custom_filters.py:158 opac/webapp/__init__.py:119
-#: opac/webapp/admin/views.py:533 opac/webapp/admin/views.py:610
-#: opac/webapp/admin/views.py:680
+#: opac/webapp/admin/views.py:534 opac/webapp/admin/views.py:611
+#: opac/webapp/admin/views.py:681
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:28
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:71
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_grouper_table_row.html:15
@@ -58,38 +41,21 @@ msgstr ""
 msgid "Periódico"
 msgstr "Journal"
 
-#: build/lib/opac/tests/test_interface_menu.py:51
 #: opac/tests/test_interface_menu.py:51
 msgid "NOME DA COLEÇÃO!!"
 msgstr "COLLECTION NAME!!"
 
-#: build/lib/opac/tests/test_interface_menu.py:53
-#: build/lib/opac/tests/test_interface_menu.py:75
-#: build/lib/opac/webapp/templates/collection/includes/nav.html:12
-#: build/lib/opac/webapp/templates/collection/includes/nav.html:54
 #: opac/tests/test_interface_menu.py:53 opac/tests/test_interface_menu.py:75
 #: opac/webapp/templates/collection/includes/nav.html:12
 #: opac/webapp/templates/collection/includes/nav.html:54
 msgid "Lista alfabética de periódicos"
 msgstr "Journal list by title"
 
-#: build/lib/opac/tests/test_interface_menu.py:55
-#: build/lib/opac/webapp/templates/collection/includes/nav.html:17
 #: opac/tests/test_interface_menu.py:55
 #: opac/webapp/templates/collection/includes/nav.html:17
 msgid "Lista temática de periódicos"
 msgstr "Journal list by subject area"
 
-#: build/lib/opac/tests/test_interface_menu.py:61
-#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:11
-#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:70
-#: build/lib/opac/webapp/templates/collection/includes/nav.html:27
-#: build/lib/opac/webapp/templates/collection/includes/nav.html:69
-#: build/lib/opac/webapp/templates/includes/metric_modal.html:7
-#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:101
-#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:105
-#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:97
-#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:101
 #: opac/tests/test_interface_menu.py:61
 #: opac/webapp/templates/article/includes/floating_menu.html:11
 #: opac/webapp/templates/article/includes/floating_menu.html:70
@@ -103,383 +69,332 @@ msgstr "Journal list by subject area"
 msgid "Métricas"
 msgstr "Metrics"
 
-#: build/lib/opac/tests/test_interface_menu.py:63
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu.html:12
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu.html:29
 #: opac/tests/test_interface_menu.py:63
 #: opac/webapp/templates/collection/includes/levelMenu.html:12
 #: opac/webapp/templates/collection/includes/levelMenu.html:29
 msgid "Sobre o SciELO"
 msgstr "About SciELO"
 
-#: build/lib/opac/tests/test_interface_menu.py:65
-#: build/lib/opac/tests/test_interface_menu.py:99
-#: build/lib/opac/webapp/templates/collection/includes/nav.html:37
-#: build/lib/opac/webapp/templates/collection/includes/nav.html:84
 #: opac/tests/test_interface_menu.py:65 opac/tests/test_interface_menu.py:99
 #: opac/webapp/templates/collection/includes/nav.html:37
 #: opac/webapp/templates/collection/includes/nav.html:84
 msgid "Contatos"
 msgstr "Contacts"
 
-#: build/lib/opac/tests/test_interface_menu.py:67
 #: opac/tests/test_interface_menu.py:67
 msgid "Rede SciELO"
 msgstr "The SciELO Network"
 
-#: build/lib/opac/tests/test_interface_menu.py:71
-#: build/lib/opac/webapp/templates/collection/includes/nav.html:49
 #: opac/tests/test_interface_menu.py:71
 #: opac/webapp/templates/collection/includes/nav.html:49
 msgid "Coleções nacionais e temáticas"
 msgstr "National and thematic collections"
 
-#: build/lib/opac/tests/test_interface_menu.py:79
-#: build/lib/opac/webapp/templates/collection/includes/nav.html:59
 #: opac/tests/test_interface_menu.py:79
 #: opac/webapp/templates/collection/includes/nav.html:59
 msgid "Lista de periódicos por assunto"
 msgstr "Journal list by subject"
 
-#: build/lib/opac/tests/test_interface_menu.py:91
-#: build/lib/opac/webapp/templates/collection/includes/nav.html:74
 #: opac/tests/test_interface_menu.py:91
 #: opac/webapp/templates/collection/includes/nav.html:74
 msgid "Acesso OAI e RSS"
 msgstr "OAI and RSS"
 
-#: build/lib/opac/tests/test_interface_menu.py:95
-#: build/lib/opac/webapp/templates/collection/includes/nav.html:79
 #: opac/tests/test_interface_menu.py:95
 #: opac/webapp/templates/collection/includes/nav.html:79
 msgid "Sobre a Rede SciELO"
 msgstr "About the SciELO Network"
 
-#: build/lib/opac/tests/test_main_errors.py:8 opac/tests/test_main_errors.py:8
+#: opac/tests/test_main_errors.py:8
 msgid "Mensagem de erro explicativo para o usuário"
 msgstr "Explanatory user error message"
 
-#: build/lib/opac/webapp/__init__.py:118 build/lib/opac/webapp/__init__.py:119
-#: build/lib/opac/webapp/__init__.py:120 build/lib/opac/webapp/__init__.py:121
-#: build/lib/opac/webapp/__init__.py:122 build/lib/opac/webapp/__init__.py:123
 #: opac/webapp/__init__.py:118 opac/webapp/__init__.py:119
 #: opac/webapp/__init__.py:120 opac/webapp/__init__.py:121
 #: opac/webapp/__init__.py:122 opac/webapp/__init__.py:123
 msgid "Catálogo"
 msgstr "Catalog"
 
-#: build/lib/opac/webapp/__init__.py:118
-#: build/lib/opac/webapp/admin/views.py:452 opac/webapp/__init__.py:118
-#: opac/webapp/admin/views.py:452
+#: opac/webapp/__init__.py:118 opac/webapp/admin/views.py:453
 msgid "Coleção"
 msgstr "Collection"
 
-#: build/lib/opac/webapp/__init__.py:120
-#: build/lib/opac/webapp/admin/views.py:537
-#: build/lib/opac/webapp/admin/views.py:609
-#: build/lib/opac/webapp/templates/issue/grid.html:41
-#: build/lib/opac/webapp/templates/news/includes/issue_last_row.html:11
-#: opac/webapp/__init__.py:120 opac/webapp/admin/views.py:537
-#: opac/webapp/admin/views.py:609 opac/webapp/templates/issue/grid.html:41
+#: opac/webapp/__init__.py:120 opac/webapp/admin/views.py:538
+#: opac/webapp/admin/views.py:610 opac/webapp/templates/issue/grid.html:41
 #: opac/webapp/templates/news/includes/issue_last_row.html:11
 msgid "Número"
 msgstr "Number"
 
-#: build/lib/opac/webapp/__init__.py:121 opac/webapp/__init__.py:121
+#: opac/webapp/__init__.py:121
 msgid "Artigo"
 msgstr "Article"
 
-#: build/lib/opac/webapp/__init__.py:122
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:27
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:70
 #: opac/webapp/__init__.py:122
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:27
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:70
 msgid "Financiador"
 msgstr "Funder"
 
-#: build/lib/opac/webapp/__init__.py:123 opac/webapp/__init__.py:123
+#: opac/webapp/__init__.py:123
 msgid "Press Release"
 msgstr "Press release"
 
-#: build/lib/opac/webapp/__init__.py:124
-#: build/lib/opac/webapp/templates/journal/detail.html:160
-#: opac/webapp/__init__.py:124 opac/webapp/templates/journal/detail.html:160
+#: opac/webapp/__init__.py:124 opac/webapp/templates/journal/detail.html:167
 msgid "Notícias"
 msgstr "News"
 
-#: build/lib/opac/webapp/__init__.py:125 build/lib/opac/webapp/__init__.py:126
 #: opac/webapp/__init__.py:125 opac/webapp/__init__.py:126
 msgid "Ativos"
 msgstr "Static files"
 
-#: build/lib/opac/webapp/__init__.py:127 opac/webapp/__init__.py:127
+#: opac/webapp/__init__.py:127
 msgid "Páginas"
 msgstr "Pages"
 
-#: build/lib/opac/webapp/__init__.py:128 build/lib/opac/webapp/__init__.py:129
 #: opac/webapp/__init__.py:128 opac/webapp/__init__.py:129
 msgid "Gestão"
 msgstr "Management"
 
-#: build/lib/opac/webapp/__init__.py:128 opac/webapp/__init__.py:128
+#: opac/webapp/__init__.py:128
 msgid "Auditoria: Páginas"
 msgstr "Auditoria: Pages"
 
-#: build/lib/opac/webapp/__init__.py:129
-#: build/lib/opac/webapp/admin/views.py:896 opac/webapp/__init__.py:129
-#: opac/webapp/admin/views.py:896
+#: opac/webapp/__init__.py:129 opac/webapp/admin/views.py:897
 msgid "Usuário"
 msgstr "User"
 
-#: build/lib/opac/webapp/choices.py:7 opac/webapp/choices.py:7
+#: opac/webapp/choices.py:7
 msgid "Conteúdo temporariamente indisponível"
 msgstr "Content temporarily unavailable"
 
-#: build/lib/opac/webapp/choices.py:11 build/lib/opac/webapp/choices.py:23
-#: build/lib/opac/webapp/templates/article/includes/modal/download.html:26
 #: opac/webapp/choices.py:11 opac/webapp/choices.py:23
 #: opac/webapp/templates/article/includes/modal/download.html:26
 msgid "Português"
 msgstr "Portuguese"
 
-#: build/lib/opac/webapp/choices.py:12 build/lib/opac/webapp/choices.py:24
-#: build/lib/opac/webapp/templates/article/includes/modal/download.html:24
 #: opac/webapp/choices.py:12 opac/webapp/choices.py:24
 #: opac/webapp/templates/article/includes/modal/download.html:24
 msgid "Inglês"
 msgstr "English"
 
-#: build/lib/opac/webapp/choices.py:13 build/lib/opac/webapp/choices.py:25
-#: build/lib/opac/webapp/templates/article/includes/modal/download.html:22
 #: opac/webapp/choices.py:13 opac/webapp/choices.py:25
 #: opac/webapp/templates/article/includes/modal/download.html:22
 msgid "Espanhol"
 msgstr "Spanish"
 
-#: build/lib/opac/webapp/choices.py:26 opac/webapp/choices.py:26
+#: opac/webapp/choices.py:26
 msgid "Albanês"
 msgstr "Albanian"
 
-#: build/lib/opac/webapp/choices.py:27 build/lib/opac/webapp/choices.py:33
 #: opac/webapp/choices.py:27 opac/webapp/choices.py:33
 msgid "Chinês"
 msgstr "Chinese"
 
-#: build/lib/opac/webapp/choices.py:28 opac/webapp/choices.py:28
+#: opac/webapp/choices.py:28
 msgid "Romeno"
 msgstr "Romanian"
 
-#: build/lib/opac/webapp/choices.py:29 opac/webapp/choices.py:29
+#: opac/webapp/choices.py:29
 msgid "Francês"
 msgstr "French"
 
-#: build/lib/opac/webapp/choices.py:30 opac/webapp/choices.py:30
+#: opac/webapp/choices.py:30
 msgid "Italiano"
 msgstr "Italian"
 
-#: build/lib/opac/webapp/choices.py:31 opac/webapp/choices.py:31
+#: opac/webapp/choices.py:31
 msgid "Russo"
 msgstr "Russian"
 
-#: build/lib/opac/webapp/choices.py:32 opac/webapp/choices.py:32
+#: opac/webapp/choices.py:32
 msgid "Árabe"
 msgstr "Arabic"
 
-#: build/lib/opac/webapp/choices.py:37 opac/webapp/choices.py:37
+#: opac/webapp/choices.py:37
 msgid "corrente"
 msgstr "current"
 
-#: build/lib/opac/webapp/choices.py:38 opac/webapp/choices.py:38
+#: opac/webapp/choices.py:38
 msgid "terminado"
 msgstr "deceased"
 
-#: build/lib/opac/webapp/choices.py:39 opac/webapp/choices.py:39
+#: opac/webapp/choices.py:39
 msgid "indexação interrompida"
 msgstr "indexing interrupted"
 
-#: build/lib/opac/webapp/choices.py:40 opac/webapp/choices.py:40
+#: opac/webapp/choices.py:40
 msgid "indexação interrompida pelo Comitê"
 msgstr "indexing interrupted by the committee"
 
-#: build/lib/opac/webapp/choices.py:41 opac/webapp/choices.py:41
+#: opac/webapp/choices.py:41
 msgid "publicação finalizada"
 msgstr "publication finished"
 
-#: build/lib/opac/webapp/choices.py:45 opac/webapp/choices.py:45
+#: opac/webapp/choices.py:45
 msgid "Ciências Agrárias"
 msgstr "Agricultural Sciences"
 
-#: build/lib/opac/webapp/choices.py:46 opac/webapp/choices.py:46
+#: opac/webapp/choices.py:46
 msgid "Ciências Sociais Aplicadas"
 msgstr "Applied Social Sciences"
 
-#: build/lib/opac/webapp/choices.py:47 opac/webapp/choices.py:47
+#: opac/webapp/choices.py:47
 msgid "Ciências Biológicas"
 msgstr "Biological Sciences"
 
-#: build/lib/opac/webapp/choices.py:48 opac/webapp/choices.py:48
+#: opac/webapp/choices.py:48
 msgid "Engenharias"
 msgstr "Engineering"
 
-#: build/lib/opac/webapp/choices.py:49 opac/webapp/choices.py:49
+#: opac/webapp/choices.py:49
 msgid "Ciências Exatas e da Terra"
 msgstr "Exact and Earth Sciences"
 
-#: build/lib/opac/webapp/choices.py:50 opac/webapp/choices.py:50
+#: opac/webapp/choices.py:50
 msgid "Ciências da Saúde"
 msgstr "Health Sciences"
 
-#: build/lib/opac/webapp/choices.py:51 opac/webapp/choices.py:51
+#: opac/webapp/choices.py:51
 msgid "Ciências Humanas"
 msgstr "Human Sciences"
 
-#: build/lib/opac/webapp/choices.py:52 build/lib/opac/webapp/choices.py:53
 #: opac/webapp/choices.py:52 opac/webapp/choices.py:53
 msgid "Lingüística, Letras e Artes"
 msgstr "Linguistics, Literature and Arts"
 
-#: build/lib/opac/webapp/controllers.py:353 opac/webapp/controllers.py:353
+#: opac/webapp/controllers.py:353
 msgid "Lista Alfabética"
 msgstr "Alphabetic List"
 
-#: build/lib/opac/webapp/controllers.py:357 opac/webapp/controllers.py:357
+#: opac/webapp/controllers.py:357
 msgid "Lista Temática"
 msgstr "Thematic List"
 
-#: build/lib/opac/webapp/controllers.py:361 opac/webapp/controllers.py:361
+#: opac/webapp/controllers.py:361
 msgid "Lista Web of Science"
 msgstr "Web of Science List"
 
-#: build/lib/opac/webapp/controllers.py:365 opac/webapp/controllers.py:365
+#: opac/webapp/controllers.py:365
 msgid "Lista by Institution"
 msgstr "List by Institution"
 
-#: build/lib/opac/webapp/controllers.py:424 opac/webapp/controllers.py:424
+#: opac/webapp/controllers.py:424
 msgid "Obrigatório um jid."
 msgstr "A jid is required."
 
-#: build/lib/opac/webapp/controllers.py:440 opac/webapp/controllers.py:440
+#: opac/webapp/controllers.py:440
 msgid "Obrigatório um acronym."
 msgstr "An acronym is required."
 
-#: build/lib/opac/webapp/controllers.py:456 opac/webapp/controllers.py:456
+#: opac/webapp/controllers.py:456
 msgid "Obrigatório um url_seg."
 msgstr "A url_seg is required."
 
-#: build/lib/opac/webapp/controllers.py:472 opac/webapp/controllers.py:472
+#: opac/webapp/controllers.py:472
 msgid "Obrigatório um issn."
 msgstr "ISSN is required."
 
-#: build/lib/opac/webapp/controllers.py:487 opac/webapp/controllers.py:487
+#: opac/webapp/controllers.py:487
 msgid "Obrigatório um title."
 msgstr ""
 
-#: build/lib/opac/webapp/controllers.py:525
-#: build/lib/opac/webapp/controllers.py:669
-#: build/lib/opac/webapp/controllers.py:830 opac/webapp/controllers.py:525
-#: opac/webapp/controllers.py:669 opac/webapp/controllers.py:830
+#: opac/webapp/controllers.py:525 opac/webapp/controllers.py:669
+#: opac/webapp/controllers.py:830
 msgid "Obrigatório uma lista de ids."
 msgstr "A list of id's is required."
 
-#: build/lib/opac/webapp/controllers.py:631
-#: build/lib/opac/webapp/controllers.py:851 opac/webapp/controllers.py:631
-#: opac/webapp/controllers.py:851
+#: opac/webapp/controllers.py:631 opac/webapp/controllers.py:851
 msgid "Obrigatório um iid."
 msgstr "A iid is required."
 
-#: build/lib/opac/webapp/controllers.py:688 opac/webapp/controllers.py:688
+#: opac/webapp/controllers.py:688
 msgid "Obrigatório um jacron e issue_label."
 msgstr "A jacron and issue_label are required."
 
-#: build/lib/opac/webapp/controllers.py:701 opac/webapp/controllers.py:701
+#: opac/webapp/controllers.py:701
 msgid "Obrigatório um PID."
 msgstr "PID is required."
 
-#: build/lib/opac/webapp/controllers.py:717 opac/webapp/controllers.py:717
+#: opac/webapp/controllers.py:717
 msgid "Obrigatório um url_seg e url_seg_issue."
 msgstr "A url_seg and url_seg_issue are required."
 
-#: build/lib/opac/webapp/controllers.py:724 opac/webapp/controllers.py:724
+#: opac/webapp/controllers.py:724
 msgid "Obrigatório um assets_code."
 msgstr " assets_code is mandatory."
 
-#: build/lib/opac/webapp/controllers.py:727 opac/webapp/controllers.py:727
+#: opac/webapp/controllers.py:727
 msgid "Obrigatório um journal."
 msgstr "Journal is mandatory."
 
-#: build/lib/opac/webapp/controllers.py:743 opac/webapp/controllers.py:743
+#: opac/webapp/controllers.py:743
 msgid "Obrigatório um aid."
 msgstr "A aid is required."
 
-#: build/lib/opac/webapp/controllers.py:757 opac/webapp/controllers.py:757
+#: opac/webapp/controllers.py:757
 msgid "Obrigatório um url_seg_article."
 msgstr "A url_seg_article is required."
 
-#: build/lib/opac/webapp/controllers.py:772 opac/webapp/controllers.py:772
+#: opac/webapp/controllers.py:772
 msgid "Obrigatório um iid and url_seg_article."
 msgstr "A iid and url_seg_article are required."
 
-#: build/lib/opac/webapp/controllers.py:788 opac/webapp/controllers.py:788
+#: opac/webapp/controllers.py:788
 msgid "Obrigatório um jid, url_seg_issue and url_seg_article."
 msgstr ""
 
-#: build/lib/opac/webapp/controllers.py:889 opac/webapp/controllers.py:889
+#: opac/webapp/controllers.py:889
 msgid "Obrigatório um pid."
 msgstr "pid is required."
 
-#: build/lib/opac/webapp/controllers.py:902 opac/webapp/controllers.py:902
+#: opac/webapp/controllers.py:902
 msgid "Obrigatório um aop_pid."
 msgstr "aop_pid is mandatory."
 
-#: build/lib/opac/webapp/controllers.py:913 opac/webapp/controllers.py:913
+#: opac/webapp/controllers.py:913
 msgid "Parámetro obrigatório: issue_iid."
 msgstr "issue_iid is mandatory."
 
-#: build/lib/opac/webapp/controllers.py:961 opac/webapp/controllers.py:961
+#: opac/webapp/controllers.py:961
 msgid "Parâmetro email deve ser uma string"
 msgstr "The parameter \"email\" must be a string."
 
-#: build/lib/opac/webapp/controllers.py:972 opac/webapp/controllers.py:972
+#: opac/webapp/controllers.py:972
 msgid "Parâmetro email deve ser uma inteiro"
 msgstr "The parameter \"email\" must be an integer."
 
-#: build/lib/opac/webapp/controllers.py:984
-#: build/lib/opac/webapp/controllers.py:998 opac/webapp/controllers.py:984
-#: opac/webapp/controllers.py:998
+#: opac/webapp/controllers.py:984 opac/webapp/controllers.py:998
 #, python-format
 msgid "Usuário deve ser do tipo %s"
 msgstr "User must be of type %s"
 
-#: build/lib/opac/webapp/controllers.py:1054 opac/webapp/controllers.py:1054
+#: opac/webapp/controllers.py:1054
 msgid "Compartilhamento de link SciELO"
 msgstr "SciELO link sharing"
 
-#: build/lib/opac/webapp/controllers.py:1055 opac/webapp/controllers.py:1055
+#: opac/webapp/controllers.py:1055
 #, python-format
 msgid "O usuário %s compartilha este link: %s, da SciELO"
 msgstr "The user %s share link: %s, of SciELO"
 
-#: build/lib/opac/webapp/controllers.py:1063
-#: build/lib/opac/webapp/controllers.py:1099
-#: build/lib/opac/webapp/controllers.py:1121 opac/webapp/controllers.py:1063
-#: opac/webapp/controllers.py:1099 opac/webapp/controllers.py:1121
+#: opac/webapp/controllers.py:1063 opac/webapp/controllers.py:1099
+#: opac/webapp/controllers.py:1121
 msgid "Mensagem enviada!"
 msgstr "Message sent!"
 
-#: build/lib/opac/webapp/controllers.py:1080 opac/webapp/controllers.py:1080
+#: opac/webapp/controllers.py:1080
 msgid "[Erro] Erro informado pelo usuário no site SciELO"
 msgstr "[Error] Error informed by the user in the SciELO site"
 
-#: build/lib/opac/webapp/controllers.py:1083 opac/webapp/controllers.py:1083
+#: opac/webapp/controllers.py:1083
 msgid "aplicação"
 msgstr ""
 
-#: build/lib/opac/webapp/controllers.py:1085 opac/webapp/controllers.py:1085
+#: opac/webapp/controllers.py:1085
 msgid "conteúdo"
 msgstr ""
 
-#: build/lib/opac/webapp/controllers.py:1090 opac/webapp/controllers.py:1090
+#: opac/webapp/controllers.py:1090
 #, python-format
 msgid ""
 "O usuário <b>%s</b> com e-mail: <b>%s</b>, informa que existe um erro na "
@@ -490,78 +405,72 @@ msgstr ""
 " %s in the website SciELO.<br><br><b>Title of page:</b> "
 "%s<br><br><b>Link:</b> %s"
 
-#: build/lib/opac/webapp/controllers.py:1111 opac/webapp/controllers.py:1111
+#: opac/webapp/controllers.py:1111
 msgid "Contato de usuário via site SciELO"
 msgstr "User contact by SciELO website"
 
-#: build/lib/opac/webapp/controllers.py:1113 opac/webapp/controllers.py:1113
+#: opac/webapp/controllers.py:1113
 #, python-format
 msgid "O usuário %s, com e-mail: %s, entra em contato com a seguinte mensagem:"
 msgstr "User %s, e-mail: %s, contact us with the following message:"
 
-#: build/lib/opac/webapp/controllers.py:1145 opac/webapp/controllers.py:1145
+#: opac/webapp/controllers.py:1145
 msgid "Obrigatório um slug_name."
 msgstr "An slug_name is required"
 
-#: build/lib/opac/webapp/forms.py:29 opac/webapp/forms.py:29
+#: opac/webapp/forms.py:29
 msgid "Endereço de e-mail inválido."
 msgstr "Invalid e-mail address."
 
-#: build/lib/opac/webapp/admin/forms.py:9
-#: build/lib/opac/webapp/admin/forms.py:21 opac/webapp/admin/forms.py:9
-#: opac/webapp/admin/forms.py:21
+#: opac/webapp/admin/forms.py:9 opac/webapp/admin/forms.py:21
 msgid "Email"
 msgstr "Email"
 
-#: build/lib/opac/webapp/admin/forms.py:10
-#: build/lib/opac/webapp/admin/forms.py:25 opac/webapp/admin/forms.py:10
-#: opac/webapp/admin/forms.py:25
+#: opac/webapp/admin/forms.py:10 opac/webapp/admin/forms.py:25
 msgid "Senha"
 msgstr "Password"
 
-#: build/lib/opac/webapp/admin/forms.py:15 opac/webapp/admin/forms.py:15
+#: opac/webapp/admin/forms.py:15
 msgid "Usuário inválido"
 msgstr "Invalid user"
 
-#: build/lib/opac/webapp/admin/forms.py:17 opac/webapp/admin/forms.py:17
+#: opac/webapp/admin/forms.py:17
 msgid "Senha inválida"
 msgstr "Invalid password"
 
-#: build/lib/opac/webapp/admin/views.py:28 opac/webapp/admin/views.py:28
+#: opac/webapp/admin/views.py:28
 msgid "Tem certeza que quer publicar os itens selecionados?"
 msgstr "Are you sure you want to publish the selected items?"
 
-#: build/lib/opac/webapp/admin/views.py:29 opac/webapp/admin/views.py:29
+#: opac/webapp/admin/views.py:29
 msgid "Tem certeza que quer despublicar os itens selecionados?"
 msgstr "Are you sure you want to unpublish the selected items?"
 
-#: build/lib/opac/webapp/admin/views.py:30 opac/webapp/admin/views.py:30
+#: opac/webapp/admin/views.py:30
 msgid "Tem certeza que quer reconstruir os artigos selecionados?"
 msgstr "Are you sure you want to rebuild the selected articles?"
 
-#: build/lib/opac/webapp/admin/views.py:31 opac/webapp/admin/views.py:31
+#: opac/webapp/admin/views.py:31
 msgid ""
 "Tem certeza que quer enviar email de confirmação aos usuários "
 "selecionados?"
 msgstr "Are you sure you want to send a confirmation email to the selected users?"
 
-#: build/lib/opac/webapp/admin/views.py:91
-#: build/lib/opac/webapp/admin/views.py:104 opac/webapp/admin/views.py:91
-#: opac/webapp/admin/views.py:104
+#: opac/webapp/admin/views.py:91 opac/webapp/admin/views.py:104
 msgid "Usuário não encontrado"
 msgstr "User not found"
 
-#: build/lib/opac/webapp/admin/views.py:94 opac/webapp/admin/views.py:94
+#: opac/webapp/admin/views.py:94
 #, python-format
 msgid "Email: %(email)s confirmado com sucesso!"
 msgstr "Email: %(email)s successfully confirmed!"
 
-#: build/lib/opac/webapp/admin/views.py:110 opac/webapp/admin/views.py:110
+#: opac/webapp/admin/views.py:110
 #, python-format
 msgid "Enviamos as instruções para recuperar a senha para: %(email)s"
 msgstr "The instructions to reset the password have been sent to: %(email)s "
 
-#: build/lib/opac/webapp/admin/views.py:113 opac/webapp/admin/views.py:113
+#: opac/webapp/admin/views.py:113
 #, python-format
 msgid ""
 "Ocorreu um erro no envio das instruções por email para: %(email)s. Erro: "
@@ -570,387 +479,342 @@ msgstr ""
 "Error in sending the instructions via email to: %(email)s. Error: "
 "%(error)s"
 
-#: build/lib/opac/webapp/admin/views.py:139 opac/webapp/admin/views.py:139
+#: opac/webapp/admin/views.py:139
 msgid "Nova senha salva com sucesso!!"
 msgstr "New password successfully saved!!"
 
-#: build/lib/opac/webapp/admin/views.py:167
-#: build/lib/opac/webapp/admin/views.py:186 opac/webapp/admin/views.py:167
-#: opac/webapp/admin/views.py:186
+#: opac/webapp/admin/views.py:167 opac/webapp/admin/views.py:186
 #, python-format
 msgid "Enviamos o email de confirmação para: %(email)s"
 msgstr "A confirmation email has been sent to: %(email)s"
 
-#: build/lib/opac/webapp/admin/views.py:170 opac/webapp/admin/views.py:170
+#: opac/webapp/admin/views.py:170
 #, python-format
 msgid ""
 "Ocorreu um erro no envio do email de confirmação para: %(email)s "
 "%(error_msg)s"
 msgstr "There was an error sending confirmation email to: %(email)s %(error_msg)s"
 
-#: build/lib/opac/webapp/admin/views.py:177 opac/webapp/admin/views.py:177
+#: opac/webapp/admin/views.py:177
 msgid "Enviar email de confirmação"
 msgstr "Send a confirmation email"
 
-#: build/lib/opac/webapp/admin/views.py:189 opac/webapp/admin/views.py:189
+#: opac/webapp/admin/views.py:189
 #, python-format
 msgid "Ocorreu um erro no envio do email de confirmação para: %(email)s"
 msgstr "An error occurred in sending the confirmation email to: %(email)s"
 
-#: build/lib/opac/webapp/admin/views.py:193 opac/webapp/admin/views.py:193
+#: opac/webapp/admin/views.py:193
 #, python-format
 msgid "%(count)s usuários foram notificados com sucesso!"
 msgstr "%(count)s users were successfully notified!"
 
-#: build/lib/opac/webapp/admin/views.py:196 opac/webapp/admin/views.py:196
+#: opac/webapp/admin/views.py:196
 #, python-format
 msgid "Ocorreu um erro no envio do emails de confirmação. Erro: %(ex)s"
 msgstr "An error occurred in sending the confirmation emails. Error: %(ex)s"
 
-#: build/lib/opac/webapp/admin/views.py:231
-#: build/lib/opac/webapp/admin/views.py:265
-#: build/lib/opac/webapp/admin/views.py:363
-#: build/lib/opac/webapp/admin/views.py:393
-#: build/lib/opac/webapp/admin/views.py:677 opac/webapp/admin/views.py:231
-#: opac/webapp/admin/views.py:265 opac/webapp/admin/views.py:363
-#: opac/webapp/admin/views.py:393 opac/webapp/admin/views.py:677
+#: opac/webapp/admin/views.py:231 opac/webapp/admin/views.py:265
+#: opac/webapp/admin/views.py:363 opac/webapp/admin/views.py:393
+#: opac/webapp/admin/views.py:678
 msgid "Nome"
 msgstr "Name"
 
-#: build/lib/opac/webapp/admin/views.py:232
-#: build/lib/opac/webapp/admin/views.py:267 opac/webapp/admin/views.py:232
-#: opac/webapp/admin/views.py:267
+#: opac/webapp/admin/views.py:232 opac/webapp/admin/views.py:267
 msgid "Link"
 msgstr "Link"
 
-#: build/lib/opac/webapp/admin/views.py:233
-#: build/lib/opac/webapp/admin/views.py:268
-#: build/lib/opac/webapp/admin/views.py:678 opac/webapp/admin/views.py:233
-#: opac/webapp/admin/views.py:268 opac/webapp/admin/views.py:678
+#: opac/webapp/admin/views.py:233 opac/webapp/admin/views.py:268
+#: opac/webapp/admin/views.py:679
 msgid "Idioma"
 msgstr "Language"
 
-#: build/lib/opac/webapp/admin/views.py:266 opac/webapp/admin/views.py:266
+#: opac/webapp/admin/views.py:266
 msgid "Previsualização"
 msgstr "Preview"
 
-#: build/lib/opac/webapp/admin/views.py:362
-#: build/lib/opac/webapp/admin/views.py:547
-#: build/lib/opac/webapp/admin/views.py:627 opac/webapp/admin/views.py:362
-#: opac/webapp/admin/views.py:547 opac/webapp/admin/views.py:627
+#: opac/webapp/admin/views.py:362 opac/webapp/admin/views.py:548
+#: opac/webapp/admin/views.py:628
 msgid "Ordem"
 msgstr "Order"
 
-#: build/lib/opac/webapp/admin/views.py:364 opac/webapp/admin/views.py:364
+#: opac/webapp/admin/views.py:364
 msgid "URL"
 msgstr "URL"
 
-#: build/lib/opac/webapp/admin/views.py:365 opac/webapp/admin/views.py:365
+#: opac/webapp/admin/views.py:365
 msgid "URL da logomarca"
 msgstr "Logo URL"
 
-#: build/lib/opac/webapp/admin/views.py:375 opac/webapp/admin/views.py:375
+#: opac/webapp/admin/views.py:375
 msgid "Financiador com Ordem ou Nome já cadastrado!"
 msgstr "Sponsor Order or Name already registered!"
 
-#: build/lib/opac/webapp/admin/views.py:394 opac/webapp/admin/views.py:394
+#: opac/webapp/admin/views.py:394
 msgid "Acerca de"
 msgstr "About"
 
-#: build/lib/opac/webapp/admin/views.py:395
-#: build/lib/opac/webapp/admin/views.py:462 opac/webapp/admin/views.py:395
-#: opac/webapp/admin/views.py:462
+#: opac/webapp/admin/views.py:395 opac/webapp/admin/views.py:463
 msgid "Acrônimo"
 msgstr "Acronym"
 
-#: build/lib/opac/webapp/admin/views.py:396 opac/webapp/admin/views.py:396
+#: opac/webapp/admin/views.py:396
 msgid "Endereço principal"
 msgstr "Main address"
 
-#: build/lib/opac/webapp/admin/views.py:397 opac/webapp/admin/views.py:397
+#: opac/webapp/admin/views.py:397
 msgid "Endereço secundário"
 msgstr "Secondary address"
 
-#: build/lib/opac/webapp/admin/views.py:398 opac/webapp/admin/views.py:398
+#: opac/webapp/admin/views.py:398
 msgid "Logo da Home (PT)"
 msgstr "Homepage's logo (PT)"
 
-#: build/lib/opac/webapp/admin/views.py:399 opac/webapp/admin/views.py:399
+#: opac/webapp/admin/views.py:399
 msgid "Logo da Home (EN)"
 msgstr "Homepage's logo (EN)"
 
-#: build/lib/opac/webapp/admin/views.py:400 opac/webapp/admin/views.py:400
+#: opac/webapp/admin/views.py:400
 msgid "Logo da Home (ES)"
 msgstr "Homepage's logo (ES)"
 
-#: build/lib/opac/webapp/admin/views.py:401 opac/webapp/admin/views.py:401
+#: opac/webapp/admin/views.py:401
 msgid "Logo do cabeçalho (PT)"
 msgstr "Header's logo (PT)"
 
-#: build/lib/opac/webapp/admin/views.py:402 opac/webapp/admin/views.py:402
+#: opac/webapp/admin/views.py:402
 msgid "Logo do cabeçalho (EN)"
 msgstr "Header's logo (EN)"
 
-#: build/lib/opac/webapp/admin/views.py:403 opac/webapp/admin/views.py:403
+#: opac/webapp/admin/views.py:403
 msgid "Logo do cabeçalho (ES)"
 msgstr "Header's logo (ES)"
 
-#: build/lib/opac/webapp/admin/views.py:404 opac/webapp/admin/views.py:404
+#: opac/webapp/admin/views.py:404
 msgid "Logo do menu (PT)"
 msgstr "Menu's logo (PT)"
 
-#: build/lib/opac/webapp/admin/views.py:405
-#: build/lib/opac/webapp/admin/views.py:406 opac/webapp/admin/views.py:405
-#: opac/webapp/admin/views.py:406
+#: opac/webapp/admin/views.py:405 opac/webapp/admin/views.py:406
 msgid "Logo do menu (ES)"
 msgstr "Menu's logo (ES)"
 
-#: build/lib/opac/webapp/admin/views.py:407 opac/webapp/admin/views.py:407
+#: opac/webapp/admin/views.py:407
 msgid "Logo do menu (drop)"
 msgstr "Drop menu's logo"
 
-#: build/lib/opac/webapp/admin/views.py:408 opac/webapp/admin/views.py:408
+#: opac/webapp/admin/views.py:408
 msgid "Logo do rodapé"
 msgstr "Footer's logo"
 
-#: build/lib/opac/webapp/admin/views.py:451 opac/webapp/admin/views.py:451
+#: opac/webapp/admin/views.py:452
 msgid "Id Periódico"
 msgstr "Journal Id"
 
-#: build/lib/opac/webapp/admin/views.py:453 opac/webapp/admin/views.py:453
+#: opac/webapp/admin/views.py:454
 msgid "Linha do tempo"
 msgstr "Timeline"
 
-#: build/lib/opac/webapp/admin/views.py:454 opac/webapp/admin/views.py:454
+#: opac/webapp/admin/views.py:455
 msgid "Categorias de assunto"
 msgstr "Subject Categories"
 
-#: build/lib/opac/webapp/admin/views.py:455 opac/webapp/admin/views.py:455
+#: opac/webapp/admin/views.py:456
 msgid "Áreas de estudo"
 msgstr "Areas of study"
 
-#: build/lib/opac/webapp/admin/views.py:456 opac/webapp/admin/views.py:456
+#: opac/webapp/admin/views.py:457
 msgid "Redes sociais"
 msgstr "Social networks"
 
-#: build/lib/opac/webapp/admin/views.py:457
-#: build/lib/opac/webapp/admin/views.py:611
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:30
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:73
-#: opac/webapp/admin/views.py:457 opac/webapp/admin/views.py:611
+#: opac/webapp/admin/views.py:458 opac/webapp/admin/views.py:612
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:30
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:73
 msgid "Título"
 msgstr "Title"
 
-#: build/lib/opac/webapp/admin/views.py:458 opac/webapp/admin/views.py:458
+#: opac/webapp/admin/views.py:459
 msgid "Título ISO"
 msgstr "ISO title"
 
-#: build/lib/opac/webapp/admin/views.py:459 opac/webapp/admin/views.py:459
+#: opac/webapp/admin/views.py:460
 msgid "Título curto"
 msgstr "Abbreviated title"
 
-#: build/lib/opac/webapp/admin/views.py:460
-#: build/lib/opac/webapp/admin/views.py:538
-#: build/lib/opac/webapp/admin/views.py:614 opac/webapp/admin/views.py:460
-#: opac/webapp/admin/views.py:538 opac/webapp/admin/views.py:614
+#: opac/webapp/admin/views.py:461 opac/webapp/admin/views.py:539
+#: opac/webapp/admin/views.py:615
 msgid "Criado"
 msgstr "Created"
 
-#: build/lib/opac/webapp/admin/views.py:461
-#: build/lib/opac/webapp/admin/views.py:539
-#: build/lib/opac/webapp/admin/views.py:615 opac/webapp/admin/views.py:461
-#: opac/webapp/admin/views.py:539 opac/webapp/admin/views.py:615
+#: opac/webapp/admin/views.py:462 opac/webapp/admin/views.py:540
+#: opac/webapp/admin/views.py:616
 msgid "Atualizado"
 msgstr "Updated"
 
-#: build/lib/opac/webapp/admin/views.py:463 opac/webapp/admin/views.py:463
+#: opac/webapp/admin/views.py:464
 msgid "ISSN SciELO"
 msgstr "SciELO ISSN"
 
-#: build/lib/opac/webapp/admin/views.py:464 opac/webapp/admin/views.py:464
+#: opac/webapp/admin/views.py:465
 msgid "ISSN impresso"
 msgstr "print ISSN"
 
-#: build/lib/opac/webapp/admin/views.py:465 opac/webapp/admin/views.py:465
+#: opac/webapp/admin/views.py:466
 msgid "ISSN eletrônico"
 msgstr "electronic ISSN"
 
-#: build/lib/opac/webapp/admin/views.py:466 opac/webapp/admin/views.py:466
+#: opac/webapp/admin/views.py:467
 msgid "Descritores de assunto"
 msgstr "Subject descriptors"
 
-#: build/lib/opac/webapp/admin/views.py:467 opac/webapp/admin/views.py:467
+#: opac/webapp/admin/views.py:468
 msgid "Url da submissão online"
 msgstr "online submission URL"
 
-#: build/lib/opac/webapp/admin/views.py:468 opac/webapp/admin/views.py:468
+#: opac/webapp/admin/views.py:469
 msgid "Url do capa"
 msgstr "Cover URL"
 
-#: build/lib/opac/webapp/admin/views.py:469 opac/webapp/admin/views.py:469
+#: opac/webapp/admin/views.py:470
 msgid "Url do logotipo"
 msgstr "Logo URL"
 
-#: build/lib/opac/webapp/admin/views.py:470 opac/webapp/admin/views.py:470
+#: opac/webapp/admin/views.py:471
 msgid "Outros títulos"
 msgstr "Other titles"
 
-#: build/lib/opac/webapp/admin/views.py:471 opac/webapp/admin/views.py:471
+#: opac/webapp/admin/views.py:472
 msgid "Nome da editora"
 msgstr "Publisher name"
 
-#: build/lib/opac/webapp/admin/views.py:472 opac/webapp/admin/views.py:472
+#: opac/webapp/admin/views.py:473
 msgid "País da editora"
 msgstr "Publisher country"
 
-#: build/lib/opac/webapp/admin/views.py:473 opac/webapp/admin/views.py:473
+#: opac/webapp/admin/views.py:474
 msgid "Estado da editora"
 msgstr "Publisher state"
 
-#: build/lib/opac/webapp/admin/views.py:474 opac/webapp/admin/views.py:474
+#: opac/webapp/admin/views.py:475
 msgid "Cidade da editora"
 msgstr "Publisher city"
 
-#: build/lib/opac/webapp/admin/views.py:475 opac/webapp/admin/views.py:475
+#: opac/webapp/admin/views.py:476
 msgid "Endereço da editora"
 msgstr "Publisher address"
 
-#: build/lib/opac/webapp/admin/views.py:476 opac/webapp/admin/views.py:476
+#: opac/webapp/admin/views.py:477
 msgid "Telefone da editora"
 msgstr "Publisher telephone"
 
-#: build/lib/opac/webapp/admin/views.py:477 opac/webapp/admin/views.py:477
+#: opac/webapp/admin/views.py:478
 msgid "Missão"
 msgstr "Mission"
 
-#: build/lib/opac/webapp/admin/views.py:478 opac/webapp/admin/views.py:478
+#: opac/webapp/admin/views.py:479
 msgid "No índice"
 msgstr "In index"
 
-#: build/lib/opac/webapp/admin/views.py:479 opac/webapp/admin/views.py:479
+#: opac/webapp/admin/views.py:480
 msgid "Patrocinadores"
 msgstr "Sponsors"
 
-#: build/lib/opac/webapp/admin/views.py:480 opac/webapp/admin/views.py:480
+#: opac/webapp/admin/views.py:481
 msgid "Ref periódico anterior"
 msgstr "Previous journal reference"
 
-#: build/lib/opac/webapp/admin/views.py:481 opac/webapp/admin/views.py:481
+#: opac/webapp/admin/views.py:482
 msgid "Situação atual"
 msgstr "Journal status"
 
-#: build/lib/opac/webapp/admin/views.py:482 opac/webapp/admin/views.py:482
+#: opac/webapp/admin/views.py:483
 msgid "Total de números"
 msgstr "Total number of issues"
 
-#: build/lib/opac/webapp/admin/views.py:483
-#: build/lib/opac/webapp/admin/views.py:548
-#: build/lib/opac/webapp/admin/views.py:618 opac/webapp/admin/views.py:483
-#: opac/webapp/admin/views.py:548 opac/webapp/admin/views.py:618
+#: opac/webapp/admin/views.py:484 opac/webapp/admin/views.py:549
+#: opac/webapp/admin/views.py:619
 msgid "Publicado?"
 msgstr "Published?"
 
-#: build/lib/opac/webapp/admin/views.py:484
-#: build/lib/opac/webapp/admin/views.py:549
-#: build/lib/opac/webapp/admin/views.py:619 opac/webapp/admin/views.py:484
-#: opac/webapp/admin/views.py:549 opac/webapp/admin/views.py:619
+#: opac/webapp/admin/views.py:485 opac/webapp/admin/views.py:550
+#: opac/webapp/admin/views.py:620
 msgid "Motivo de despublicação"
 msgstr "Reason for unpublishing"
 
-#: build/lib/opac/webapp/admin/views.py:485
-#: build/lib/opac/webapp/admin/views.py:551
-#: build/lib/opac/webapp/admin/views.py:620 opac/webapp/admin/views.py:485
-#: opac/webapp/admin/views.py:551 opac/webapp/admin/views.py:620
+#: opac/webapp/admin/views.py:486 opac/webapp/admin/views.py:552
+#: opac/webapp/admin/views.py:621
 msgid "Segmento de URL"
 msgstr "URL Segment"
 
-#: build/lib/opac/webapp/admin/views.py:488
-#: build/lib/opac/webapp/admin/views.py:554
-#: build/lib/opac/webapp/admin/views.py:633 opac/webapp/admin/views.py:488
-#: opac/webapp/admin/views.py:554 opac/webapp/admin/views.py:633
+#: opac/webapp/admin/views.py:489 opac/webapp/admin/views.py:555
+#: opac/webapp/admin/views.py:634
 msgid "Publicar"
 msgstr "Publish"
 
-#: build/lib/opac/webapp/admin/views.py:493 opac/webapp/admin/views.py:493
+#: opac/webapp/admin/views.py:494
 msgid "Periódico(s) publicado(s) com sucesso!!"
 msgstr "Journal(s) successfully published!!"
 
-#: build/lib/opac/webapp/admin/views.py:495 opac/webapp/admin/views.py:495
+#: opac/webapp/admin/views.py:496
 msgid "Ocorreu um erro tentando publicar o(s) periódico(s)!!"
 msgstr "An error occurred trying to publish the journal(s)!!"
 
-#: build/lib/opac/webapp/admin/views.py:501 opac/webapp/admin/views.py:501
+#: opac/webapp/admin/views.py:502
 msgid "Periódico(s) despublicado com sucesso!!"
 msgstr "Journal(s) successfully unpublished!!"
 
-#: build/lib/opac/webapp/admin/views.py:504 opac/webapp/admin/views.py:504
+#: opac/webapp/admin/views.py:505
 #, python-format
 msgid "Ocorreu um erro tentando despublicar o(s) periódico(s)!!. Erro: %(ex)s"
 msgstr ""
 "An error occurred while attempting to unpublish the journal(s)!!. Error: "
 "%(ex)s"
 
-#: build/lib/opac/webapp/admin/views.py:508
-#: build/lib/opac/webapp/admin/views.py:576
-#: build/lib/opac/webapp/admin/views.py:656 opac/webapp/admin/views.py:508
-#: opac/webapp/admin/views.py:576 opac/webapp/admin/views.py:656
+#: opac/webapp/admin/views.py:509 opac/webapp/admin/views.py:577
+#: opac/webapp/admin/views.py:657
 #, python-format
 msgid "Despublicar por %s"
 msgstr "Unpublished because of %s"
 
-#: build/lib/opac/webapp/admin/views.py:532 opac/webapp/admin/views.py:532
+#: opac/webapp/admin/views.py:533
 msgid "Id Número"
 msgstr "ID number"
 
-#: build/lib/opac/webapp/admin/views.py:534
-#: build/lib/opac/webapp/admin/views.py:624 opac/webapp/admin/views.py:534
-#: opac/webapp/admin/views.py:624
+#: opac/webapp/admin/views.py:535 opac/webapp/admin/views.py:625
 msgid "Seções"
 msgstr "Sections"
 
-#: build/lib/opac/webapp/admin/views.py:535 opac/webapp/admin/views.py:535
+#: opac/webapp/admin/views.py:536
 msgid "Url da capa"
 msgstr "Cover's URL"
 
-#: build/lib/opac/webapp/admin/views.py:536
-#: build/lib/opac/webapp/templates/collection/list_feed_content.html:3
-#: build/lib/opac/webapp/templates/issue/grid.html:40
-#: build/lib/opac/webapp/templates/news/includes/issue_last_row.html:7
-#: opac/webapp/admin/views.py:536
+#: opac/webapp/admin/views.py:537
 #: opac/webapp/templates/collection/list_feed_content.html:3
 #: opac/webapp/templates/issue/grid.html:40
 #: opac/webapp/templates/news/includes/issue_last_row.html:7
 msgid "Volume"
 msgstr "Volume"
 
-#: build/lib/opac/webapp/admin/views.py:540 opac/webapp/admin/views.py:540
+#: opac/webapp/admin/views.py:541
 msgid "Tipo"
 msgstr "Type"
 
-#: build/lib/opac/webapp/admin/views.py:541 opac/webapp/admin/views.py:541
+#: opac/webapp/admin/views.py:542
 msgid "Texto do suplemento"
 msgstr "Text for supplement"
 
-#: build/lib/opac/webapp/admin/views.py:542 opac/webapp/admin/views.py:542
+#: opac/webapp/admin/views.py:543
 msgid "Texto do especial"
 msgstr "Text for special"
 
-#: build/lib/opac/webapp/admin/views.py:543 opac/webapp/admin/views.py:543
+#: opac/webapp/admin/views.py:544
 msgid "Mês inicial"
 msgstr "Beginning month"
 
-#: build/lib/opac/webapp/admin/views.py:544 opac/webapp/admin/views.py:544
+#: opac/webapp/admin/views.py:545
 msgid "Mês final"
 msgstr "End month"
 
-#: build/lib/opac/webapp/admin/views.py:545
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:25
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:68
-#: build/lib/opac/webapp/templates/issue/grid.html:39
-#: build/lib/opac/webapp/templates/news/includes/issue_last_row.html:5
-#: opac/webapp/admin/views.py:545
+#: opac/webapp/admin/views.py:546
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:25
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:68
 #: opac/webapp/templates/issue/grid.html:39
@@ -958,218 +822,184 @@ msgstr "End month"
 msgid "Ano"
 msgstr "Year"
 
-#: build/lib/opac/webapp/admin/views.py:546 opac/webapp/admin/views.py:546
+#: opac/webapp/admin/views.py:547
 msgid "Etiqueta"
 msgstr "Tag"
 
-#: build/lib/opac/webapp/admin/views.py:550
-#: build/lib/opac/webapp/admin/views.py:621 opac/webapp/admin/views.py:550
-#: opac/webapp/admin/views.py:621
+#: opac/webapp/admin/views.py:551 opac/webapp/admin/views.py:622
 msgid "PID"
 msgstr "PID"
 
-#: build/lib/opac/webapp/admin/views.py:559 opac/webapp/admin/views.py:559
+#: opac/webapp/admin/views.py:560
 msgid "Número(s) publicado(s) com sucesso!!"
 msgstr "Issue(s) published successfully!!"
 
-#: build/lib/opac/webapp/admin/views.py:562
-#: build/lib/opac/webapp/admin/views.py:642 opac/webapp/admin/views.py:562
-#: opac/webapp/admin/views.py:642
+#: opac/webapp/admin/views.py:563 opac/webapp/admin/views.py:643
 #, python-format
 msgid "Ocorreu um erro tentando publicar o(s) número(s)!!. Erro: %(ex)s"
 msgstr "There was an error trying to publish the Issue(s) !!. Error: %(ex)s"
 
-#: build/lib/opac/webapp/admin/views.py:569 opac/webapp/admin/views.py:569
+#: opac/webapp/admin/views.py:570
 msgid "Número(s) despublicado(s) com sucesso!!"
 msgstr "Issue(s) unpublished successfully!!"
 
-#: build/lib/opac/webapp/admin/views.py:572
-#: build/lib/opac/webapp/admin/views.py:652 opac/webapp/admin/views.py:572
-#: opac/webapp/admin/views.py:652
+#: opac/webapp/admin/views.py:573 opac/webapp/admin/views.py:653
 #, python-format
 msgid "Ocorreu um erro tentando despublicar o(s) número(s)!!. Erro: %(ex)s"
 msgstr "There was an error trying to unpublish the Issue(s) !!. Error: %(ex)s"
 
-#: build/lib/opac/webapp/admin/views.py:608 opac/webapp/admin/views.py:608
+#: opac/webapp/admin/views.py:609
 msgid "Id Artigo"
 msgstr "Article ID"
 
-#: build/lib/opac/webapp/admin/views.py:612 opac/webapp/admin/views.py:612
+#: opac/webapp/admin/views.py:613
 msgid "Seção"
 msgstr "Section"
 
-#: build/lib/opac/webapp/admin/views.py:613 opac/webapp/admin/views.py:613
+#: opac/webapp/admin/views.py:614
 msgid "É Ahead of Print?"
 msgstr "Ahead of Print?"
 
-#: build/lib/opac/webapp/admin/views.py:616 opac/webapp/admin/views.py:616
+#: opac/webapp/admin/views.py:617
 msgid "HTML's"
 msgstr "HTML's"
 
-#: build/lib/opac/webapp/admin/views.py:617 opac/webapp/admin/views.py:617
+#: opac/webapp/admin/views.py:618
 msgid "Chave de domínio"
 msgstr "Domain key"
 
-#: build/lib/opac/webapp/admin/views.py:622 opac/webapp/admin/views.py:622
+#: opac/webapp/admin/views.py:623
 msgid "Idioma original"
 msgstr "Original language"
 
-#: build/lib/opac/webapp/admin/views.py:623 opac/webapp/admin/views.py:623
+#: opac/webapp/admin/views.py:624
 msgid "Idiomas das traduções"
 msgstr "Translations languages"
 
-#: build/lib/opac/webapp/admin/views.py:625 opac/webapp/admin/views.py:625
+#: opac/webapp/admin/views.py:626
 msgid "Autores"
 msgstr "Authors"
 
-#: build/lib/opac/webapp/admin/views.py:626
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:29
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:72
-#: build/lib/opac/webapp/templates/issue/toc.html:176
-#: opac/webapp/admin/views.py:626
+#: opac/webapp/admin/views.py:627
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:29
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:72
-#: opac/webapp/templates/issue/toc.html:176
+#: opac/webapp/templates/issue/toc.html:169
 msgid "Resumo"
 msgstr "Abstract"
 
-#: build/lib/opac/webapp/admin/views.py:628 opac/webapp/admin/views.py:628
+#: opac/webapp/admin/views.py:629
 msgid "DOI"
 msgstr "DOI"
 
-#: build/lib/opac/webapp/admin/views.py:629 opac/webapp/admin/views.py:629
+#: opac/webapp/admin/views.py:630
 msgid "Idiomas"
 msgstr "Languages"
 
-#: build/lib/opac/webapp/admin/views.py:630 opac/webapp/admin/views.py:630
+#: opac/webapp/admin/views.py:631
 msgid "Idiomas dos resumos"
 msgstr "Abstracts languages"
 
-#: build/lib/opac/webapp/admin/views.py:638 opac/webapp/admin/views.py:638
+#: opac/webapp/admin/views.py:639
 msgid "Artigo(s) publicado com sucesso!!"
 msgstr "Article(s) successfully published!!"
 
-#: build/lib/opac/webapp/admin/views.py:649 opac/webapp/admin/views.py:649
+#: opac/webapp/admin/views.py:650
 msgid "Artigo(s) despublicado com sucesso!!"
 msgstr "Article(s) successfully unpublished!!"
 
-#: build/lib/opac/webapp/admin/views.py:679 opac/webapp/admin/views.py:679
+#: opac/webapp/admin/views.py:680
 msgid "Conteúdo"
 msgstr "Content"
 
-#: build/lib/opac/webapp/admin/views.py:681
-#: build/lib/opac/webapp/admin/views.py:901 opac/webapp/admin/views.py:681
-#: opac/webapp/admin/views.py:901
+#: opac/webapp/admin/views.py:682 opac/webapp/admin/views.py:902
 msgid "Descrição"
 msgstr "Description"
 
-#: build/lib/opac/webapp/admin/views.py:682
-#: build/lib/opac/webapp/admin/views.py:898 opac/webapp/admin/views.py:682
-#: opac/webapp/admin/views.py:898
+#: opac/webapp/admin/views.py:683 opac/webapp/admin/views.py:899
 msgid "Data de Criação"
 msgstr "Creation Date"
 
-#: build/lib/opac/webapp/admin/views.py:683 opac/webapp/admin/views.py:683
+#: opac/webapp/admin/views.py:684
 msgid "Data de Atualização"
 msgstr "Update Date"
 
-#: build/lib/opac/webapp/admin/views.py:897 opac/webapp/admin/views.py:897
+#: opac/webapp/admin/views.py:898
 msgid "Ação"
 msgstr "Action"
 
-#: build/lib/opac/webapp/admin/views.py:899 opac/webapp/admin/views.py:899
+#: opac/webapp/admin/views.py:900
 msgid "Modelo Auditado"
 msgstr "Audited Module"
 
-#: build/lib/opac/webapp/admin/views.py:900 opac/webapp/admin/views.py:900
+#: opac/webapp/admin/views.py:901
 msgid "Id Auditado"
 msgstr "Audited Id"
 
-#: build/lib/opac/webapp/admin/views.py:902 opac/webapp/admin/views.py:902
+#: opac/webapp/admin/views.py:903
 msgid "Dados dos campos"
 msgstr "Field data"
 
-#: build/lib/opac/webapp/main/views.py:34 opac/webapp/main/views.py:34
+#: opac/webapp/main/views.py:34
 msgid "O periódico está indisponível por motivo de: "
 msgstr "The journal is unavailable because:"
 
-#: build/lib/opac/webapp/main/views.py:35 opac/webapp/main/views.py:35
+#: opac/webapp/main/views.py:35
 msgid "O número está indisponível por motivo de: "
 msgstr "The Issue is unavailable because of:"
 
-#: build/lib/opac/webapp/main/views.py:36 opac/webapp/main/views.py:36
+#: opac/webapp/main/views.py:36
 msgid "O artigo está indisponível por motivo de: "
 msgstr "The article is unavailable because:"
 
-#: build/lib/opac/webapp/main/views.py:127 opac/webapp/main/views.py:127
+#: opac/webapp/main/views.py:127
 msgid "Código de idioma inválido"
 msgstr "Invalid language code"
 
-#: build/lib/opac/webapp/main/views.py:197 opac/webapp/main/views.py:197
+#: opac/webapp/main/views.py:197
 msgid "Últimos periódicos inseridos na coleção"
 msgstr "Latest journals added to the collection"
 
-#: build/lib/opac/webapp/main/views.py:198 opac/webapp/main/views.py:198
+#: opac/webapp/main/views.py:198
 #, python-format
 msgid "10 últimos periódicos inseridos na coleção %s"
 msgstr "10 latest journals added to the collection %s"
 
-#: build/lib/opac/webapp/main/views.py:257 opac/webapp/main/views.py:257
+#: opac/webapp/main/views.py:257
 msgid "Página não encontrada"
 msgstr ""
 
-#: build/lib/opac/webapp/main/views.py:281
-#: build/lib/opac/webapp/main/views.py:371 opac/webapp/main/views.py:281
-#: opac/webapp/main/views.py:371
+#: opac/webapp/main/views.py:281 opac/webapp/main/views.py:371
 #, python-format
 msgid "Requsição inválida ao tentar acessar o artigo com pid: %s"
 msgstr ""
 
-#: build/lib/opac/webapp/main/views.py:289
-#: build/lib/opac/webapp/main/views.py:339
-#: build/lib/opac/webapp/main/views.py:383
-#: build/lib/opac/webapp/main/views.py:452
-#: build/lib/opac/webapp/main/views.py:500
-#: build/lib/opac/webapp/main/views.py:647
-#: build/lib/opac/webapp/main/views.py:664
-#: build/lib/opac/webapp/main/views.py:1127 opac/webapp/main/views.py:289
-#: opac/webapp/main/views.py:339 opac/webapp/main/views.py:383
-#: opac/webapp/main/views.py:452 opac/webapp/main/views.py:500
-#: opac/webapp/main/views.py:647 opac/webapp/main/views.py:664
-#: opac/webapp/main/views.py:1127
+#: opac/webapp/main/views.py:289 opac/webapp/main/views.py:339
+#: opac/webapp/main/views.py:383 opac/webapp/main/views.py:452
+#: opac/webapp/main/views.py:500 opac/webapp/main/views.py:647
+#: opac/webapp/main/views.py:664 opac/webapp/main/views.py:1127
 msgid "Periódico não encontrado"
 msgstr "Journal not found"
 
-#: build/lib/opac/webapp/main/views.py:301
-#: build/lib/opac/webapp/main/views.py:714
-#: build/lib/opac/webapp/main/views.py:773
-#: build/lib/opac/webapp/main/views.py:1136 opac/webapp/main/views.py:301
-#: opac/webapp/main/views.py:714 opac/webapp/main/views.py:773
-#: opac/webapp/main/views.py:1136
+#: opac/webapp/main/views.py:301 opac/webapp/main/views.py:714
+#: opac/webapp/main/views.py:773 opac/webapp/main/views.py:1136
 msgid "Número não encontrado"
 msgstr "Issue not found"
 
-#: build/lib/opac/webapp/main/views.py:319
-#: build/lib/opac/webapp/main/views.py:354
-#: build/lib/opac/webapp/main/views.py:825
-#: build/lib/opac/webapp/main/views.py:910
-#: build/lib/opac/webapp/main/views.py:1060 opac/webapp/main/views.py:319
-#: opac/webapp/main/views.py:354 opac/webapp/main/views.py:825
-#: opac/webapp/main/views.py:910 opac/webapp/main/views.py:1060
+#: opac/webapp/main/views.py:319 opac/webapp/main/views.py:354
+#: opac/webapp/main/views.py:825 opac/webapp/main/views.py:910
+#: opac/webapp/main/views.py:1060
 msgid "Artigo não encontrado"
 msgstr "Article not found"
 
-#: build/lib/opac/webapp/main/views.py:476 opac/webapp/main/views.py:476
+#: opac/webapp/main/views.py:476
 msgid "Artigo sem título"
 msgstr "Article not found"
 
-#: build/lib/opac/webapp/main/views.py:548
-#: build/lib/opac/webapp/main/views.py:565 opac/webapp/main/views.py:548
-#: opac/webapp/main/views.py:565
+#: opac/webapp/main/views.py:548 opac/webapp/main/views.py:565
 msgid "Requisição inválida. Deve ser por ajax"
 msgstr "Invalid request. Must be made via ajax"
 
-#: build/lib/opac/webapp/main/views.py:581 opac/webapp/main/views.py:581
+#: opac/webapp/main/views.py:581
 msgid ""
 "Parámetro \"filter\" é inválido, deve ser \"areas\", \"wos\" ou "
 "\"publisher\"."
@@ -1177,11 +1007,11 @@ msgstr ""
 "Invalid parameter \"filter\". Should be \"areas\", \"wos\" or "
 "\"publisher\"."
 
-#: build/lib/opac/webapp/main/views.py:590 opac/webapp/main/views.py:590
+#: opac/webapp/main/views.py:590
 msgid "Parámetro \"extension\" é inválido, deve ser \"csv\" ou \"xls\"."
 msgstr "Invalid parameter \"extension\". Should be \"csv\" or \"xls\"."
 
-#: build/lib/opac/webapp/main/views.py:592 opac/webapp/main/views.py:592
+#: opac/webapp/main/views.py:592
 msgid ""
 "Parámetro \"list_type\" é inválido, deve ser: \"alpha\", \"areas\", "
 "\"wos\" ou \"publisher\"."
@@ -1189,78 +1019,61 @@ msgstr ""
 "Invalid parameter \"list_type\". Should be: \"alpha\", \"areas\", \"wos\""
 " or \"publisher\"."
 
-#: build/lib/opac/webapp/main/views.py:613 opac/webapp/main/views.py:613
+#: opac/webapp/main/views.py:613
 msgid "Requisição inválida, deve ser ajax."
 msgstr ""
 
-#: build/lib/opac/webapp/main/views.py:622 opac/webapp/main/views.py:622
+#: opac/webapp/main/views.py:622
 msgid "Periódico não permite envio de email."
 msgstr ""
 
-#: build/lib/opac/webapp/main/views.py:640 opac/webapp/main/views.py:640
+#: opac/webapp/main/views.py:640
 msgid "Requisição inválida, captcha inválido."
 msgstr ""
 
-#: build/lib/opac/webapp/main/views.py:901
-#: build/lib/opac/webapp/main/views.py:1055 opac/webapp/main/views.py:901
-#: opac/webapp/main/views.py:1055
+#: opac/webapp/main/views.py:901 opac/webapp/main/views.py:1055
 msgid "Issue não encontrado"
 msgstr "Issue not found"
 
-#: build/lib/opac/webapp/main/views.py:943
-#: build/lib/opac/webapp/main/views.py:949
-#: build/lib/opac/webapp/main/views.py:1092
-#: build/lib/opac/webapp/main/views.py:1100
-#: build/lib/opac/webapp/main/views.py:1102 opac/webapp/main/views.py:943
-#: opac/webapp/main/views.py:949 opac/webapp/main/views.py:1092
-#: opac/webapp/main/views.py:1100 opac/webapp/main/views.py:1102
+#: opac/webapp/main/views.py:943 opac/webapp/main/views.py:949
+#: opac/webapp/main/views.py:1092 opac/webapp/main/views.py:1100
+#: opac/webapp/main/views.py:1102
 msgid "PDF do Artigo não encontrado"
 msgstr "Article's PDF not found"
 
-#: build/lib/opac/webapp/main/views.py:954 opac/webapp/main/views.py:954
+#: opac/webapp/main/views.py:954
 msgid "HTML do Artigo não encontrado ou indisponível"
 msgstr "HTML of article not found or unavailable"
 
-#: build/lib/opac/webapp/main/views.py:1001 opac/webapp/main/views.py:1001
+#: opac/webapp/main/views.py:1001
 msgid "Parâmetros insuficientes para obter o EPDF do artigo"
 msgstr "Insufficient parameters to obtain article's EPDF"
 
-#: build/lib/opac/webapp/main/views.py:1022 opac/webapp/main/views.py:1022
+#: opac/webapp/main/views.py:1022
 msgid "Recruso não encontrado"
 msgstr "Resource not found"
 
-#: build/lib/opac/webapp/main/views.py:1041 opac/webapp/main/views.py:1041
+#: opac/webapp/main/views.py:1041
 msgid "Recurso do Artigo não encontrado. Caminho inválido!"
 msgstr "Article resource not found. Invalid path!"
 
-#: build/lib/opac/webapp/main/views.py:1154 opac/webapp/main/views.py:1154
+#: opac/webapp/main/views.py:1154
 msgid "PDF do artigo não foi encontrado"
 msgstr "Article's PDF not found"
 
-#: build/lib/opac/webapp/main/views.py:1169
-#: build/lib/opac/webapp/main/views.py:1200 opac/webapp/main/views.py:1169
-#: opac/webapp/main/views.py:1200
+#: opac/webapp/main/views.py:1169 opac/webapp/main/views.py:1200
 msgid "Requisição inválida."
 msgstr "Invalid request"
 
-#: build/lib/opac/webapp/templates/admin/index.html:7
 #: opac/webapp/templates/admin/index.html:7
 msgid "da coleção"
 msgstr "of collection"
 
-#: build/lib/opac/webapp/templates/admin/index.html:12
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu.html:31
 #: opac/webapp/templates/admin/index.html:12
 #: opac/webapp/templates/collection/includes/levelMenu.html:31
 msgid "Periódicos"
 msgstr "Journals"
 
-#: build/lib/opac/webapp/templates/admin/index.html:15
-#: build/lib/opac/webapp/templates/admin/index.html:22
-#: build/lib/opac/webapp/templates/admin/index.html:35
-#: build/lib/opac/webapp/templates/admin/index.html:42
-#: build/lib/opac/webapp/templates/admin/index.html:55
-#: build/lib/opac/webapp/templates/admin/index.html:62
 #: opac/webapp/templates/admin/index.html:15
 #: opac/webapp/templates/admin/index.html:22
 #: opac/webapp/templates/admin/index.html:35
@@ -1270,12 +1083,6 @@ msgstr "Journals"
 msgid "Publicados"
 msgstr "Published"
 
-#: build/lib/opac/webapp/templates/admin/index.html:16
-#: build/lib/opac/webapp/templates/admin/index.html:36
-#: build/lib/opac/webapp/templates/admin/index.html:56
-#: build/lib/opac/webapp/templates/admin/index.html:75
-#: build/lib/opac/webapp/templates/admin/index.html:85
-#: build/lib/opac/webapp/templates/admin/index.html:95
 #: opac/webapp/templates/admin/index.html:16
 #: opac/webapp/templates/admin/index.html:36
 #: opac/webapp/templates/admin/index.html:56
@@ -1285,78 +1092,58 @@ msgstr "Published"
 msgid "Total"
 msgstr "Total"
 
-#: build/lib/opac/webapp/templates/admin/index.html:32
 #: opac/webapp/templates/admin/index.html:32
 msgid "Fascícluos"
 msgstr "Issues"
 
-#: build/lib/opac/webapp/templates/admin/index.html:52
 #: opac/webapp/templates/admin/index.html:52
 msgid "Artigos"
 msgstr "Articles"
 
-#: build/lib/opac/webapp/templates/admin/index.html:72
 #: opac/webapp/templates/admin/index.html:72
 msgid "News"
 msgstr "News"
 
-#: build/lib/opac/webapp/templates/admin/index.html:82
 #: opac/webapp/templates/admin/index.html:82
 msgid "Sponsors"
 msgstr "Sponsors"
 
-#: build/lib/opac/webapp/templates/admin/index.html:92
 #: opac/webapp/templates/admin/index.html:92
 msgid "Press Releases"
 msgstr "Press Releases"
 
-#: build/lib/opac/webapp/templates/admin/auth/reset.html:9
-#: build/lib/opac/webapp/templates/admin/auth/reset_with_token.html:9
-#: build/lib/opac/webapp/templates/admin/opac_base.html:13
 #: opac/webapp/templates/admin/auth/reset.html:9
 #: opac/webapp/templates/admin/auth/reset_with_token.html:9
 #: opac/webapp/templates/admin/opac_base.html:13
 msgid "Recuperar a senha"
 msgstr "Reset password"
 
-#: build/lib/opac/webapp/templates/admin/opac_base.html:14
 #: opac/webapp/templates/admin/opac_base.html:14
 msgid "Terminar sessão"
 msgstr "Logout"
 
-#: build/lib/opac/webapp/templates/admin/auth/login.html:11
-#: build/lib/opac/webapp/templates/admin/auth/login.html:20
-#: build/lib/opac/webapp/templates/admin/opac_base.html:18
 #: opac/webapp/templates/admin/auth/login.html:11
 #: opac/webapp/templates/admin/auth/login.html:20
 #: opac/webapp/templates/admin/opac_base.html:18
 msgid "Iniciar sessão"
 msgstr "Login"
 
-#: build/lib/opac/webapp/templates/admin/audit_log/fields_data_table.html:4
 #: opac/webapp/templates/admin/audit_log/fields_data_table.html:4
 msgid "Campo: "
 msgstr "Field:"
 
-#: build/lib/opac/webapp/templates/admin/audit_log/fields_data_table.html:5
 #: opac/webapp/templates/admin/audit_log/fields_data_table.html:5
 msgid "Valor anterior: "
 msgstr "Previous value:"
 
-#: build/lib/opac/webapp/templates/admin/audit_log/fields_data_table.html:6
 #: opac/webapp/templates/admin/audit_log/fields_data_table.html:6
 msgid "Valor novo: "
 msgstr "New value:"
 
-#: build/lib/opac/webapp/templates/admin/auth/login.html:13
 #: opac/webapp/templates/admin/auth/login.html:13
 msgid "Você já iniciou sessão!"
 msgstr "You’re already logged in!"
 
-#: build/lib/opac/webapp/templates/admin/auth/login.html:24
-#: build/lib/opac/webapp/templates/admin/auth/reset.html:13
-#: build/lib/opac/webapp/templates/admin/auth/reset_with_token.html:13
-#: build/lib/opac/webapp/templates/includes/error_form.html:60
 #: opac/webapp/templates/admin/auth/login.html:24
 #: opac/webapp/templates/admin/auth/reset.html:13
 #: opac/webapp/templates/admin/auth/reset_with_token.html:13
@@ -1364,17 +1151,14 @@ msgstr "You’re already logged in!"
 msgid "Enviar"
 msgstr "Send"
 
-#: build/lib/opac/webapp/templates/admin/auth/login.html:28
 #: opac/webapp/templates/admin/auth/login.html:28
 msgid "Esqueci a senha?"
 msgstr "Forgot the password?"
 
-#: build/lib/opac/webapp/templates/admin/auth/unconfirm_email.html:7
 #: opac/webapp/templates/admin/auth/unconfirm_email.html:7
 msgid "Email não confirmado!"
 msgstr "Email not confirmed!"
 
-#: build/lib/opac/webapp/templates/admin/auth/unconfirm_email.html:9
 #: opac/webapp/templates/admin/auth/unconfirm_email.html:9
 msgid ""
 "Você <strong>deve</strong> confirmar seu email.<br>\n"
@@ -1384,7 +1168,6 @@ msgstr ""
 "You <strong>should</strong> confirm your email.<br>\n"
 "<strong>Please contact your administrator.</strong>"
 
-#: build/lib/opac/webapp/templates/admin/pages/edit.html:7
 #: opac/webapp/templates/admin/pages/edit.html:7
 msgid ""
 "<strong>Atenção:</strong> ao selecionar um <strong>periódico</strong> "
@@ -1397,11 +1180,6 @@ msgstr ""
 "otherwise the page will be a collection page, check the collection pages "
 "at <em>About SciELO</em>"
 
-#: build/lib/opac/webapp/templates/article/includes/alternative_header.html:7
-#: build/lib/opac/webapp/templates/collection/includes/header.html:7
-#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:7
-#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:7
-#: build/lib/opac/webapp/templates/journal/includes/header.html:8
 #: opac/webapp/templates/article/includes/alternative_header.html:7
 #: opac/webapp/templates/collection/includes/header.html:7
 #: opac/webapp/templates/issue/includes/alternative_header.html:7
@@ -1410,10 +1188,6 @@ msgstr ""
 msgid "Abrir menu"
 msgstr "Open menu"
 
-#: build/lib/opac/webapp/templates/article/includes/alternative_header.html:9
-#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:9
-#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:9
-#: build/lib/opac/webapp/templates/journal/includes/header.html:10
 #: opac/webapp/templates/article/includes/alternative_header.html:9
 #: opac/webapp/templates/issue/includes/alternative_header.html:9
 #: opac/webapp/templates/journal/includes/alternative_header.html:9
@@ -1421,11 +1195,6 @@ msgstr "Open menu"
 msgid "Ir para a homepage da coleção: "
 msgstr "Go to the home page of the collection:"
 
-#: build/lib/opac/webapp/templates/article/includes/alternative_header.html:42
-#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:7
-#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:121
-#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:117
-#: build/lib/opac/webapp/templates/journal/includes/header.html:118
 #: opac/webapp/templates/article/includes/alternative_header.html:42
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:7
 #: opac/webapp/templates/issue/includes/alternative_header.html:121
@@ -1434,11 +1203,6 @@ msgstr "Go to the home page of the collection:"
 msgid "Submissão de manuscritos"
 msgstr "Submission of manuscripts"
 
-#: build/lib/opac/webapp/templates/article/includes/alternative_header.html:48
-#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:16
-#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:127
-#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:123
-#: build/lib/opac/webapp/templates/journal/includes/header.html:124
 #: opac/webapp/templates/article/includes/alternative_header.html:48
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:16
 #: opac/webapp/templates/issue/includes/alternative_header.html:127
@@ -1447,11 +1211,6 @@ msgstr "Submission of manuscripts"
 msgid "Sobre o periódico"
 msgstr "About the journal"
 
-#: build/lib/opac/webapp/templates/article/includes/alternative_header.html:53
-#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:10
-#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:132
-#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:128
-#: build/lib/opac/webapp/templates/journal/includes/header.html:129
 #: opac/webapp/templates/article/includes/alternative_header.html:53
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:10
 #: opac/webapp/templates/issue/includes/alternative_header.html:132
@@ -1460,11 +1219,6 @@ msgstr "About the journal"
 msgid "Corpo Editorial"
 msgstr "Editorial Board"
 
-#: build/lib/opac/webapp/templates/article/includes/alternative_header.html:58
-#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:13
-#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:137
-#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:133
-#: build/lib/opac/webapp/templates/journal/includes/header.html:134
 #: opac/webapp/templates/article/includes/alternative_header.html:58
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:13
 #: opac/webapp/templates/issue/includes/alternative_header.html:137
@@ -1473,11 +1227,6 @@ msgstr "Editorial Board"
 msgid "Instruções aos autores"
 msgstr "Instructions to authors"
 
-#: build/lib/opac/webapp/templates/article/includes/alternative_header.html:63
-#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:19
-#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:142
-#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:138
-#: build/lib/opac/webapp/templates/journal/includes/header.html:140
 #: opac/webapp/templates/article/includes/alternative_header.html:63
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:19
 #: opac/webapp/templates/issue/includes/alternative_header.html:142
@@ -1486,81 +1235,56 @@ msgstr "Instructions to authors"
 msgid "Contato"
 msgstr "Contact"
 
-#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:2
-#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:60
 #: opac/webapp/templates/article/includes/floating_menu.html:2
 #: opac/webapp/templates/article/includes/floating_menu.html:60
 msgid "Ir para o topo"
 msgstr "Go to top"
 
-#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:6
-#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:65
 #: opac/webapp/templates/article/includes/floating_menu.html:6
 #: opac/webapp/templates/article/includes/floating_menu.html:65
 msgid "PDFs"
 msgstr "PDFs"
 
-#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:26
-#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:77
 #: opac/webapp/templates/article/includes/floating_menu.html:26
 #: opac/webapp/templates/article/includes/floating_menu.html:77
 msgid "Figuras e tabelas"
 msgstr "Figures and tables"
 
-#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:32
-#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:83
 #: opac/webapp/templates/article/includes/floating_menu.html:32
 #: opac/webapp/templates/article/includes/floating_menu.html:83
 msgid "Versões e traduções"
 msgstr "Versions and translations"
 
-#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:37
-#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:88
 #: opac/webapp/templates/article/includes/floating_menu.html:37
 #: opac/webapp/templates/article/includes/floating_menu.html:88
 msgid "Como citar este artigo"
 msgstr "How to cite this article"
 
-#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:42
-#: build/lib/opac/webapp/templates/article/includes/modal/related_article.html:9
 #: opac/webapp/templates/article/includes/floating_menu.html:42
 #: opac/webapp/templates/article/includes/modal/related_article.html:9
 msgid "Artigos relacionados"
 msgstr "Related articles"
 
-#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:93
 #: opac/webapp/templates/article/includes/floating_menu.html:93
 msgid "Artigos e similares"
 msgstr "Articles and alike"
 
-#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:9
 #: opac/webapp/templates/article/includes/levelMenu.html:9
 msgid "home do periodico"
 msgstr "Home of journal"
 
-#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:17
-#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:70
-#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:123
 #: opac/webapp/templates/article/includes/levelMenu.html:17
 #: opac/webapp/templates/article/includes/levelMenu.html:70
 #: opac/webapp/templates/article/includes/levelMenu.html:123
 msgid "sumário"
 msgstr "summary"
 
-#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:30
-#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:75
-#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:71
 #: opac/webapp/templates/article/includes/levelMenu.html:30
 #: opac/webapp/templates/issue/includes/alternative_header.html:75
 #: opac/webapp/templates/journal/includes/alternative_header.html:71
 msgid "anterior"
 msgstr "previous"
 
-#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:35
-#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:88
-#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:141
-#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:82
-#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:78
 #: opac/webapp/templates/article/includes/levelMenu.html:35
 #: opac/webapp/templates/article/includes/levelMenu.html:88
 #: opac/webapp/templates/article/includes/levelMenu.html:141
@@ -1569,15 +1293,10 @@ msgstr "previous"
 msgid "atual"
 msgstr "current"
 
-#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:48
 #: opac/webapp/templates/article/includes/levelMenu.html:48
 msgid "seguinte"
 msgstr "next"
 
-#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:193
-#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:219
-#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:264
-#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:290
 #: opac/webapp/templates/article/includes/levelMenu.html:193
 #: opac/webapp/templates/article/includes/levelMenu.html:219
 #: opac/webapp/templates/article/includes/levelMenu.html:264
@@ -1585,10 +1304,6 @@ msgstr "next"
 msgid "Download PDF (Espanhol)"
 msgstr "Download PDF (Spanish)"
 
-#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:195
-#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:221
-#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:266
-#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:292
 #: opac/webapp/templates/article/includes/levelMenu.html:195
 #: opac/webapp/templates/article/includes/levelMenu.html:221
 #: opac/webapp/templates/article/includes/levelMenu.html:266
@@ -1596,10 +1311,6 @@ msgstr "Download PDF (Spanish)"
 msgid "Download PDF (Inglês)"
 msgstr "Download PDF (English)"
 
-#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:197
-#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:223
-#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:268
-#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:294
 #: opac/webapp/templates/article/includes/levelMenu.html:197
 #: opac/webapp/templates/article/includes/levelMenu.html:223
 #: opac/webapp/templates/article/includes/levelMenu.html:268
@@ -1607,13 +1318,6 @@ msgstr "Download PDF (English)"
 msgid "Download PDF (Português)"
 msgstr "Download PDF (Portuguese)"
 
-#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:310
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu.html:38
-#: build/lib/opac/webapp/templates/collection/includes/list_journals_section_title.html:14
-#: build/lib/opac/webapp/templates/issue/grid.html:14
-#: build/lib/opac/webapp/templates/issue/toc.html:13
-#: build/lib/opac/webapp/templates/journal/about.html:16
-#: build/lib/opac/webapp/templates/journal/detail.html:11
 #: opac/webapp/templates/article/includes/levelMenu.html:310
 #: opac/webapp/templates/collection/includes/levelMenu.html:38
 #: opac/webapp/templates/collection/includes/list_journals_section_title.html:14
@@ -1624,11 +1328,6 @@ msgstr "Download PDF (Portuguese)"
 msgid "Compartilhe"
 msgstr "Share"
 
-#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:311
-#: build/lib/opac/webapp/templates/collection/includes/list_journals_section_title.html:16
-#: build/lib/opac/webapp/templates/issue/toc.html:14
-#: build/lib/opac/webapp/templates/journal/about.html:17
-#: build/lib/opac/webapp/templates/journal/detail.html:12
 #: opac/webapp/templates/article/includes/levelMenu.html:311
 #: opac/webapp/templates/collection/includes/list_journals_section_title.html:16
 #: opac/webapp/templates/issue/toc.html:14
@@ -1637,11 +1336,6 @@ msgstr "Share"
 msgid "Enviar link por e-mail"
 msgstr "Send link by email"
 
-#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:314
-#: build/lib/opac/webapp/templates/collection/includes/list_journals_section_title.html:19
-#: build/lib/opac/webapp/templates/issue/toc.html:15
-#: build/lib/opac/webapp/templates/journal/about.html:18
-#: build/lib/opac/webapp/templates/journal/detail.html:13
 #: opac/webapp/templates/article/includes/levelMenu.html:314
 #: opac/webapp/templates/collection/includes/list_journals_section_title.html:19
 #: opac/webapp/templates/issue/toc.html:15
@@ -1650,11 +1344,6 @@ msgstr "Send link by email"
 msgid "Compartilhar no Facebook"
 msgstr "Share in Facebook"
 
-#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:317
-#: build/lib/opac/webapp/templates/collection/includes/list_journals_section_title.html:22
-#: build/lib/opac/webapp/templates/issue/toc.html:16
-#: build/lib/opac/webapp/templates/journal/about.html:19
-#: build/lib/opac/webapp/templates/journal/detail.html:14
 #: opac/webapp/templates/article/includes/levelMenu.html:317
 #: opac/webapp/templates/collection/includes/list_journals_section_title.html:22
 #: opac/webapp/templates/issue/toc.html:16
@@ -1663,18 +1352,6 @@ msgstr "Share in Facebook"
 msgid "Compartilhar no Twitter"
 msgstr "Share in Twitter"
 
-#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:320
-#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:325
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu.html:46
-#: build/lib/opac/webapp/templates/collection/includes/list_journals_section_title.html:25
-#: build/lib/opac/webapp/templates/collection/includes/list_journals_section_title.html:30
-#: build/lib/opac/webapp/templates/issue/grid.html:20
-#: build/lib/opac/webapp/templates/issue/toc.html:17
-#: build/lib/opac/webapp/templates/issue/toc.html:19
-#: build/lib/opac/webapp/templates/journal/about.html:20
-#: build/lib/opac/webapp/templates/journal/about.html:22
-#: build/lib/opac/webapp/templates/journal/detail.html:15
-#: build/lib/opac/webapp/templates/journal/detail.html:17
 #: opac/webapp/templates/article/includes/levelMenu.html:320
 #: opac/webapp/templates/article/includes/levelMenu.html:325
 #: opac/webapp/templates/collection/includes/levelMenu.html:46
@@ -1690,24 +1367,16 @@ msgstr "Share in Twitter"
 msgid "Outras redes sociais"
 msgstr "Other social networks"
 
-#: build/lib/opac/webapp/templates/article/includes/recent_articles_row.html:6
-#: build/lib/opac/webapp/templates/issue/toc.html:149
 #: opac/webapp/templates/article/includes/recent_articles_row.html:6
 #: opac/webapp/templates/issue/toc.html:149
 msgid "Documento sem título"
 msgstr "Untitled document"
 
-#: build/lib/opac/webapp/templates/article/includes/recent_articles_row.html:13
-#: build/lib/opac/webapp/templates/news/includes/journal_news_row.html:14
 #: opac/webapp/templates/article/includes/recent_articles_row.html:13
 #: opac/webapp/templates/news/includes/journal_news_row.html:14
 msgid "Continue lendo"
 msgstr "Continue reading"
 
-#: build/lib/opac/webapp/templates/article/includes/modal/download.html:6
-#: build/lib/opac/webapp/templates/article/includes/modal/related_article.html:7
-#: build/lib/opac/webapp/templates/email/email_form.html:7
-#: build/lib/opac/webapp/templates/includes/metric_modal.html:6
 #: opac/webapp/templates/article/includes/modal/download.html:6
 #: opac/webapp/templates/article/includes/modal/related_article.html:7
 #: opac/webapp/templates/email/email_form.html:7
@@ -1715,416 +1384,317 @@ msgstr "Continue reading"
 msgid "Fechar"
 msgstr "Close"
 
-#: build/lib/opac/webapp/templates/article/includes/modal/download.html:8
 #: opac/webapp/templates/article/includes/modal/download.html:8
 msgid "Versão para download de PDF"
 msgstr "PDF version for download"
 
-#: build/lib/opac/webapp/templates/article/includes/modal/translate_version.html:6
 #: opac/webapp/templates/article/includes/modal/translate_version.html:6
 msgid "Versões e tradução automática"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/article/includes/modal/translate_version.html:11
 #: opac/webapp/templates/article/includes/modal/translate_version.html:11
 msgid "Versão original do texto"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/about.html:23
-#: build/lib/opac/webapp/templates/collection/pages.html:21
 #: opac/webapp/templates/collection/about.html:23
-#: opac/webapp/templates/collection/pages.html:21
 #, python-format
 msgid " %(page)s "
 msgstr " %(page)s "
 
-#: build/lib/opac/webapp/templates/collection/about.html:38
-#: build/lib/opac/webapp/templates/collection/pages.html:36
 #: opac/webapp/templates/collection/about.html:38
-#: opac/webapp/templates/collection/pages.html:36
 msgid " Conteúdo não cadastrado "
 msgstr "No journal information has been submitted"
 
-#: build/lib/opac/webapp/templates/collection/index.html:17
 #: opac/webapp/templates/collection/index.html:17
 msgid "em números | Métricas"
 msgstr "in numbers | Metrics"
 
-#: build/lib/opac/webapp/templates/collection/index.html:27
 #: opac/webapp/templates/collection/index.html:27
 msgid "períodicos"
 msgstr "journals"
 
-#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:31
-#: build/lib/opac/webapp/templates/collection/index.html:31
-#: build/lib/opac/webapp/templates/collection/list_feed_content.html:7
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:31
 #: opac/webapp/templates/collection/index.html:31
 #: opac/webapp/templates/collection/list_feed_content.html:7
 msgid "números"
 msgstr "issues"
 
-#: build/lib/opac/webapp/templates/collection/index.html:35
-#: build/lib/opac/webapp/templates/issue/grid.html:68
 #: opac/webapp/templates/collection/index.html:35
 #: opac/webapp/templates/issue/grid.html:68
 msgid "artigos"
 msgstr "articles"
 
-#: build/lib/opac/webapp/templates/collection/index.html:39
 #: opac/webapp/templates/collection/index.html:39
 msgid "referências"
 msgstr "references"
 
-#: build/lib/opac/webapp/templates/collection/index.html:45
 #: opac/webapp/templates/collection/index.html:45
 msgid "Downloads"
 msgstr "Downloads"
 
-#: build/lib/opac/webapp/templates/collection/index.html:48
 #: opac/webapp/templates/collection/index.html:48
 msgid "Citações"
 msgstr "Citations"
 
-#: build/lib/opac/webapp/templates/collection/index.html:51
 #: opac/webapp/templates/collection/index.html:51
 msgid "Outros indicadores"
 msgstr "Other indicators"
 
-#: build/lib/opac/webapp/templates/collection/index.html:62
-#: build/lib/opac/webapp/templates/collection/list_journal.html:3
 #: opac/webapp/templates/collection/index.html:62
 #: opac/webapp/templates/collection/list_journal.html:3
 msgid "Lista de periódicos"
 msgstr "Journal list"
 
-#: build/lib/opac/webapp/templates/collection/index.html:66
-#: build/lib/opac/webapp/templates/collection/list_journal.html:21
 #: opac/webapp/templates/collection/index.html:66
 #: opac/webapp/templates/collection/list_journal.html:21
 msgid "Alfabética"
 msgstr "Alphabetic"
 
-#: build/lib/opac/webapp/templates/collection/index.html:69
-#: build/lib/opac/webapp/templates/collection/list_journal.html:24
 #: opac/webapp/templates/collection/index.html:69
 #: opac/webapp/templates/collection/list_journal.html:24
 msgid "Temática"
 msgstr "Thematic"
 
-#: build/lib/opac/webapp/templates/collection/index.html:77
 #: opac/webapp/templates/collection/index.html:77
 msgid "Busca por periódicos"
 msgstr "Search by journals"
 
-#: build/lib/opac/webapp/templates/collection/index.html:105
 #: opac/webapp/templates/collection/index.html:105
 msgid "Números <span>mais recentes</span>"
 msgstr "<span>Latest</span> issues"
 
-#: build/lib/opac/webapp/templates/collection/index.html:149
 #: opac/webapp/templates/collection/index.html:149
 msgid "em perspectiva"
 msgstr "in perspective"
 
-#: build/lib/opac/webapp/templates/collection/list_feed_content.html:1
 #: opac/webapp/templates/collection/list_feed_content.html:1
 msgid "Último número"
 msgstr "Last issue"
 
-#: build/lib/opac/webapp/templates/collection/list_feed_content.html:4
 #: opac/webapp/templates/collection/list_feed_content.html:4
 msgid "Nº"
 msgstr "Nº"
 
-#: build/lib/opac/webapp/templates/collection/list_feed_content.html:6
 #: opac/webapp/templates/collection/list_feed_content.html:6
 msgid "descontinuado"
 msgstr "non-current"
 
-#: build/lib/opac/webapp/templates/collection/list_feed_content.html:7
 #: opac/webapp/templates/collection/list_feed_content.html:7
 msgid "de"
 msgstr "of"
 
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu.html:11
-#: build/lib/opac/webapp/templates/collection/list_journal.html:16
 #: opac/webapp/templates/collection/includes/levelMenu.html:11
 #: opac/webapp/templates/collection/list_journal.html:16
 msgid "Home"
 msgstr "Home"
 
-#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_grouper_table_container.html:14
-#: build/lib/opac/webapp/templates/collection/list_journal.html:52
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_grouper_table_container.html:14
 #: opac/webapp/templates/collection/list_journal.html:52
 msgid "download da lista"
 msgstr "list download"
 
-#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_grouper_table_container.html:15
-#: build/lib/opac/webapp/templates/collection/list_journal.html:53
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_grouper_table_container.html:15
 #: opac/webapp/templates/collection/list_journal.html:53
 msgid "Lista em arquivo para Excel"
 msgstr "List downloaded as an Excel file"
 
-#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_grouper_table_container.html:18
-#: build/lib/opac/webapp/templates/collection/list_journal.html:56
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_grouper_table_container.html:18
 #: opac/webapp/templates/collection/list_journal.html:56
 msgid "Lista em arquivo CSV"
 msgstr "List downloaded as a CSV file"
 
-#: build/lib/opac/webapp/templates/collection/list_journal.html:80
-#: build/lib/opac/webapp/templates/collection/list_journal.html:84
 #: opac/webapp/templates/collection/list_journal.html:80
 #: opac/webapp/templates/collection/list_journal.html:84
 msgid "Grandes áreas do conhecimento"
 msgstr "Major areas of knowledge"
 
-#: build/lib/opac/webapp/templates/collection/list_journal.html:85
 #: opac/webapp/templates/collection/list_journal.html:85
 msgid "Áreas temáticas do Web of Science"
 msgstr "Web of Science Thematic Areas"
 
-#: build/lib/opac/webapp/templates/collection/list_journal.html:222
 #: opac/webapp/templates/collection/list_journal.html:222
 msgid "grandes áreas"
 msgstr "broad areas"
 
-#: build/lib/opac/webapp/templates/collection/list_journal.html:236
 #: opac/webapp/templates/collection/list_journal.html:236
 msgid "áreas WOS"
 msgstr "WOS subject areas"
 
-#: build/lib/opac/webapp/templates/collection/list_journal.html:248
 #: opac/webapp/templates/collection/list_journal.html:248
 msgid "Editoras"
 msgstr "Publishers"
 
-#: build/lib/opac/webapp/templates/collection/list_journal.html:249
 #: opac/webapp/templates/collection/list_journal.html:249
 msgid "editoras"
 msgstr "publishers"
 
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:7
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:7
 msgid "Sobre o"
 msgstr "About"
 
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:19
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:62
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:19
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:62
 msgid "Entre uma ou mais palavras"
 msgstr "Enter one or more words"
 
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:24
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:67
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:24
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:67
 msgid "Todos os índices"
 msgstr "All indexes"
 
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:26
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:69
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:26
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:69
 msgid "Autor"
 msgstr "Author"
 
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:38
-#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:95
-#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:91
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:38
 #: opac/webapp/templates/issue/includes/alternative_header.html:95
 #: opac/webapp/templates/journal/includes/alternative_header.html:91
 msgid "Buscar"
 msgstr "Search"
 
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:44
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:44
 msgid "Adicionar outro campo"
 msgstr "Add another field"
 
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:49
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:49
 msgid "Apagar campo"
 msgstr "Delete field"
 
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:63
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:63
 msgid "Limpar expressão"
 msgstr "Reset"
 
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:92
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:92
 msgid "Sem resultados"
 msgstr "No results"
 
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:96
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:96
 msgid "Não foram encontrados documentos para sua pesquisa"
 msgstr "No documents found which meet your search criteria"
 
-#: build/lib/opac/webapp/templates/collection/includes/list_journals_search_input.html:5
 #: opac/webapp/templates/collection/includes/list_journals_search_input.html:5
 msgid "Todos"
 msgstr "All"
 
-#: build/lib/opac/webapp/templates/collection/includes/list_journals_search_input.html:9
 #: opac/webapp/templates/collection/includes/list_journals_search_input.html:9
 msgid "Periódicos ativos"
 msgstr "Current journals"
 
-#: build/lib/opac/webapp/templates/collection/includes/list_journals_search_input.html:13
 #: opac/webapp/templates/collection/includes/list_journals_search_input.html:13
 msgid "Periódicos descontinuados"
 msgstr "Non-current journals"
 
-#: build/lib/opac/webapp/templates/collection/includes/list_journals_search_input.html:24
 #: opac/webapp/templates/collection/includes/list_journals_search_input.html:24
 msgid "Digite uma ou mais palavras para filtrar a lista"
 msgstr "Enter one or more words to filter the list"
 
-#: build/lib/opac/webapp/templates/collection/includes/nav.html:22
-#: build/lib/opac/webapp/templates/collection/includes/nav.html:64
 #: opac/webapp/templates/collection/includes/nav.html:22
 #: opac/webapp/templates/collection/includes/nav.html:64
 msgid "Busca"
 msgstr "Search"
 
-#: build/lib/opac/webapp/templates/collection/includes/nav.html:32
 #: opac/webapp/templates/collection/includes/nav.html:32
 msgid "Sobre:"
 msgstr "About:"
 
-#: build/lib/opac/webapp/templates/collection/includes/nav.html:44
 #: opac/webapp/templates/collection/includes/nav.html:44
 msgid "SciELO.org - Rede SciELO"
 msgstr "SciELO.org - The SciELO Network"
 
-#: build/lib/opac/webapp/templates/collection/includes/nav.html:95
 #: opac/webapp/templates/collection/includes/nav.html:95
 msgid "Blog SciELO em Perspectiva"
 msgstr "Blog SciELO in Perspective"
 
-#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_empty.html:3
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_empty.html:3
 msgid "Nenhum periódico encontrado."
 msgstr "No journals found."
 
-#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_error.html:3
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_error.html:3
 msgid "Ocorreu um erro obtendo a lista de periódicos."
 msgstr "An error occurred in getting the list of journals."
 
-#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_grouper_table_container.html:10
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_grouper_table_container.html:10
 msgid "periódicos"
 msgstr "journals"
 
-#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:3
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:3
 msgid "Homepage"
 msgstr "Home page"
 
-#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:25
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:25
 msgid "Título do periódico"
 msgstr "Journal title"
 
-#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:29
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:29
 msgid "Grade de número"
 msgstr "Issue grid"
 
-#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:36
-#: build/lib/opac/webapp/templates/journal/detail.html:89
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:36
 #: opac/webapp/templates/journal/detail.html:89
 msgid "Número mais recente"
 msgstr "Most recent issue"
 
-#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:37
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:37
 msgid "Último"
 msgstr "Latest"
 
-#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:45
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:45
 msgid "Continua como "
 msgstr "Continues as"
 
-#: build/lib/opac/webapp/templates/email/email_form.html:10
 #: opac/webapp/templates/email/email_form.html:10
 msgid "Enviar página por e-mail"
 msgstr "Send page by e-mail "
 
-#: build/lib/opac/webapp/templates/email/email_form.html:18
-#: build/lib/opac/webapp/templates/includes/error_form.html:26
-#: build/lib/opac/webapp/templates/journal/includes/contact_form.html:20
 #: opac/webapp/templates/email/email_form.html:18
 #: opac/webapp/templates/includes/error_form.html:26
 #: opac/webapp/templates/journal/includes/contact_form.html:20
 msgid "Seu e-mail"
 msgstr "Your e-mail"
 
-#: build/lib/opac/webapp/templates/email/email_form.html:23
 #: opac/webapp/templates/email/email_form.html:23
 msgid "Para"
 msgstr "For"
 
-#: build/lib/opac/webapp/templates/email/email_form.html:27
 #: opac/webapp/templates/email/email_form.html:27
 msgid "Utilize ; (ponto e vírgula) para inserir mais emails."
 msgstr "Use ; (point and comma)  for insert more emails"
 
-#: build/lib/opac/webapp/templates/email/email_form.html:36
 #: opac/webapp/templates/email/email_form.html:36
 msgid "Alterar assunto e comentários"
 msgstr "Change subject e comments"
 
-#: build/lib/opac/webapp/templates/email/email_form.html:41
 #: opac/webapp/templates/email/email_form.html:41
 msgid "Assunto"
 msgstr "Subject"
 
-#: build/lib/opac/webapp/templates/email/email_form.html:45
 #: opac/webapp/templates/email/email_form.html:45
 msgid "Comentário"
 msgstr "Comments"
 
-#: build/lib/opac/webapp/templates/email/email_form.html:49
 #: opac/webapp/templates/email/email_form.html:49
 msgid "Remover remetente, assunto e comentários"
 msgstr "Remove sender, subject and comments"
 
-#: build/lib/opac/webapp/templates/email/email_form.html:75
 #: opac/webapp/templates/email/email_form.html:75
 msgid "Email enviado com sucesso."
 msgstr "Email sent with success."
 
-#: build/lib/opac/webapp/templates/email/email_form.html:76
-#: build/lib/opac/webapp/templates/includes/error_form.html:86
-#: build/lib/opac/webapp/templates/journal/includes/contact_form.html:77
 #: opac/webapp/templates/email/email_form.html:76
 #: opac/webapp/templates/includes/error_form.html:86
 #: opac/webapp/templates/journal/includes/contact_form.html:77
 msgid "Erro ao tentar enviar e-mail, por favor tente mais tarde."
 msgstr "Error trying send e-mail, please, try again later."
 
-#: build/lib/opac/webapp/templates/errors/400.html:7
 #: opac/webapp/templates/errors/400.html:7
 msgid "Ação inválida"
 msgstr "Invalid action"
 
-#: build/lib/opac/webapp/templates/errors/403.html:7
 #: opac/webapp/templates/errors/403.html:7
 msgid "Acesso não autorizado!"
 msgstr "Access not authorized"
 
-#: build/lib/opac/webapp/templates/errors/404.html:7
 #: opac/webapp/templates/errors/404.html:7
 msgid ""
 "A URL solicitada não foi encontrada no servidor. Se você digitou a URL "
@@ -2133,7 +1703,6 @@ msgstr ""
 "The requested URL was not found on the server. If you typed in the URL, "
 "please check it and try again."
 
-#: build/lib/opac/webapp/templates/errors/500.html:5
 #: opac/webapp/templates/errors/500.html:5
 msgid ""
 "Erro interno do servidor. Tente novamente mais tarde. Nossos engenheiros "
@@ -2142,370 +1711,304 @@ msgstr ""
 "Internal server error. Please try again later. Our technical staff has "
 "been notified."
 
-#: build/lib/opac/webapp/templates/errors/500.html:9
 #: opac/webapp/templates/errors/500.html:9
 msgid "Id. do erro"
 msgstr "Error id."
 
-#: build/lib/opac/webapp/templates/errors/base.html:24
 #: opac/webapp/templates/errors/base.html:24
 msgid "Erro"
 msgstr "Error"
 
-#: build/lib/opac/webapp/templates/errors/base.html:27
 #: opac/webapp/templates/errors/base.html:27
 msgid "Qualquer dúvida, por favor entre em contato com o administrador"
 msgstr ""
 "Please contact the administrator if you have any questions, doubts or "
 "concerns"
 
-#: build/lib/opac/webapp/templates/includes/error_form.html:5
 #: opac/webapp/templates/includes/error_form.html:5
 msgid " Reportar erro "
 msgstr ""
 
-#: build/lib/opac/webapp/templates/includes/error_form.html:20
-#: build/lib/opac/webapp/templates/journal/includes/contact_form.html:14
 #: opac/webapp/templates/includes/error_form.html:20
 #: opac/webapp/templates/journal/includes/contact_form.html:14
 msgid "Seu Nome"
 msgstr "Your Name"
 
-#: build/lib/opac/webapp/templates/includes/error_form.html:21
 #: opac/webapp/templates/includes/error_form.html:21
 msgid "Digite seu Nome"
 msgstr "Type your Name"
 
-#: build/lib/opac/webapp/templates/includes/error_form.html:32
 #: opac/webapp/templates/includes/error_form.html:32
 msgid "Erro referente"
 msgstr "Referring error"
 
-#: build/lib/opac/webapp/templates/includes/error_form.html:35
 #: opac/webapp/templates/includes/error_form.html:35
 msgid "ao conteúdo"
 msgstr "to content"
 
-#: build/lib/opac/webapp/templates/includes/error_form.html:39
 #: opac/webapp/templates/includes/error_form.html:39
 msgid "à aplicação"
 msgstr "the app"
 
-#: build/lib/opac/webapp/templates/includes/error_form.html:46
 #: opac/webapp/templates/includes/error_form.html:46
 msgid "Descrição do erro"
 msgstr "Erro description"
 
-#: build/lib/opac/webapp/templates/includes/error_form.html:47
 #: opac/webapp/templates/includes/error_form.html:47
 msgid "Digite sua mensagem"
 msgstr "Enter your message"
 
-#: build/lib/opac/webapp/templates/includes/error_form.html:49
 #: opac/webapp/templates/includes/error_form.html:49
 msgid "Obs.: Link e título da página são enviados automaticamente"
 msgstr "Note: Link and page title are sent automatically"
 
-#: build/lib/opac/webapp/templates/includes/error_form.html:85
 #: opac/webapp/templates/includes/error_form.html:85
 msgid "Email de erro enviado com sucesso."
 msgstr "Error email sent successfully."
 
-#: build/lib/opac/webapp/templates/includes/footer.html:36
 #: opac/webapp/templates/includes/footer.html:36
 msgid "Open Access"
 msgstr "Open Access"
 
-#: build/lib/opac/webapp/templates/includes/footer.html:38
 #: opac/webapp/templates/includes/footer.html:38
 msgid "Leia"
 msgstr "Read"
 
-#: build/lib/opac/webapp/templates/includes/footer.html:38
 #: opac/webapp/templates/includes/footer.html:38
 msgid "a Declaração de Acesso Aberto"
 msgstr "our Open Access Statement"
 
-#: build/lib/opac/webapp/templates/issue/grid.html:4
 #: opac/webapp/templates/issue/grid.html:4
 msgid "Fascículos"
 msgstr "Issues"
 
-#: build/lib/opac/webapp/templates/issue/grid.html:33
 #: opac/webapp/templates/issue/grid.html:33
 msgid "Todos os números"
 msgstr "All issues"
 
-#: build/lib/opac/webapp/templates/issue/grid.html:79
 #: opac/webapp/templates/issue/grid.html:79
 msgid "supl."
 msgstr "suppl."
 
-#: build/lib/opac/webapp/templates/issue/grid.html:98
 #: opac/webapp/templates/issue/grid.html:98
 msgid "Nenhum número encontrado para esse periódico"
 msgstr "No Issue was found for this Journal"
 
-#: build/lib/opac/webapp/templates/issue/grid.html:101
 #: opac/webapp/templates/issue/grid.html:101
 msgid "Histórico deste periódico na coleção"
 msgstr "History of the journal in the collection"
 
-#: build/lib/opac/webapp/templates/issue/grid.html:105
 #: opac/webapp/templates/issue/grid.html:105
 msgid " admitido na coleção da SciELO"
 msgstr "admitted to the SciELO collection"
 
-#: build/lib/opac/webapp/templates/issue/toc.html:10
-#: build/lib/opac/webapp/templates/journal/detail.html:8
 #: opac/webapp/templates/issue/toc.html:10
 #: opac/webapp/templates/journal/detail.html:8
 msgid "Imprimir"
 msgstr "Print"
 
-#: build/lib/opac/webapp/templates/issue/toc.html:41
 #: opac/webapp/templates/issue/toc.html:41
 msgid "Editor científico"
 msgstr "Scientific editor"
 
-#: build/lib/opac/webapp/templates/issue/toc.html:45
 #: opac/webapp/templates/issue/toc.html:45
 msgid "Editores associados"
 msgstr "Associate editors"
 
-#: build/lib/opac/webapp/templates/issue/toc.html:52
 #: opac/webapp/templates/issue/toc.html:52
 msgid "Veja toda a equipe editorial"
 msgstr "View the editorial team"
 
-#: build/lib/opac/webapp/templates/issue/toc.html:63
 #: opac/webapp/templates/issue/toc.html:63
 msgid "Expandir/recolher conteúdo"
 msgstr "Expand/collapse content"
 
-#: build/lib/opac/webapp/templates/issue/toc.html:72
-#: build/lib/opac/webapp/templates/journal/detail.html:96
 #: opac/webapp/templates/issue/toc.html:72
 #: opac/webapp/templates/journal/detail.html:96
 msgid "Sumário"
 msgstr "Summary"
 
-#: build/lib/opac/webapp/templates/issue/toc.html:79
 #: opac/webapp/templates/issue/toc.html:79
 msgid "Ordenar publicações por"
 msgstr "Sort publications by"
 
-#: build/lib/opac/webapp/templates/issue/toc.html:82
 #: opac/webapp/templates/issue/toc.html:82
 msgid "Ordem do fascículo"
 msgstr "Order issues by"
 
-#: build/lib/opac/webapp/templates/issue/toc.html:83
 #: opac/webapp/templates/issue/toc.html:83
 msgid "Mais novos primeiro"
 msgstr "Newest first"
 
-#: build/lib/opac/webapp/templates/issue/toc.html:84
 #: opac/webapp/templates/issue/toc.html:84
 msgid "Mais antigos primeiro"
 msgstr "Oldest first"
 
-#: build/lib/opac/webapp/templates/issue/toc.html:102
-#: build/lib/opac/webapp/templates/issue/toc.html:104
 #: opac/webapp/templates/issue/toc.html:102
 #: opac/webapp/templates/issue/toc.html:104
 msgid "Todas as seções"
 msgstr "All the sections"
 
-#: build/lib/opac/webapp/templates/issue/toc.html:187
-#: opac/webapp/templates/issue/toc.html:187
+#: opac/webapp/templates/issue/toc.html:182
 msgid "Texto"
 msgstr "Text"
 
-#: build/lib/opac/webapp/templates/issue/toc.html:214
-#: opac/webapp/templates/issue/toc.html:214
+#: opac/webapp/templates/issue/toc.html:195
+msgid "PDF"
+msgstr ""
+
+#: opac/webapp/templates/issue/toc.html:210
+msgid "ePDF"
+msgstr ""
+
+#: opac/webapp/templates/issue/toc.html:232
 msgid "Resumo em"
 msgstr "Abstract in"
 
-#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:31
-#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:31
 #: opac/webapp/templates/issue/includes/alternative_header.html:31
 #: opac/webapp/templates/journal/includes/alternative_header.html:31
 msgid "Número atual"
 msgstr "Current issue"
 
-#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:51
-#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:47
 #: opac/webapp/templates/issue/includes/alternative_header.html:51
 #: opac/webapp/templates/journal/includes/alternative_header.html:47
 msgid "Homepage do periódico"
 msgstr "Journal home page"
 
-#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:62
-#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:58
 #: opac/webapp/templates/issue/includes/alternative_header.html:62
 #: opac/webapp/templates/journal/includes/alternative_header.html:58
 msgid "Números"
 msgstr "Issues"
 
-#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:68
-#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:64
-#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:90
 #: opac/webapp/templates/issue/includes/alternative_header.html:68
 #: opac/webapp/templates/journal/includes/alternative_header.html:64
 #: opac/webapp/templates/journal/includes/levelMenu.html:90
 msgid "todos"
 msgstr "all"
 
-#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:89
-#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:85
 #: opac/webapp/templates/issue/includes/alternative_header.html:89
 #: opac/webapp/templates/journal/includes/alternative_header.html:85
 msgid "próximo"
 msgstr "next"
 
-#: build/lib/opac/webapp/templates/journal/about.html:39
 #: opac/webapp/templates/journal/about.html:39
 msgid "Conteúdo não cadastrado"
 msgstr "Content not submitted"
 
-#: build/lib/opac/webapp/templates/journal/about.html:55
-#: build/lib/opac/webapp/templates/journal/includes/contact_footer.html:48
 #: opac/webapp/templates/journal/about.html:55
 #: opac/webapp/templates/journal/includes/contact_footer.html:48
 msgid "Siga este periódico nas redes sociais"
 msgstr "Follow this journal in the social networks"
 
-#: build/lib/opac/webapp/templates/journal/detail.html:32
+#: opac/webapp/templates/journal/detail.html:9
+#: opac/webapp/templates/journal/includes/contact_footer.html:53
+msgid "RSS do número mais recente do periódico"
+msgstr "RSS of this journal's latest issue"
+
 #: opac/webapp/templates/journal/detail.html:32
 msgid "Nossa Missão"
 msgstr "Our Mission"
 
-#: build/lib/opac/webapp/templates/journal/detail.html:34
 #: opac/webapp/templates/journal/detail.html:34
 msgid "Periódico sem missão cadastrada"
 msgstr "Journal without mission"
 
-#: build/lib/opac/webapp/templates/journal/detail.html:42
 #: opac/webapp/templates/journal/detail.html:42
 msgid "Métricas deste periódico"
 msgstr "Metrics for this journal"
 
-#: build/lib/opac/webapp/templates/journal/detail.html:52
 #: opac/webapp/templates/journal/detail.html:52
 msgid "Índice h5"
 msgstr "h5 index"
 
-#: build/lib/opac/webapp/templates/journal/detail.html:54
-#: build/lib/opac/webapp/templates/journal/detail.html:66
 #: opac/webapp/templates/journal/detail.html:54
 #: opac/webapp/templates/journal/detail.html:66
 msgid "ano"
 msgstr "year"
 
-#: build/lib/opac/webapp/templates/journal/detail.html:58
-#: build/lib/opac/webapp/templates/journal/detail.html:70
 #: opac/webapp/templates/journal/detail.html:58
 #: opac/webapp/templates/journal/detail.html:70
 msgid "Não possui"
 msgstr "Does not have"
 
-#: build/lib/opac/webapp/templates/journal/detail.html:63
 #: opac/webapp/templates/journal/detail.html:63
 msgid "Mediana h5"
 msgstr "Median h5"
 
-#: build/lib/opac/webapp/templates/journal/detail.html:86
 #: opac/webapp/templates/journal/detail.html:86
 msgid "Capa do número mais recente"
 msgstr "Cover of most recent issue"
 
-#: build/lib/opac/webapp/templates/journal/detail.html:138
-#: opac/webapp/templates/journal/detail.html:138
+#: opac/webapp/templates/journal/detail.html:117
+#: opac/webapp/templates/journal/detail.html:119
+msgid "RSS dos Press Releases mais recentes desse periódico"
+msgstr "RSS of this journal's latests Press Releases"
+
+#: opac/webapp/templates/journal/detail.html:145
 msgid "Artigos mais recentes"
 msgstr "Latest articles"
 
-#: build/lib/opac/webapp/templates/journal/includes/contact_footer.html:57
 #: opac/webapp/templates/journal/includes/contact_footer.html:57
 msgid "Acompanhe os números deste periódico no seu leitor de RSS"
 msgstr "Stay informed of issues for this journal through your RSS reader"
 
-#: build/lib/opac/webapp/templates/journal/includes/contact_form.html:26
 #: opac/webapp/templates/journal/includes/contact_form.html:26
 msgid "Mensagem"
 msgstr "Message"
 
-#: build/lib/opac/webapp/templates/journal/includes/contact_form.html:76
 #: opac/webapp/templates/journal/includes/contact_form.html:76
 msgid "Email enviado para "
 msgstr "Email sent to "
 
-#: build/lib/opac/webapp/templates/journal/includes/contact_form.html:76
 #: opac/webapp/templates/journal/includes/contact_form.html:76
 msgid "com sucesso."
 msgstr "successfully."
 
-#: build/lib/opac/webapp/templates/journal/includes/header.html:42
 #: opac/webapp/templates/journal/includes/header.html:42
 msgid "Publicação de:"
 msgstr "Publication of:"
 
-#: build/lib/opac/webapp/templates/journal/includes/header.html:47
 #: opac/webapp/templates/journal/includes/header.html:47
 msgid "Área:"
 msgstr "Area:"
 
-#: build/lib/opac/webapp/templates/journal/includes/header.html:51
 #: opac/webapp/templates/journal/includes/header.html:51
 msgid "Multidisciplinar"
 msgstr "Multidisciplinary"
 
-#: build/lib/opac/webapp/templates/journal/includes/header.html:60
 #: opac/webapp/templates/journal/includes/header.html:60
 msgid "Versão impressa ISSN:"
 msgstr "ISSN printed version:"
 
-#: build/lib/opac/webapp/templates/journal/includes/header.html:67
 #: opac/webapp/templates/journal/includes/header.html:67
 msgid "Versão on-line ISSN:"
 msgstr "ISSN online version:"
 
-#: build/lib/opac/webapp/templates/journal/includes/header.html:76
 #: opac/webapp/templates/journal/includes/header.html:76
 msgid "Novo título:"
 msgstr "New title:"
 
-#: build/lib/opac/webapp/templates/journal/includes/header.html:93
 #: opac/webapp/templates/journal/includes/header.html:93
 msgid "Título anterior:"
 msgstr "Previous title"
 
-#: build/lib/opac/webapp/templates/journal/includes/header.html:148
 #: opac/webapp/templates/journal/includes/header.html:148
 msgid "Siga-nos"
 msgstr "Follow us"
 
-#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:10
 #: opac/webapp/templates/journal/includes/levelMenu.html:10
 msgid "home do periódico"
 msgstr "Journal homepage"
 
-#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:19
 #: opac/webapp/templates/journal/includes/levelMenu.html:19
 msgid "todos os números"
 msgstr "all issues"
 
-#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:25
-#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:29
 #: opac/webapp/templates/journal/includes/levelMenu.html:25
 #: opac/webapp/templates/journal/includes/levelMenu.html:29
 msgid "número anterior"
 msgstr "previous issue"
 
-#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:36
-#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:40
-#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:107
-#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:111
 #: opac/webapp/templates/journal/includes/levelMenu.html:36
 #: opac/webapp/templates/journal/includes/levelMenu.html:40
 #: opac/webapp/templates/journal/includes/levelMenu.html:107
@@ -2513,24 +2016,16 @@ msgstr "previous issue"
 msgid "número atual"
 msgstr "current issue"
 
-#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:47
-#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:51
 #: opac/webapp/templates/journal/includes/levelMenu.html:47
 #: opac/webapp/templates/journal/includes/levelMenu.html:51
 msgid "número seguinte"
 msgstr "next issue"
 
-#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:59
-#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:130
 #: opac/webapp/templates/journal/includes/levelMenu.html:59
 #: opac/webapp/templates/journal/includes/levelMenu.html:130
 msgid "buscar"
 msgstr "search"
 
-#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:65
-#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:69
-#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:136
-#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:140
 #: opac/webapp/templates/journal/includes/levelMenu.html:65
 #: opac/webapp/templates/journal/includes/levelMenu.html:69
 #: opac/webapp/templates/journal/includes/levelMenu.html:136
@@ -2538,27 +2033,22 @@ msgstr "search"
 msgid "métricas"
 msgstr "metrics"
 
-#: build/lib/opac/webapp/templates/macros/issue.html:5
 #: opac/webapp/templates/macros/issue.html:5
 msgid " número especial "
 msgstr " special issue "
 
-#: build/lib/opac/webapp/templates/macros/issue.html:10
 #: opac/webapp/templates/macros/issue.html:10
 msgid "número especial"
 msgstr "special issue"
 
-#: build/lib/opac/webapp/templates/news/includes/collection_news_row.html:16
 #: opac/webapp/templates/news/includes/collection_news_row.html:16
 msgid "continue lendo"
 msgstr "continue reading"
 
-#: build/lib/opac/webapp/templates/news/includes/issue_last_row.html:15
 #: opac/webapp/templates/news/includes/issue_last_row.html:15
 msgid "Suplemento"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/news/includes/issue_last_row.html:20
 #: opac/webapp/templates/news/includes/issue_last_row.html:20
 msgid "Ver"
 msgstr "Open"

--- a/opac/webapp/translations/es/LC_MESSAGES/messages.po
+++ b/opac/webapp/translations/es/LC_MESSAGES/messages.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version:  OPAC\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-05-09 17:02-0300\n"
+"POT-Creation-Date: 2019-05-31 21:18+0000\n"
 "PO-Revision-Date: 2018-03-07 00:47+0000\n"
 "Last-Translator: jamil Atta <atta.jamil@gmail.com>\n"
 "Language: es\n"
@@ -24,30 +24,13 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.6.0\n"
 
-#: build/lib/opac/tests/test_admin_custom_filters.py:100
-#: build/lib/opac/tests/test_admin_custom_filters.py:114
-#: build/lib/opac/tests/test_admin_custom_filters.py:129
-#: build/lib/opac/tests/test_admin_custom_filters.py:144
-#: build/lib/opac/tests/test_admin_custom_filters.py:158
-#: build/lib/opac/webapp/__init__.py:119
-#: build/lib/opac/webapp/admin/views.py:533
-#: build/lib/opac/webapp/admin/views.py:610
-#: build/lib/opac/webapp/admin/views.py:680
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:28
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:71
-#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_grouper_table_row.html:15
-#: build/lib/opac/webapp/templates/collection/list_journal.html:49
-#: build/lib/opac/webapp/templates/collection/list_journal.html:221
-#: build/lib/opac/webapp/templates/collection/list_journal.html:235
-#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:116
-#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:112
 #: opac/tests/test_admin_custom_filters.py:100
 #: opac/tests/test_admin_custom_filters.py:114
 #: opac/tests/test_admin_custom_filters.py:129
 #: opac/tests/test_admin_custom_filters.py:144
 #: opac/tests/test_admin_custom_filters.py:158 opac/webapp/__init__.py:119
-#: opac/webapp/admin/views.py:533 opac/webapp/admin/views.py:610
-#: opac/webapp/admin/views.py:680
+#: opac/webapp/admin/views.py:534 opac/webapp/admin/views.py:611
+#: opac/webapp/admin/views.py:681
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:28
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:71
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_grouper_table_row.html:15
@@ -59,38 +42,21 @@ msgstr ""
 msgid "Periódico"
 msgstr "Revista"
 
-#: build/lib/opac/tests/test_interface_menu.py:51
 #: opac/tests/test_interface_menu.py:51
 msgid "NOME DA COLEÇÃO!!"
 msgstr "NOMBRE DE LA COLECCIÓN!!"
 
-#: build/lib/opac/tests/test_interface_menu.py:53
-#: build/lib/opac/tests/test_interface_menu.py:75
-#: build/lib/opac/webapp/templates/collection/includes/nav.html:12
-#: build/lib/opac/webapp/templates/collection/includes/nav.html:54
 #: opac/tests/test_interface_menu.py:53 opac/tests/test_interface_menu.py:75
 #: opac/webapp/templates/collection/includes/nav.html:12
 #: opac/webapp/templates/collection/includes/nav.html:54
 msgid "Lista alfabética de periódicos"
 msgstr "Lista alfabética de revistas"
 
-#: build/lib/opac/tests/test_interface_menu.py:55
-#: build/lib/opac/webapp/templates/collection/includes/nav.html:17
 #: opac/tests/test_interface_menu.py:55
 #: opac/webapp/templates/collection/includes/nav.html:17
 msgid "Lista temática de periódicos"
 msgstr "Lista temática de revistas"
 
-#: build/lib/opac/tests/test_interface_menu.py:61
-#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:11
-#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:70
-#: build/lib/opac/webapp/templates/collection/includes/nav.html:27
-#: build/lib/opac/webapp/templates/collection/includes/nav.html:69
-#: build/lib/opac/webapp/templates/includes/metric_modal.html:7
-#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:101
-#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:105
-#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:97
-#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:101
 #: opac/tests/test_interface_menu.py:61
 #: opac/webapp/templates/article/includes/floating_menu.html:11
 #: opac/webapp/templates/article/includes/floating_menu.html:70
@@ -104,383 +70,332 @@ msgstr "Lista temática de revistas"
 msgid "Métricas"
 msgstr "Métricas"
 
-#: build/lib/opac/tests/test_interface_menu.py:63
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu.html:12
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu.html:29
 #: opac/tests/test_interface_menu.py:63
 #: opac/webapp/templates/collection/includes/levelMenu.html:12
 #: opac/webapp/templates/collection/includes/levelMenu.html:29
 msgid "Sobre o SciELO"
 msgstr "Acerca de SciELO"
 
-#: build/lib/opac/tests/test_interface_menu.py:65
-#: build/lib/opac/tests/test_interface_menu.py:99
-#: build/lib/opac/webapp/templates/collection/includes/nav.html:37
-#: build/lib/opac/webapp/templates/collection/includes/nav.html:84
 #: opac/tests/test_interface_menu.py:65 opac/tests/test_interface_menu.py:99
 #: opac/webapp/templates/collection/includes/nav.html:37
 #: opac/webapp/templates/collection/includes/nav.html:84
 msgid "Contatos"
 msgstr "Contactos"
 
-#: build/lib/opac/tests/test_interface_menu.py:67
 #: opac/tests/test_interface_menu.py:67
 msgid "Rede SciELO"
 msgstr "Red SciELO"
 
-#: build/lib/opac/tests/test_interface_menu.py:71
-#: build/lib/opac/webapp/templates/collection/includes/nav.html:49
 #: opac/tests/test_interface_menu.py:71
 #: opac/webapp/templates/collection/includes/nav.html:49
 msgid "Coleções nacionais e temáticas"
 msgstr "Colecciones nacionales y temáticas"
 
-#: build/lib/opac/tests/test_interface_menu.py:79
-#: build/lib/opac/webapp/templates/collection/includes/nav.html:59
 #: opac/tests/test_interface_menu.py:79
 #: opac/webapp/templates/collection/includes/nav.html:59
 msgid "Lista de periódicos por assunto"
 msgstr "Lista de revistas por asunto"
 
-#: build/lib/opac/tests/test_interface_menu.py:91
-#: build/lib/opac/webapp/templates/collection/includes/nav.html:74
 #: opac/tests/test_interface_menu.py:91
 #: opac/webapp/templates/collection/includes/nav.html:74
 msgid "Acesso OAI e RSS"
 msgstr "Acceso OAI y RSS"
 
-#: build/lib/opac/tests/test_interface_menu.py:95
-#: build/lib/opac/webapp/templates/collection/includes/nav.html:79
 #: opac/tests/test_interface_menu.py:95
 #: opac/webapp/templates/collection/includes/nav.html:79
 msgid "Sobre a Rede SciELO"
 msgstr "Acerca de la Red SciELO"
 
-#: build/lib/opac/tests/test_main_errors.py:8 opac/tests/test_main_errors.py:8
+#: opac/tests/test_main_errors.py:8
 msgid "Mensagem de erro explicativo para o usuário"
 msgstr "Mensaje de error explicativo para el usuario"
 
-#: build/lib/opac/webapp/__init__.py:118 build/lib/opac/webapp/__init__.py:119
-#: build/lib/opac/webapp/__init__.py:120 build/lib/opac/webapp/__init__.py:121
-#: build/lib/opac/webapp/__init__.py:122 build/lib/opac/webapp/__init__.py:123
 #: opac/webapp/__init__.py:118 opac/webapp/__init__.py:119
 #: opac/webapp/__init__.py:120 opac/webapp/__init__.py:121
 #: opac/webapp/__init__.py:122 opac/webapp/__init__.py:123
 msgid "Catálogo"
 msgstr "Catálogo"
 
-#: build/lib/opac/webapp/__init__.py:118
-#: build/lib/opac/webapp/admin/views.py:452 opac/webapp/__init__.py:118
-#: opac/webapp/admin/views.py:452
+#: opac/webapp/__init__.py:118 opac/webapp/admin/views.py:453
 msgid "Coleção"
 msgstr "Colección"
 
-#: build/lib/opac/webapp/__init__.py:120
-#: build/lib/opac/webapp/admin/views.py:537
-#: build/lib/opac/webapp/admin/views.py:609
-#: build/lib/opac/webapp/templates/issue/grid.html:41
-#: build/lib/opac/webapp/templates/news/includes/issue_last_row.html:11
-#: opac/webapp/__init__.py:120 opac/webapp/admin/views.py:537
-#: opac/webapp/admin/views.py:609 opac/webapp/templates/issue/grid.html:41
+#: opac/webapp/__init__.py:120 opac/webapp/admin/views.py:538
+#: opac/webapp/admin/views.py:610 opac/webapp/templates/issue/grid.html:41
 #: opac/webapp/templates/news/includes/issue_last_row.html:11
 msgid "Número"
 msgstr "Número"
 
-#: build/lib/opac/webapp/__init__.py:121 opac/webapp/__init__.py:121
+#: opac/webapp/__init__.py:121
 msgid "Artigo"
 msgstr "Artículo"
 
-#: build/lib/opac/webapp/__init__.py:122
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:27
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:70
 #: opac/webapp/__init__.py:122
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:27
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:70
 msgid "Financiador"
 msgstr "Financiador"
 
-#: build/lib/opac/webapp/__init__.py:123 opac/webapp/__init__.py:123
+#: opac/webapp/__init__.py:123
 msgid "Press Release"
 msgstr "Comunicado de prensa"
 
-#: build/lib/opac/webapp/__init__.py:124
-#: build/lib/opac/webapp/templates/journal/detail.html:160
-#: opac/webapp/__init__.py:124 opac/webapp/templates/journal/detail.html:160
+#: opac/webapp/__init__.py:124 opac/webapp/templates/journal/detail.html:167
 msgid "Notícias"
 msgstr "Noticias"
 
-#: build/lib/opac/webapp/__init__.py:125 build/lib/opac/webapp/__init__.py:126
 #: opac/webapp/__init__.py:125 opac/webapp/__init__.py:126
 msgid "Ativos"
 msgstr "Activos"
 
-#: build/lib/opac/webapp/__init__.py:127 opac/webapp/__init__.py:127
+#: opac/webapp/__init__.py:127
 msgid "Páginas"
 msgstr "Páginas"
 
-#: build/lib/opac/webapp/__init__.py:128 build/lib/opac/webapp/__init__.py:129
 #: opac/webapp/__init__.py:128 opac/webapp/__init__.py:129
 msgid "Gestão"
 msgstr "Gestión"
 
-#: build/lib/opac/webapp/__init__.py:128 opac/webapp/__init__.py:128
+#: opac/webapp/__init__.py:128
 msgid "Auditoria: Páginas"
 msgstr ""
 
-#: build/lib/opac/webapp/__init__.py:129
-#: build/lib/opac/webapp/admin/views.py:896 opac/webapp/__init__.py:129
-#: opac/webapp/admin/views.py:896
+#: opac/webapp/__init__.py:129 opac/webapp/admin/views.py:897
 msgid "Usuário"
 msgstr "Usuario"
 
-#: build/lib/opac/webapp/choices.py:7 opac/webapp/choices.py:7
+#: opac/webapp/choices.py:7
 msgid "Conteúdo temporariamente indisponível"
 msgstr "Contenido indisponible temporalmente"
 
-#: build/lib/opac/webapp/choices.py:11 build/lib/opac/webapp/choices.py:23
-#: build/lib/opac/webapp/templates/article/includes/modal/download.html:26
 #: opac/webapp/choices.py:11 opac/webapp/choices.py:23
 #: opac/webapp/templates/article/includes/modal/download.html:26
 msgid "Português"
 msgstr "Portugués"
 
-#: build/lib/opac/webapp/choices.py:12 build/lib/opac/webapp/choices.py:24
-#: build/lib/opac/webapp/templates/article/includes/modal/download.html:24
 #: opac/webapp/choices.py:12 opac/webapp/choices.py:24
 #: opac/webapp/templates/article/includes/modal/download.html:24
 msgid "Inglês"
 msgstr "Inglés"
 
-#: build/lib/opac/webapp/choices.py:13 build/lib/opac/webapp/choices.py:25
-#: build/lib/opac/webapp/templates/article/includes/modal/download.html:22
 #: opac/webapp/choices.py:13 opac/webapp/choices.py:25
 #: opac/webapp/templates/article/includes/modal/download.html:22
 msgid "Espanhol"
 msgstr "Español"
 
-#: build/lib/opac/webapp/choices.py:26 opac/webapp/choices.py:26
+#: opac/webapp/choices.py:26
 msgid "Albanês"
 msgstr "Albanés"
 
-#: build/lib/opac/webapp/choices.py:27 build/lib/opac/webapp/choices.py:33
 #: opac/webapp/choices.py:27 opac/webapp/choices.py:33
 msgid "Chinês"
 msgstr "Chino"
 
-#: build/lib/opac/webapp/choices.py:28 opac/webapp/choices.py:28
+#: opac/webapp/choices.py:28
 msgid "Romeno"
 msgstr "Rumano"
 
-#: build/lib/opac/webapp/choices.py:29 opac/webapp/choices.py:29
+#: opac/webapp/choices.py:29
 msgid "Francês"
 msgstr "Francés"
 
-#: build/lib/opac/webapp/choices.py:30 opac/webapp/choices.py:30
+#: opac/webapp/choices.py:30
 msgid "Italiano"
 msgstr "Italiano"
 
-#: build/lib/opac/webapp/choices.py:31 opac/webapp/choices.py:31
+#: opac/webapp/choices.py:31
 msgid "Russo"
 msgstr "Ruso"
 
-#: build/lib/opac/webapp/choices.py:32 opac/webapp/choices.py:32
+#: opac/webapp/choices.py:32
 msgid "Árabe"
 msgstr "Árabe"
 
-#: build/lib/opac/webapp/choices.py:37 opac/webapp/choices.py:37
+#: opac/webapp/choices.py:37
 msgid "corrente"
 msgstr "vigente"
 
-#: build/lib/opac/webapp/choices.py:38 opac/webapp/choices.py:38
+#: opac/webapp/choices.py:38
 msgid "terminado"
 msgstr "terminado"
 
-#: build/lib/opac/webapp/choices.py:39 opac/webapp/choices.py:39
+#: opac/webapp/choices.py:39
 msgid "indexação interrompida"
 msgstr "indización interrumpida"
 
-#: build/lib/opac/webapp/choices.py:40 opac/webapp/choices.py:40
+#: opac/webapp/choices.py:40
 msgid "indexação interrompida pelo Comitê"
 msgstr "indización interrumpida por el comité"
 
-#: build/lib/opac/webapp/choices.py:41 opac/webapp/choices.py:41
+#: opac/webapp/choices.py:41
 msgid "publicação finalizada"
 msgstr "publicación finalizada"
 
-#: build/lib/opac/webapp/choices.py:45 opac/webapp/choices.py:45
+#: opac/webapp/choices.py:45
 msgid "Ciências Agrárias"
 msgstr "Ciencias Agrícolas"
 
-#: build/lib/opac/webapp/choices.py:46 opac/webapp/choices.py:46
+#: opac/webapp/choices.py:46
 msgid "Ciências Sociais Aplicadas"
 msgstr "Ciencias Sociales Aplicadas"
 
-#: build/lib/opac/webapp/choices.py:47 opac/webapp/choices.py:47
+#: opac/webapp/choices.py:47
 msgid "Ciências Biológicas"
 msgstr "Ciencias Biológicas"
 
-#: build/lib/opac/webapp/choices.py:48 opac/webapp/choices.py:48
+#: opac/webapp/choices.py:48
 msgid "Engenharias"
 msgstr "Ingeniería"
 
-#: build/lib/opac/webapp/choices.py:49 opac/webapp/choices.py:49
+#: opac/webapp/choices.py:49
 msgid "Ciências Exatas e da Terra"
 msgstr "Ciencias Exactas y de la Tierra"
 
-#: build/lib/opac/webapp/choices.py:50 opac/webapp/choices.py:50
+#: opac/webapp/choices.py:50
 msgid "Ciências da Saúde"
 msgstr "Ciencias de la Salud"
 
-#: build/lib/opac/webapp/choices.py:51 opac/webapp/choices.py:51
+#: opac/webapp/choices.py:51
 msgid "Ciências Humanas"
 msgstr "Humanidades"
 
-#: build/lib/opac/webapp/choices.py:52 build/lib/opac/webapp/choices.py:53
 #: opac/webapp/choices.py:52 opac/webapp/choices.py:53
 msgid "Lingüística, Letras e Artes"
 msgstr "Linguística, Letras y Artes"
 
-#: build/lib/opac/webapp/controllers.py:353 opac/webapp/controllers.py:353
+#: opac/webapp/controllers.py:353
 msgid "Lista Alfabética"
 msgstr "Lista Alfabética"
 
-#: build/lib/opac/webapp/controllers.py:357 opac/webapp/controllers.py:357
+#: opac/webapp/controllers.py:357
 msgid "Lista Temática"
 msgstr "Lista Temática"
 
-#: build/lib/opac/webapp/controllers.py:361 opac/webapp/controllers.py:361
+#: opac/webapp/controllers.py:361
 msgid "Lista Web of Science"
 msgstr "Lista Web of Science"
 
-#: build/lib/opac/webapp/controllers.py:365 opac/webapp/controllers.py:365
+#: opac/webapp/controllers.py:365
 msgid "Lista by Institution"
 msgstr "Lista por Institución"
 
-#: build/lib/opac/webapp/controllers.py:424 opac/webapp/controllers.py:424
+#: opac/webapp/controllers.py:424
 msgid "Obrigatório um jid."
 msgstr "Obligatorio un jid."
 
-#: build/lib/opac/webapp/controllers.py:440 opac/webapp/controllers.py:440
+#: opac/webapp/controllers.py:440
 msgid "Obrigatório um acronym."
 msgstr "Obligatorio un acronym."
 
-#: build/lib/opac/webapp/controllers.py:456 opac/webapp/controllers.py:456
+#: opac/webapp/controllers.py:456
 msgid "Obrigatório um url_seg."
 msgstr "Obligatorio un url_seg."
 
-#: build/lib/opac/webapp/controllers.py:472 opac/webapp/controllers.py:472
+#: opac/webapp/controllers.py:472
 msgid "Obrigatório um issn."
 msgstr "ISSN obligatorio."
 
-#: build/lib/opac/webapp/controllers.py:487 opac/webapp/controllers.py:487
+#: opac/webapp/controllers.py:487
 msgid "Obrigatório um title."
 msgstr ""
 
-#: build/lib/opac/webapp/controllers.py:525
-#: build/lib/opac/webapp/controllers.py:669
-#: build/lib/opac/webapp/controllers.py:830 opac/webapp/controllers.py:525
-#: opac/webapp/controllers.py:669 opac/webapp/controllers.py:830
+#: opac/webapp/controllers.py:525 opac/webapp/controllers.py:669
+#: opac/webapp/controllers.py:830
 msgid "Obrigatório uma lista de ids."
 msgstr "Obligatorio un listado de ids."
 
-#: build/lib/opac/webapp/controllers.py:631
-#: build/lib/opac/webapp/controllers.py:851 opac/webapp/controllers.py:631
-#: opac/webapp/controllers.py:851
+#: opac/webapp/controllers.py:631 opac/webapp/controllers.py:851
 msgid "Obrigatório um iid."
 msgstr "Obligatorio un iid."
 
-#: build/lib/opac/webapp/controllers.py:688 opac/webapp/controllers.py:688
+#: opac/webapp/controllers.py:688
 msgid "Obrigatório um jacron e issue_label."
 msgstr "Obligatorio un jacron e issue_label."
 
-#: build/lib/opac/webapp/controllers.py:701 opac/webapp/controllers.py:701
+#: opac/webapp/controllers.py:701
 msgid "Obrigatório um PID."
 msgstr "PID obligatorio."
 
-#: build/lib/opac/webapp/controllers.py:717 opac/webapp/controllers.py:717
+#: opac/webapp/controllers.py:717
 msgid "Obrigatório um url_seg e url_seg_issue."
 msgstr "Obligatorio un url_seg y url_seg_issue."
 
-#: build/lib/opac/webapp/controllers.py:724 opac/webapp/controllers.py:724
+#: opac/webapp/controllers.py:724
 msgid "Obrigatório um assets_code."
 msgstr "assets_code es obligatório."
 
-#: build/lib/opac/webapp/controllers.py:727 opac/webapp/controllers.py:727
+#: opac/webapp/controllers.py:727
 msgid "Obrigatório um journal."
 msgstr "journal es obligatorio."
 
-#: build/lib/opac/webapp/controllers.py:743 opac/webapp/controllers.py:743
+#: opac/webapp/controllers.py:743
 msgid "Obrigatório um aid."
 msgstr "Obligatorio un aid."
 
-#: build/lib/opac/webapp/controllers.py:757 opac/webapp/controllers.py:757
+#: opac/webapp/controllers.py:757
 msgid "Obrigatório um url_seg_article."
 msgstr "Obligatorio un url_seg_article."
 
-#: build/lib/opac/webapp/controllers.py:772 opac/webapp/controllers.py:772
+#: opac/webapp/controllers.py:772
 msgid "Obrigatório um iid and url_seg_article."
 msgstr "Obligatorio un iid and url_seg_article."
 
-#: build/lib/opac/webapp/controllers.py:788 opac/webapp/controllers.py:788
+#: opac/webapp/controllers.py:788
 msgid "Obrigatório um jid, url_seg_issue and url_seg_article."
 msgstr ""
 
-#: build/lib/opac/webapp/controllers.py:889 opac/webapp/controllers.py:889
+#: opac/webapp/controllers.py:889
 msgid "Obrigatório um pid."
 msgstr "PID obligatorio."
 
-#: build/lib/opac/webapp/controllers.py:902 opac/webapp/controllers.py:902
+#: opac/webapp/controllers.py:902
 msgid "Obrigatório um aop_pid."
 msgstr "Obligatorio un aop_pid."
 
-#: build/lib/opac/webapp/controllers.py:913 opac/webapp/controllers.py:913
+#: opac/webapp/controllers.py:913
 msgid "Parámetro obrigatório: issue_iid."
 msgstr "Parámetro obligatorio: issue_iid."
 
-#: build/lib/opac/webapp/controllers.py:961 opac/webapp/controllers.py:961
+#: opac/webapp/controllers.py:961
 msgid "Parâmetro email deve ser uma string"
 msgstr "Parámetro email debe ser un string"
 
-#: build/lib/opac/webapp/controllers.py:972 opac/webapp/controllers.py:972
+#: opac/webapp/controllers.py:972
 msgid "Parâmetro email deve ser uma inteiro"
 msgstr "Parámetro email debe ser un entero"
 
-#: build/lib/opac/webapp/controllers.py:984
-#: build/lib/opac/webapp/controllers.py:998 opac/webapp/controllers.py:984
-#: opac/webapp/controllers.py:998
+#: opac/webapp/controllers.py:984 opac/webapp/controllers.py:998
 #, python-format
 msgid "Usuário deve ser do tipo %s"
 msgstr "Usuario debe ser del tipo %s"
 
-#: build/lib/opac/webapp/controllers.py:1054 opac/webapp/controllers.py:1054
+#: opac/webapp/controllers.py:1054
 msgid "Compartilhamento de link SciELO"
 msgstr "Compartir enlace SciELO"
 
-#: build/lib/opac/webapp/controllers.py:1055 opac/webapp/controllers.py:1055
+#: opac/webapp/controllers.py:1055
 #, python-format
 msgid "O usuário %s compartilha este link: %s, da SciELO"
 msgstr "El usuario %s comparte este enlace: %s, de SciELO"
 
-#: build/lib/opac/webapp/controllers.py:1063
-#: build/lib/opac/webapp/controllers.py:1099
-#: build/lib/opac/webapp/controllers.py:1121 opac/webapp/controllers.py:1063
-#: opac/webapp/controllers.py:1099 opac/webapp/controllers.py:1121
+#: opac/webapp/controllers.py:1063 opac/webapp/controllers.py:1099
+#: opac/webapp/controllers.py:1121
 msgid "Mensagem enviada!"
 msgstr "Mensaje enviado!"
 
-#: build/lib/opac/webapp/controllers.py:1080 opac/webapp/controllers.py:1080
+#: opac/webapp/controllers.py:1080
 msgid "[Erro] Erro informado pelo usuário no site SciELO"
 msgstr ""
 
-#: build/lib/opac/webapp/controllers.py:1083 opac/webapp/controllers.py:1083
+#: opac/webapp/controllers.py:1083
 msgid "aplicação"
 msgstr ""
 
-#: build/lib/opac/webapp/controllers.py:1085 opac/webapp/controllers.py:1085
+#: opac/webapp/controllers.py:1085
 msgid "conteúdo"
 msgstr ""
 
-#: build/lib/opac/webapp/controllers.py:1090 opac/webapp/controllers.py:1090
+#: opac/webapp/controllers.py:1090
 #, python-format
 msgid ""
 "O usuário <b>%s</b> com e-mail: <b>%s</b>, informa que existe um erro na "
@@ -491,56 +406,52 @@ msgstr ""
 " en la% s en el sitio SciELO. <br> <br> <b> Título de la página: </ b>% s"
 " <br> <br> <b> Link: </ b% s"
 
-#: build/lib/opac/webapp/controllers.py:1111 opac/webapp/controllers.py:1111
+#: opac/webapp/controllers.py:1111
 msgid "Contato de usuário via site SciELO"
 msgstr "Contacto de usuário por sitio SciELO"
 
-#: build/lib/opac/webapp/controllers.py:1113 opac/webapp/controllers.py:1113
+#: opac/webapp/controllers.py:1113
 #, python-format
 msgid "O usuário %s, com e-mail: %s, entra em contato com a seguinte mensagem:"
 msgstr "El usuario %s, con e-mail: %s, entra en contacto com la siguiente mensaje:"
 
-#: build/lib/opac/webapp/controllers.py:1145 opac/webapp/controllers.py:1145
+#: opac/webapp/controllers.py:1145
 msgid "Obrigatório um slug_name."
 msgstr ""
 
-#: build/lib/opac/webapp/forms.py:29 opac/webapp/forms.py:29
+#: opac/webapp/forms.py:29
 msgid "Endereço de e-mail inválido."
 msgstr "Dirección de e-mail inválida."
 
-#: build/lib/opac/webapp/admin/forms.py:9
-#: build/lib/opac/webapp/admin/forms.py:21 opac/webapp/admin/forms.py:9
-#: opac/webapp/admin/forms.py:21
+#: opac/webapp/admin/forms.py:9 opac/webapp/admin/forms.py:21
 msgid "Email"
 msgstr "Email"
 
-#: build/lib/opac/webapp/admin/forms.py:10
-#: build/lib/opac/webapp/admin/forms.py:25 opac/webapp/admin/forms.py:10
-#: opac/webapp/admin/forms.py:25
+#: opac/webapp/admin/forms.py:10 opac/webapp/admin/forms.py:25
 msgid "Senha"
 msgstr "Contraseña"
 
-#: build/lib/opac/webapp/admin/forms.py:15 opac/webapp/admin/forms.py:15
+#: opac/webapp/admin/forms.py:15
 msgid "Usuário inválido"
 msgstr "Usuario inválido"
 
-#: build/lib/opac/webapp/admin/forms.py:17 opac/webapp/admin/forms.py:17
+#: opac/webapp/admin/forms.py:17
 msgid "Senha inválida"
 msgstr "Contraseña inválida"
 
-#: build/lib/opac/webapp/admin/views.py:28 opac/webapp/admin/views.py:28
+#: opac/webapp/admin/views.py:28
 msgid "Tem certeza que quer publicar os itens selecionados?"
 msgstr "¿Está seguro que desea publicar los ítems seleccionados?"
 
-#: build/lib/opac/webapp/admin/views.py:29 opac/webapp/admin/views.py:29
+#: opac/webapp/admin/views.py:29
 msgid "Tem certeza que quer despublicar os itens selecionados?"
 msgstr "¿Está seguro que desea despublicar los ítems seleccionados?"
 
-#: build/lib/opac/webapp/admin/views.py:30 opac/webapp/admin/views.py:30
+#: opac/webapp/admin/views.py:30
 msgid "Tem certeza que quer reconstruir os artigos selecionados?"
 msgstr "¿Está seguro que desea reconstruir los artículos seleccionados?"
 
-#: build/lib/opac/webapp/admin/views.py:31 opac/webapp/admin/views.py:31
+#: opac/webapp/admin/views.py:31
 msgid ""
 "Tem certeza que quer enviar email de confirmação aos usuários "
 "selecionados?"
@@ -548,23 +459,21 @@ msgstr ""
 "¿Está seguro que desea enviar email de confirmación a los usuarios "
 "seleccionados?"
 
-#: build/lib/opac/webapp/admin/views.py:91
-#: build/lib/opac/webapp/admin/views.py:104 opac/webapp/admin/views.py:91
-#: opac/webapp/admin/views.py:104
+#: opac/webapp/admin/views.py:91 opac/webapp/admin/views.py:104
 msgid "Usuário não encontrado"
 msgstr "Usuario no encontrado"
 
-#: build/lib/opac/webapp/admin/views.py:94 opac/webapp/admin/views.py:94
+#: opac/webapp/admin/views.py:94
 #, python-format
 msgid "Email: %(email)s confirmado com sucesso!"
 msgstr "Email: %(email)s confirmado com éxito!"
 
-#: build/lib/opac/webapp/admin/views.py:110 opac/webapp/admin/views.py:110
+#: opac/webapp/admin/views.py:110
 #, python-format
 msgid "Enviamos as instruções para recuperar a senha para: %(email)s"
 msgstr "Enviamos las instrucciones para recuperar la contraseña para: %(email)s"
 
-#: build/lib/opac/webapp/admin/views.py:113 opac/webapp/admin/views.py:113
+#: opac/webapp/admin/views.py:113
 #, python-format
 msgid ""
 "Ocorreu um erro no envio das instruções por email para: %(email)s. Erro: "
@@ -573,18 +482,16 @@ msgstr ""
 "Ocurrió un error en el envío de las instrucciones por email para "
 "%(email)s. Error: %(error)s"
 
-#: build/lib/opac/webapp/admin/views.py:139 opac/webapp/admin/views.py:139
+#: opac/webapp/admin/views.py:139
 msgid "Nova senha salva com sucesso!!"
 msgstr "Nueva contraseña guardada con éxito!!"
 
-#: build/lib/opac/webapp/admin/views.py:167
-#: build/lib/opac/webapp/admin/views.py:186 opac/webapp/admin/views.py:167
-#: opac/webapp/admin/views.py:186
+#: opac/webapp/admin/views.py:167 opac/webapp/admin/views.py:186
 #, python-format
 msgid "Enviamos o email de confirmação para: %(email)s"
 msgstr "Enviamos el email de confirmación para: %(email)s"
 
-#: build/lib/opac/webapp/admin/views.py:170 opac/webapp/admin/views.py:170
+#: opac/webapp/admin/views.py:170
 #, python-format
 msgid ""
 "Ocorreu um erro no envio do email de confirmação para: %(email)s "
@@ -593,367 +500,324 @@ msgstr ""
 "Ocurrió un error en el envío de e-mail de confirmación "
 "para:%(email)s%(error_msg)s"
 
-#: build/lib/opac/webapp/admin/views.py:177 opac/webapp/admin/views.py:177
+#: opac/webapp/admin/views.py:177
 msgid "Enviar email de confirmação"
 msgstr "Enviar email de confirmación"
 
-#: build/lib/opac/webapp/admin/views.py:189 opac/webapp/admin/views.py:189
+#: opac/webapp/admin/views.py:189
 #, python-format
 msgid "Ocorreu um erro no envio do email de confirmação para: %(email)s"
 msgstr "Ocurrió un error en el envío de email de confirmación para: %(email)s"
 
-#: build/lib/opac/webapp/admin/views.py:193 opac/webapp/admin/views.py:193
+#: opac/webapp/admin/views.py:193
 #, python-format
 msgid "%(count)s usuários foram notificados com sucesso!"
 msgstr "%(count)s usuarios fueron notificados con éxito!"
 
-#: build/lib/opac/webapp/admin/views.py:196 opac/webapp/admin/views.py:196
+#: opac/webapp/admin/views.py:196
 #, python-format
 msgid "Ocorreu um erro no envio do emails de confirmação. Erro: %(ex)s"
 msgstr "Ocurrió un error en el envío de emails de confirmación. Error: %(ex)s"
 
-#: build/lib/opac/webapp/admin/views.py:231
-#: build/lib/opac/webapp/admin/views.py:265
-#: build/lib/opac/webapp/admin/views.py:363
-#: build/lib/opac/webapp/admin/views.py:393
-#: build/lib/opac/webapp/admin/views.py:677 opac/webapp/admin/views.py:231
-#: opac/webapp/admin/views.py:265 opac/webapp/admin/views.py:363
-#: opac/webapp/admin/views.py:393 opac/webapp/admin/views.py:677
+#: opac/webapp/admin/views.py:231 opac/webapp/admin/views.py:265
+#: opac/webapp/admin/views.py:363 opac/webapp/admin/views.py:393
+#: opac/webapp/admin/views.py:678
 msgid "Nome"
 msgstr "Nombre"
 
-#: build/lib/opac/webapp/admin/views.py:232
-#: build/lib/opac/webapp/admin/views.py:267 opac/webapp/admin/views.py:232
-#: opac/webapp/admin/views.py:267
+#: opac/webapp/admin/views.py:232 opac/webapp/admin/views.py:267
 msgid "Link"
 msgstr "Enlace"
 
-#: build/lib/opac/webapp/admin/views.py:233
-#: build/lib/opac/webapp/admin/views.py:268
-#: build/lib/opac/webapp/admin/views.py:678 opac/webapp/admin/views.py:233
-#: opac/webapp/admin/views.py:268 opac/webapp/admin/views.py:678
+#: opac/webapp/admin/views.py:233 opac/webapp/admin/views.py:268
+#: opac/webapp/admin/views.py:679
 msgid "Idioma"
 msgstr "idioma"
 
-#: build/lib/opac/webapp/admin/views.py:266 opac/webapp/admin/views.py:266
+#: opac/webapp/admin/views.py:266
 msgid "Previsualização"
 msgstr "Previsualización"
 
-#: build/lib/opac/webapp/admin/views.py:362
-#: build/lib/opac/webapp/admin/views.py:547
-#: build/lib/opac/webapp/admin/views.py:627 opac/webapp/admin/views.py:362
-#: opac/webapp/admin/views.py:547 opac/webapp/admin/views.py:627
+#: opac/webapp/admin/views.py:362 opac/webapp/admin/views.py:548
+#: opac/webapp/admin/views.py:628
 msgid "Ordem"
 msgstr "Orden"
 
-#: build/lib/opac/webapp/admin/views.py:364 opac/webapp/admin/views.py:364
+#: opac/webapp/admin/views.py:364
 msgid "URL"
 msgstr "URL"
 
-#: build/lib/opac/webapp/admin/views.py:365 opac/webapp/admin/views.py:365
+#: opac/webapp/admin/views.py:365
 msgid "URL da logomarca"
 msgstr "URL del logo"
 
-#: build/lib/opac/webapp/admin/views.py:375 opac/webapp/admin/views.py:375
+#: opac/webapp/admin/views.py:375
 msgid "Financiador com Ordem ou Nome já cadastrado!"
 msgstr "Financiador con Orden o Nombre ya registrado!"
 
-#: build/lib/opac/webapp/admin/views.py:394 opac/webapp/admin/views.py:394
+#: opac/webapp/admin/views.py:394
 msgid "Acerca de"
 msgstr "Acerca de"
 
-#: build/lib/opac/webapp/admin/views.py:395
-#: build/lib/opac/webapp/admin/views.py:462 opac/webapp/admin/views.py:395
-#: opac/webapp/admin/views.py:462
+#: opac/webapp/admin/views.py:395 opac/webapp/admin/views.py:463
 msgid "Acrônimo"
 msgstr "Acrónimo"
 
-#: build/lib/opac/webapp/admin/views.py:396 opac/webapp/admin/views.py:396
+#: opac/webapp/admin/views.py:396
 msgid "Endereço principal"
 msgstr "Dirección principal"
 
-#: build/lib/opac/webapp/admin/views.py:397 opac/webapp/admin/views.py:397
+#: opac/webapp/admin/views.py:397
 msgid "Endereço secundário"
 msgstr "Dirección secundaria"
 
-#: build/lib/opac/webapp/admin/views.py:398 opac/webapp/admin/views.py:398
+#: opac/webapp/admin/views.py:398
 msgid "Logo da Home (PT)"
 msgstr "Logo de la Homepage (PT)"
 
-#: build/lib/opac/webapp/admin/views.py:399 opac/webapp/admin/views.py:399
+#: opac/webapp/admin/views.py:399
 msgid "Logo da Home (EN)"
 msgstr "Logo de la Homepage (EN)"
 
-#: build/lib/opac/webapp/admin/views.py:400 opac/webapp/admin/views.py:400
+#: opac/webapp/admin/views.py:400
 msgid "Logo da Home (ES)"
 msgstr "Logo de la Homepage (ES)"
 
-#: build/lib/opac/webapp/admin/views.py:401 opac/webapp/admin/views.py:401
+#: opac/webapp/admin/views.py:401
 msgid "Logo do cabeçalho (PT)"
 msgstr "Logo del encabezado (PT)"
 
-#: build/lib/opac/webapp/admin/views.py:402 opac/webapp/admin/views.py:402
+#: opac/webapp/admin/views.py:402
 msgid "Logo do cabeçalho (EN)"
 msgstr "Logo del encabezado (EN)"
 
-#: build/lib/opac/webapp/admin/views.py:403 opac/webapp/admin/views.py:403
+#: opac/webapp/admin/views.py:403
 msgid "Logo do cabeçalho (ES)"
 msgstr "Logo del encabezado (ES)"
 
-#: build/lib/opac/webapp/admin/views.py:404 opac/webapp/admin/views.py:404
+#: opac/webapp/admin/views.py:404
 msgid "Logo do menu (PT)"
 msgstr "Logo del menú (PT)"
 
-#: build/lib/opac/webapp/admin/views.py:405
-#: build/lib/opac/webapp/admin/views.py:406 opac/webapp/admin/views.py:405
-#: opac/webapp/admin/views.py:406
+#: opac/webapp/admin/views.py:405 opac/webapp/admin/views.py:406
 msgid "Logo do menu (ES)"
 msgstr "Logo del menú (ES)"
 
-#: build/lib/opac/webapp/admin/views.py:407 opac/webapp/admin/views.py:407
+#: opac/webapp/admin/views.py:407
 msgid "Logo do menu (drop)"
 msgstr "Logo del menú (drop)"
 
-#: build/lib/opac/webapp/admin/views.py:408 opac/webapp/admin/views.py:408
+#: opac/webapp/admin/views.py:408
 msgid "Logo do rodapé"
 msgstr "Logo del pié de página"
 
-#: build/lib/opac/webapp/admin/views.py:451 opac/webapp/admin/views.py:451
+#: opac/webapp/admin/views.py:452
 msgid "Id Periódico"
 msgstr "Id Revista"
 
-#: build/lib/opac/webapp/admin/views.py:453 opac/webapp/admin/views.py:453
+#: opac/webapp/admin/views.py:454
 msgid "Linha do tempo"
 msgstr "Línea de tiempo"
 
-#: build/lib/opac/webapp/admin/views.py:454 opac/webapp/admin/views.py:454
+#: opac/webapp/admin/views.py:455
 msgid "Categorias de assunto"
 msgstr "Categorías de asunto"
 
-#: build/lib/opac/webapp/admin/views.py:455 opac/webapp/admin/views.py:455
+#: opac/webapp/admin/views.py:456
 msgid "Áreas de estudo"
 msgstr "Áreas de estudio"
 
-#: build/lib/opac/webapp/admin/views.py:456 opac/webapp/admin/views.py:456
+#: opac/webapp/admin/views.py:457
 msgid "Redes sociais"
 msgstr "Redes sociales"
 
-#: build/lib/opac/webapp/admin/views.py:457
-#: build/lib/opac/webapp/admin/views.py:611
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:30
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:73
-#: opac/webapp/admin/views.py:457 opac/webapp/admin/views.py:611
+#: opac/webapp/admin/views.py:458 opac/webapp/admin/views.py:612
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:30
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:73
 msgid "Título"
 msgstr "Título"
 
-#: build/lib/opac/webapp/admin/views.py:458 opac/webapp/admin/views.py:458
+#: opac/webapp/admin/views.py:459
 msgid "Título ISO"
 msgstr "Título ISO"
 
-#: build/lib/opac/webapp/admin/views.py:459 opac/webapp/admin/views.py:459
+#: opac/webapp/admin/views.py:460
 msgid "Título curto"
 msgstr "Título corto"
 
-#: build/lib/opac/webapp/admin/views.py:460
-#: build/lib/opac/webapp/admin/views.py:538
-#: build/lib/opac/webapp/admin/views.py:614 opac/webapp/admin/views.py:460
-#: opac/webapp/admin/views.py:538 opac/webapp/admin/views.py:614
+#: opac/webapp/admin/views.py:461 opac/webapp/admin/views.py:539
+#: opac/webapp/admin/views.py:615
 msgid "Criado"
 msgstr "Creado"
 
-#: build/lib/opac/webapp/admin/views.py:461
-#: build/lib/opac/webapp/admin/views.py:539
-#: build/lib/opac/webapp/admin/views.py:615 opac/webapp/admin/views.py:461
-#: opac/webapp/admin/views.py:539 opac/webapp/admin/views.py:615
+#: opac/webapp/admin/views.py:462 opac/webapp/admin/views.py:540
+#: opac/webapp/admin/views.py:616
 msgid "Atualizado"
 msgstr "Actualizado"
 
-#: build/lib/opac/webapp/admin/views.py:463 opac/webapp/admin/views.py:463
+#: opac/webapp/admin/views.py:464
 msgid "ISSN SciELO"
 msgstr "ISSN SciELO"
 
-#: build/lib/opac/webapp/admin/views.py:464 opac/webapp/admin/views.py:464
+#: opac/webapp/admin/views.py:465
 msgid "ISSN impresso"
 msgstr "ISSN impreso"
 
-#: build/lib/opac/webapp/admin/views.py:465 opac/webapp/admin/views.py:465
+#: opac/webapp/admin/views.py:466
 msgid "ISSN eletrônico"
 msgstr "ISSN electrónico"
 
-#: build/lib/opac/webapp/admin/views.py:466 opac/webapp/admin/views.py:466
+#: opac/webapp/admin/views.py:467
 msgid "Descritores de assunto"
 msgstr "Descriptores de asunto"
 
-#: build/lib/opac/webapp/admin/views.py:467 opac/webapp/admin/views.py:467
+#: opac/webapp/admin/views.py:468
 msgid "Url da submissão online"
 msgstr "Url de envío online"
 
-#: build/lib/opac/webapp/admin/views.py:468 opac/webapp/admin/views.py:468
+#: opac/webapp/admin/views.py:469
 msgid "Url do capa"
 msgstr "Url de carátula"
 
-#: build/lib/opac/webapp/admin/views.py:469 opac/webapp/admin/views.py:469
+#: opac/webapp/admin/views.py:470
 msgid "Url do logotipo"
 msgstr "Url de logotipo"
 
-#: build/lib/opac/webapp/admin/views.py:470 opac/webapp/admin/views.py:470
+#: opac/webapp/admin/views.py:471
 msgid "Outros títulos"
 msgstr "Otros títulos"
 
-#: build/lib/opac/webapp/admin/views.py:471 opac/webapp/admin/views.py:471
+#: opac/webapp/admin/views.py:472
 msgid "Nome da editora"
 msgstr "Nombre de la editorial"
 
-#: build/lib/opac/webapp/admin/views.py:472 opac/webapp/admin/views.py:472
+#: opac/webapp/admin/views.py:473
 msgid "País da editora"
 msgstr "País de la editorial"
 
-#: build/lib/opac/webapp/admin/views.py:473 opac/webapp/admin/views.py:473
+#: opac/webapp/admin/views.py:474
 msgid "Estado da editora"
 msgstr "Estado de la editorial"
 
-#: build/lib/opac/webapp/admin/views.py:474 opac/webapp/admin/views.py:474
+#: opac/webapp/admin/views.py:475
 msgid "Cidade da editora"
 msgstr "Ciudad de la editorial"
 
-#: build/lib/opac/webapp/admin/views.py:475 opac/webapp/admin/views.py:475
+#: opac/webapp/admin/views.py:476
 msgid "Endereço da editora"
 msgstr "Dirección de la editorial"
 
-#: build/lib/opac/webapp/admin/views.py:476 opac/webapp/admin/views.py:476
+#: opac/webapp/admin/views.py:477
 msgid "Telefone da editora"
 msgstr "Teléfono de la editorial"
 
-#: build/lib/opac/webapp/admin/views.py:477 opac/webapp/admin/views.py:477
+#: opac/webapp/admin/views.py:478
 msgid "Missão"
 msgstr "Misión"
 
-#: build/lib/opac/webapp/admin/views.py:478 opac/webapp/admin/views.py:478
+#: opac/webapp/admin/views.py:479
 msgid "No índice"
 msgstr "En el índice"
 
-#: build/lib/opac/webapp/admin/views.py:479 opac/webapp/admin/views.py:479
+#: opac/webapp/admin/views.py:480
 msgid "Patrocinadores"
 msgstr "Patrocinadores"
 
-#: build/lib/opac/webapp/admin/views.py:480 opac/webapp/admin/views.py:480
+#: opac/webapp/admin/views.py:481
 msgid "Ref periódico anterior"
 msgstr "Ref. de la revista anterior"
 
-#: build/lib/opac/webapp/admin/views.py:481 opac/webapp/admin/views.py:481
+#: opac/webapp/admin/views.py:482
 msgid "Situação atual"
 msgstr "Estado actual"
 
-#: build/lib/opac/webapp/admin/views.py:482 opac/webapp/admin/views.py:482
+#: opac/webapp/admin/views.py:483
 msgid "Total de números"
 msgstr "Total de números"
 
-#: build/lib/opac/webapp/admin/views.py:483
-#: build/lib/opac/webapp/admin/views.py:548
-#: build/lib/opac/webapp/admin/views.py:618 opac/webapp/admin/views.py:483
-#: opac/webapp/admin/views.py:548 opac/webapp/admin/views.py:618
+#: opac/webapp/admin/views.py:484 opac/webapp/admin/views.py:549
+#: opac/webapp/admin/views.py:619
 msgid "Publicado?"
 msgstr "¿Publicado?"
 
-#: build/lib/opac/webapp/admin/views.py:484
-#: build/lib/opac/webapp/admin/views.py:549
-#: build/lib/opac/webapp/admin/views.py:619 opac/webapp/admin/views.py:484
-#: opac/webapp/admin/views.py:549 opac/webapp/admin/views.py:619
+#: opac/webapp/admin/views.py:485 opac/webapp/admin/views.py:550
+#: opac/webapp/admin/views.py:620
 msgid "Motivo de despublicação"
 msgstr "Motivo de la despublicación"
 
-#: build/lib/opac/webapp/admin/views.py:485
-#: build/lib/opac/webapp/admin/views.py:551
-#: build/lib/opac/webapp/admin/views.py:620 opac/webapp/admin/views.py:485
-#: opac/webapp/admin/views.py:551 opac/webapp/admin/views.py:620
+#: opac/webapp/admin/views.py:486 opac/webapp/admin/views.py:552
+#: opac/webapp/admin/views.py:621
 msgid "Segmento de URL"
 msgstr "Segmento de la URL"
 
-#: build/lib/opac/webapp/admin/views.py:488
-#: build/lib/opac/webapp/admin/views.py:554
-#: build/lib/opac/webapp/admin/views.py:633 opac/webapp/admin/views.py:488
-#: opac/webapp/admin/views.py:554 opac/webapp/admin/views.py:633
+#: opac/webapp/admin/views.py:489 opac/webapp/admin/views.py:555
+#: opac/webapp/admin/views.py:634
 msgid "Publicar"
 msgstr "Publicar"
 
-#: build/lib/opac/webapp/admin/views.py:493 opac/webapp/admin/views.py:493
+#: opac/webapp/admin/views.py:494
 msgid "Periódico(s) publicado(s) com sucesso!!"
 msgstr "Revista(s) publicada(s) éxitosamente!!"
 
-#: build/lib/opac/webapp/admin/views.py:495 opac/webapp/admin/views.py:495
+#: opac/webapp/admin/views.py:496
 msgid "Ocorreu um erro tentando publicar o(s) periódico(s)!!"
 msgstr "Ocurrió un error intentando publicar la/s revista(s)!!"
 
-#: build/lib/opac/webapp/admin/views.py:501 opac/webapp/admin/views.py:501
+#: opac/webapp/admin/views.py:502
 msgid "Periódico(s) despublicado com sucesso!!"
 msgstr "Revista(s) despublicada(s) éxitosamente!!"
 
-#: build/lib/opac/webapp/admin/views.py:504 opac/webapp/admin/views.py:504
+#: opac/webapp/admin/views.py:505
 #, python-format
 msgid "Ocorreu um erro tentando despublicar o(s) periódico(s)!!. Erro: %(ex)s"
 msgstr "Ocurrió un error intentando despublicar la/s revista(s)!!. Error: %(ex)s"
 
-#: build/lib/opac/webapp/admin/views.py:508
-#: build/lib/opac/webapp/admin/views.py:576
-#: build/lib/opac/webapp/admin/views.py:656 opac/webapp/admin/views.py:508
-#: opac/webapp/admin/views.py:576 opac/webapp/admin/views.py:656
+#: opac/webapp/admin/views.py:509 opac/webapp/admin/views.py:577
+#: opac/webapp/admin/views.py:657
 #, python-format
 msgid "Despublicar por %s"
 msgstr "Despublicar por %s"
 
-#: build/lib/opac/webapp/admin/views.py:532 opac/webapp/admin/views.py:532
+#: opac/webapp/admin/views.py:533
 msgid "Id Número"
 msgstr "Id. Número"
 
-#: build/lib/opac/webapp/admin/views.py:534
-#: build/lib/opac/webapp/admin/views.py:624 opac/webapp/admin/views.py:534
-#: opac/webapp/admin/views.py:624
+#: opac/webapp/admin/views.py:535 opac/webapp/admin/views.py:625
 msgid "Seções"
 msgstr "Secciones"
 
-#: build/lib/opac/webapp/admin/views.py:535 opac/webapp/admin/views.py:535
+#: opac/webapp/admin/views.py:536
 msgid "Url da capa"
 msgstr "URL de la capa"
 
-#: build/lib/opac/webapp/admin/views.py:536
-#: build/lib/opac/webapp/templates/collection/list_feed_content.html:3
-#: build/lib/opac/webapp/templates/issue/grid.html:40
-#: build/lib/opac/webapp/templates/news/includes/issue_last_row.html:7
-#: opac/webapp/admin/views.py:536
+#: opac/webapp/admin/views.py:537
 #: opac/webapp/templates/collection/list_feed_content.html:3
 #: opac/webapp/templates/issue/grid.html:40
 #: opac/webapp/templates/news/includes/issue_last_row.html:7
 msgid "Volume"
 msgstr "Volumen"
 
-#: build/lib/opac/webapp/admin/views.py:540 opac/webapp/admin/views.py:540
+#: opac/webapp/admin/views.py:541
 msgid "Tipo"
 msgstr "Tipo"
 
-#: build/lib/opac/webapp/admin/views.py:541 opac/webapp/admin/views.py:541
+#: opac/webapp/admin/views.py:542
 msgid "Texto do suplemento"
 msgstr "Texto del suplemento"
 
-#: build/lib/opac/webapp/admin/views.py:542 opac/webapp/admin/views.py:542
+#: opac/webapp/admin/views.py:543
 msgid "Texto do especial"
 msgstr "Texto del especial"
 
-#: build/lib/opac/webapp/admin/views.py:543 opac/webapp/admin/views.py:543
+#: opac/webapp/admin/views.py:544
 msgid "Mês inicial"
 msgstr "Mes inicial"
 
-#: build/lib/opac/webapp/admin/views.py:544 opac/webapp/admin/views.py:544
+#: opac/webapp/admin/views.py:545
 msgid "Mês final"
 msgstr "Mes final"
 
-#: build/lib/opac/webapp/admin/views.py:545
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:25
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:68
-#: build/lib/opac/webapp/templates/issue/grid.html:39
-#: build/lib/opac/webapp/templates/news/includes/issue_last_row.html:5
-#: opac/webapp/admin/views.py:545
+#: opac/webapp/admin/views.py:546
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:25
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:68
 #: opac/webapp/templates/issue/grid.html:39
@@ -961,218 +825,184 @@ msgstr "Mes final"
 msgid "Ano"
 msgstr "Año"
 
-#: build/lib/opac/webapp/admin/views.py:546 opac/webapp/admin/views.py:546
+#: opac/webapp/admin/views.py:547
 msgid "Etiqueta"
 msgstr "Etiqueta"
 
-#: build/lib/opac/webapp/admin/views.py:550
-#: build/lib/opac/webapp/admin/views.py:621 opac/webapp/admin/views.py:550
-#: opac/webapp/admin/views.py:621
+#: opac/webapp/admin/views.py:551 opac/webapp/admin/views.py:622
 msgid "PID"
 msgstr "PID"
 
-#: build/lib/opac/webapp/admin/views.py:559 opac/webapp/admin/views.py:559
+#: opac/webapp/admin/views.py:560
 msgid "Número(s) publicado(s) com sucesso!!"
 msgstr "Fascículo(s) publicado(s) con éxito!!"
 
-#: build/lib/opac/webapp/admin/views.py:562
-#: build/lib/opac/webapp/admin/views.py:642 opac/webapp/admin/views.py:562
-#: opac/webapp/admin/views.py:642
+#: opac/webapp/admin/views.py:563 opac/webapp/admin/views.py:643
 #, python-format
 msgid "Ocorreu um erro tentando publicar o(s) número(s)!!. Erro: %(ex)s"
 msgstr "Ocurrió un error intentando publicar el/los fascículo(s)!! Error: %(ex)s"
 
-#: build/lib/opac/webapp/admin/views.py:569 opac/webapp/admin/views.py:569
+#: opac/webapp/admin/views.py:570
 msgid "Número(s) despublicado(s) com sucesso!!"
 msgstr "Fascículo(s) despublicado(s) con éxito!!"
 
-#: build/lib/opac/webapp/admin/views.py:572
-#: build/lib/opac/webapp/admin/views.py:652 opac/webapp/admin/views.py:572
-#: opac/webapp/admin/views.py:652
+#: opac/webapp/admin/views.py:573 opac/webapp/admin/views.py:653
 #, python-format
 msgid "Ocorreu um erro tentando despublicar o(s) número(s)!!. Erro: %(ex)s"
 msgstr "Ocurrió un error intentando despublicar el/los fascículo(s)!! Error:%(ex)s"
 
-#: build/lib/opac/webapp/admin/views.py:608 opac/webapp/admin/views.py:608
+#: opac/webapp/admin/views.py:609
 msgid "Id Artigo"
 msgstr "Id. Artículo"
 
-#: build/lib/opac/webapp/admin/views.py:612 opac/webapp/admin/views.py:612
+#: opac/webapp/admin/views.py:613
 msgid "Seção"
 msgstr "Sección"
 
-#: build/lib/opac/webapp/admin/views.py:613 opac/webapp/admin/views.py:613
+#: opac/webapp/admin/views.py:614
 msgid "É Ahead of Print?"
 msgstr "¿Es Ahead of Print?"
 
-#: build/lib/opac/webapp/admin/views.py:616 opac/webapp/admin/views.py:616
+#: opac/webapp/admin/views.py:617
 msgid "HTML's"
 msgstr "HTML's"
 
-#: build/lib/opac/webapp/admin/views.py:617 opac/webapp/admin/views.py:617
+#: opac/webapp/admin/views.py:618
 msgid "Chave de domínio"
 msgstr "Clave de domínio"
 
-#: build/lib/opac/webapp/admin/views.py:622 opac/webapp/admin/views.py:622
+#: opac/webapp/admin/views.py:623
 msgid "Idioma original"
 msgstr "Idioma original"
 
-#: build/lib/opac/webapp/admin/views.py:623 opac/webapp/admin/views.py:623
+#: opac/webapp/admin/views.py:624
 msgid "Idiomas das traduções"
 msgstr "Idiomas de las traducciones"
 
-#: build/lib/opac/webapp/admin/views.py:625 opac/webapp/admin/views.py:625
+#: opac/webapp/admin/views.py:626
 msgid "Autores"
 msgstr "Autores"
 
-#: build/lib/opac/webapp/admin/views.py:626
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:29
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:72
-#: build/lib/opac/webapp/templates/issue/toc.html:176
-#: opac/webapp/admin/views.py:626
+#: opac/webapp/admin/views.py:627
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:29
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:72
-#: opac/webapp/templates/issue/toc.html:176
+#: opac/webapp/templates/issue/toc.html:169
 msgid "Resumo"
 msgstr "Resumen"
 
-#: build/lib/opac/webapp/admin/views.py:628 opac/webapp/admin/views.py:628
+#: opac/webapp/admin/views.py:629
 msgid "DOI"
 msgstr "DOI"
 
-#: build/lib/opac/webapp/admin/views.py:629 opac/webapp/admin/views.py:629
+#: opac/webapp/admin/views.py:630
 msgid "Idiomas"
 msgstr "Idiomas"
 
-#: build/lib/opac/webapp/admin/views.py:630 opac/webapp/admin/views.py:630
+#: opac/webapp/admin/views.py:631
 msgid "Idiomas dos resumos"
 msgstr "Idiomas de los resúmenes"
 
-#: build/lib/opac/webapp/admin/views.py:638 opac/webapp/admin/views.py:638
+#: opac/webapp/admin/views.py:639
 msgid "Artigo(s) publicado com sucesso!!"
 msgstr "Artículo(s) publicado éxitosamente!!"
 
-#: build/lib/opac/webapp/admin/views.py:649 opac/webapp/admin/views.py:649
+#: opac/webapp/admin/views.py:650
 msgid "Artigo(s) despublicado com sucesso!!"
 msgstr "Artículo(s) despublicado éxitosamente!!"
 
-#: build/lib/opac/webapp/admin/views.py:679 opac/webapp/admin/views.py:679
+#: opac/webapp/admin/views.py:680
 msgid "Conteúdo"
 msgstr "Contenido"
 
-#: build/lib/opac/webapp/admin/views.py:681
-#: build/lib/opac/webapp/admin/views.py:901 opac/webapp/admin/views.py:681
-#: opac/webapp/admin/views.py:901
+#: opac/webapp/admin/views.py:682 opac/webapp/admin/views.py:902
 msgid "Descrição"
 msgstr "Descripción"
 
-#: build/lib/opac/webapp/admin/views.py:682
-#: build/lib/opac/webapp/admin/views.py:898 opac/webapp/admin/views.py:682
-#: opac/webapp/admin/views.py:898
+#: opac/webapp/admin/views.py:683 opac/webapp/admin/views.py:899
 msgid "Data de Criação"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:683 opac/webapp/admin/views.py:683
+#: opac/webapp/admin/views.py:684
 msgid "Data de Atualização"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:897 opac/webapp/admin/views.py:897
+#: opac/webapp/admin/views.py:898
 msgid "Ação"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:899 opac/webapp/admin/views.py:899
+#: opac/webapp/admin/views.py:900
 msgid "Modelo Auditado"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:900 opac/webapp/admin/views.py:900
+#: opac/webapp/admin/views.py:901
 msgid "Id Auditado"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:902 opac/webapp/admin/views.py:902
+#: opac/webapp/admin/views.py:903
 msgid "Dados dos campos"
 msgstr ""
 
-#: build/lib/opac/webapp/main/views.py:34 opac/webapp/main/views.py:34
+#: opac/webapp/main/views.py:34
 msgid "O periódico está indisponível por motivo de: "
 msgstr "La revista no está disponible debido a:"
 
-#: build/lib/opac/webapp/main/views.py:35 opac/webapp/main/views.py:35
+#: opac/webapp/main/views.py:35
 msgid "O número está indisponível por motivo de: "
 msgstr "O fascículo esta indisponible por motivo de:"
 
-#: build/lib/opac/webapp/main/views.py:36 opac/webapp/main/views.py:36
+#: opac/webapp/main/views.py:36
 msgid "O artigo está indisponível por motivo de: "
 msgstr "El artículo no está disponible debido a:"
 
-#: build/lib/opac/webapp/main/views.py:127 opac/webapp/main/views.py:127
+#: opac/webapp/main/views.py:127
 msgid "Código de idioma inválido"
 msgstr "Código de idioma inválido"
 
-#: build/lib/opac/webapp/main/views.py:197 opac/webapp/main/views.py:197
+#: opac/webapp/main/views.py:197
 msgid "Últimos periódicos inseridos na coleção"
 msgstr "Últimas revistas incluidas en la colección"
 
-#: build/lib/opac/webapp/main/views.py:198 opac/webapp/main/views.py:198
+#: opac/webapp/main/views.py:198
 #, python-format
 msgid "10 últimos periódicos inseridos na coleção %s"
 msgstr "10 últimas revistas incluidas en la colección %s"
 
-#: build/lib/opac/webapp/main/views.py:257 opac/webapp/main/views.py:257
+#: opac/webapp/main/views.py:257
 msgid "Página não encontrada"
 msgstr "Página no encontrada"
 
-#: build/lib/opac/webapp/main/views.py:281
-#: build/lib/opac/webapp/main/views.py:371 opac/webapp/main/views.py:281
-#: opac/webapp/main/views.py:371
+#: opac/webapp/main/views.py:281 opac/webapp/main/views.py:371
 #, python-format
 msgid "Requsição inválida ao tentar acessar o artigo com pid: %s"
 msgstr "Requiere no válida al intentar tener acceso al artículo con pid:% s"
 
-#: build/lib/opac/webapp/main/views.py:289
-#: build/lib/opac/webapp/main/views.py:339
-#: build/lib/opac/webapp/main/views.py:383
-#: build/lib/opac/webapp/main/views.py:452
-#: build/lib/opac/webapp/main/views.py:500
-#: build/lib/opac/webapp/main/views.py:647
-#: build/lib/opac/webapp/main/views.py:664
-#: build/lib/opac/webapp/main/views.py:1127 opac/webapp/main/views.py:289
-#: opac/webapp/main/views.py:339 opac/webapp/main/views.py:383
-#: opac/webapp/main/views.py:452 opac/webapp/main/views.py:500
-#: opac/webapp/main/views.py:647 opac/webapp/main/views.py:664
-#: opac/webapp/main/views.py:1127
+#: opac/webapp/main/views.py:289 opac/webapp/main/views.py:339
+#: opac/webapp/main/views.py:383 opac/webapp/main/views.py:452
+#: opac/webapp/main/views.py:500 opac/webapp/main/views.py:647
+#: opac/webapp/main/views.py:664 opac/webapp/main/views.py:1127
 msgid "Periódico não encontrado"
 msgstr "Revista no encontrada"
 
-#: build/lib/opac/webapp/main/views.py:301
-#: build/lib/opac/webapp/main/views.py:714
-#: build/lib/opac/webapp/main/views.py:773
-#: build/lib/opac/webapp/main/views.py:1136 opac/webapp/main/views.py:301
-#: opac/webapp/main/views.py:714 opac/webapp/main/views.py:773
-#: opac/webapp/main/views.py:1136
+#: opac/webapp/main/views.py:301 opac/webapp/main/views.py:714
+#: opac/webapp/main/views.py:773 opac/webapp/main/views.py:1136
 msgid "Número não encontrado"
 msgstr "Fascículo no encontrado"
 
-#: build/lib/opac/webapp/main/views.py:319
-#: build/lib/opac/webapp/main/views.py:354
-#: build/lib/opac/webapp/main/views.py:825
-#: build/lib/opac/webapp/main/views.py:910
-#: build/lib/opac/webapp/main/views.py:1060 opac/webapp/main/views.py:319
-#: opac/webapp/main/views.py:354 opac/webapp/main/views.py:825
-#: opac/webapp/main/views.py:910 opac/webapp/main/views.py:1060
+#: opac/webapp/main/views.py:319 opac/webapp/main/views.py:354
+#: opac/webapp/main/views.py:825 opac/webapp/main/views.py:910
+#: opac/webapp/main/views.py:1060
 msgid "Artigo não encontrado"
 msgstr "Artículo no encontrado"
 
-#: build/lib/opac/webapp/main/views.py:476 opac/webapp/main/views.py:476
+#: opac/webapp/main/views.py:476
 msgid "Artigo sem título"
 msgstr "Artículo sin título"
 
-#: build/lib/opac/webapp/main/views.py:548
-#: build/lib/opac/webapp/main/views.py:565 opac/webapp/main/views.py:548
-#: opac/webapp/main/views.py:565
+#: opac/webapp/main/views.py:548 opac/webapp/main/views.py:565
 msgid "Requisição inválida. Deve ser por ajax"
 msgstr "Solicitud no válida. Debe ser por ajax"
 
-#: build/lib/opac/webapp/main/views.py:581 opac/webapp/main/views.py:581
+#: opac/webapp/main/views.py:581
 msgid ""
 "Parámetro \"filter\" é inválido, deve ser \"areas\", \"wos\" ou "
 "\"publisher\"."
@@ -1180,11 +1010,11 @@ msgstr ""
 "Parámetro \"filter\" no es válido, debe ser \"areas\", \"wos\" o "
 "\"publisher\"."
 
-#: build/lib/opac/webapp/main/views.py:590 opac/webapp/main/views.py:590
+#: opac/webapp/main/views.py:590
 msgid "Parámetro \"extension\" é inválido, deve ser \"csv\" ou \"xls\"."
 msgstr "Parámetro \"extension\" no es válido, debe ser \"csv\" o \"xls\"."
 
-#: build/lib/opac/webapp/main/views.py:592 opac/webapp/main/views.py:592
+#: opac/webapp/main/views.py:592
 msgid ""
 "Parámetro \"list_type\" é inválido, deve ser: \"alpha\", \"areas\", "
 "\"wos\" ou \"publisher\"."
@@ -1192,78 +1022,61 @@ msgstr ""
 "Parámetro \"list_type\" no es válido, debe ser:  \"alpha\", \"areas\", "
 "\"wos\" o \"publisher\"."
 
-#: build/lib/opac/webapp/main/views.py:613 opac/webapp/main/views.py:613
+#: opac/webapp/main/views.py:613
 msgid "Requisição inválida, deve ser ajax."
 msgstr ""
 
-#: build/lib/opac/webapp/main/views.py:622 opac/webapp/main/views.py:622
+#: opac/webapp/main/views.py:622
 msgid "Periódico não permite envio de email."
 msgstr "La revista no permite envío de correo electrónico"
 
-#: build/lib/opac/webapp/main/views.py:640 opac/webapp/main/views.py:640
+#: opac/webapp/main/views.py:640
 msgid "Requisição inválida, captcha inválido."
 msgstr "Solicitud no válida, captcha inválida."
 
-#: build/lib/opac/webapp/main/views.py:901
-#: build/lib/opac/webapp/main/views.py:1055 opac/webapp/main/views.py:901
-#: opac/webapp/main/views.py:1055
+#: opac/webapp/main/views.py:901 opac/webapp/main/views.py:1055
 msgid "Issue não encontrado"
 msgstr "Fascículo no encontrado"
 
-#: build/lib/opac/webapp/main/views.py:943
-#: build/lib/opac/webapp/main/views.py:949
-#: build/lib/opac/webapp/main/views.py:1092
-#: build/lib/opac/webapp/main/views.py:1100
-#: build/lib/opac/webapp/main/views.py:1102 opac/webapp/main/views.py:943
-#: opac/webapp/main/views.py:949 opac/webapp/main/views.py:1092
-#: opac/webapp/main/views.py:1100 opac/webapp/main/views.py:1102
+#: opac/webapp/main/views.py:943 opac/webapp/main/views.py:949
+#: opac/webapp/main/views.py:1092 opac/webapp/main/views.py:1100
+#: opac/webapp/main/views.py:1102
 msgid "PDF do Artigo não encontrado"
 msgstr "PDF del artículo no encontrado"
 
-#: build/lib/opac/webapp/main/views.py:954 opac/webapp/main/views.py:954
+#: opac/webapp/main/views.py:954
 msgid "HTML do Artigo não encontrado ou indisponível"
 msgstr ""
 
-#: build/lib/opac/webapp/main/views.py:1001 opac/webapp/main/views.py:1001
+#: opac/webapp/main/views.py:1001
 msgid "Parâmetros insuficientes para obter o EPDF do artigo"
 msgstr "Parámetros insuficientes para obtener el EPDF del artículo"
 
-#: build/lib/opac/webapp/main/views.py:1022 opac/webapp/main/views.py:1022
+#: opac/webapp/main/views.py:1022
 msgid "Recruso não encontrado"
 msgstr ""
 
-#: build/lib/opac/webapp/main/views.py:1041 opac/webapp/main/views.py:1041
+#: opac/webapp/main/views.py:1041
 msgid "Recurso do Artigo não encontrado. Caminho inválido!"
 msgstr "Recurso del Artículo no encontrado. Camino inválido!"
 
-#: build/lib/opac/webapp/main/views.py:1154 opac/webapp/main/views.py:1154
+#: opac/webapp/main/views.py:1154
 msgid "PDF do artigo não foi encontrado"
 msgstr "PDF del artículo no encontrado"
 
-#: build/lib/opac/webapp/main/views.py:1169
-#: build/lib/opac/webapp/main/views.py:1200 opac/webapp/main/views.py:1169
-#: opac/webapp/main/views.py:1200
+#: opac/webapp/main/views.py:1169 opac/webapp/main/views.py:1200
 msgid "Requisição inválida."
 msgstr "Petición inválida."
 
-#: build/lib/opac/webapp/templates/admin/index.html:7
 #: opac/webapp/templates/admin/index.html:7
 msgid "da coleção"
 msgstr "de la colección"
 
-#: build/lib/opac/webapp/templates/admin/index.html:12
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu.html:31
 #: opac/webapp/templates/admin/index.html:12
 #: opac/webapp/templates/collection/includes/levelMenu.html:31
 msgid "Periódicos"
 msgstr "Revistas"
 
-#: build/lib/opac/webapp/templates/admin/index.html:15
-#: build/lib/opac/webapp/templates/admin/index.html:22
-#: build/lib/opac/webapp/templates/admin/index.html:35
-#: build/lib/opac/webapp/templates/admin/index.html:42
-#: build/lib/opac/webapp/templates/admin/index.html:55
-#: build/lib/opac/webapp/templates/admin/index.html:62
 #: opac/webapp/templates/admin/index.html:15
 #: opac/webapp/templates/admin/index.html:22
 #: opac/webapp/templates/admin/index.html:35
@@ -1273,12 +1086,6 @@ msgstr "Revistas"
 msgid "Publicados"
 msgstr "Publicados"
 
-#: build/lib/opac/webapp/templates/admin/index.html:16
-#: build/lib/opac/webapp/templates/admin/index.html:36
-#: build/lib/opac/webapp/templates/admin/index.html:56
-#: build/lib/opac/webapp/templates/admin/index.html:75
-#: build/lib/opac/webapp/templates/admin/index.html:85
-#: build/lib/opac/webapp/templates/admin/index.html:95
 #: opac/webapp/templates/admin/index.html:16
 #: opac/webapp/templates/admin/index.html:36
 #: opac/webapp/templates/admin/index.html:56
@@ -1288,78 +1095,58 @@ msgstr "Publicados"
 msgid "Total"
 msgstr "Total"
 
-#: build/lib/opac/webapp/templates/admin/index.html:32
 #: opac/webapp/templates/admin/index.html:32
 msgid "Fascícluos"
 msgstr "Fascículos"
 
-#: build/lib/opac/webapp/templates/admin/index.html:52
 #: opac/webapp/templates/admin/index.html:52
 msgid "Artigos"
 msgstr "Artículos"
 
-#: build/lib/opac/webapp/templates/admin/index.html:72
 #: opac/webapp/templates/admin/index.html:72
 msgid "News"
 msgstr "News"
 
-#: build/lib/opac/webapp/templates/admin/index.html:82
 #: opac/webapp/templates/admin/index.html:82
 msgid "Sponsors"
 msgstr "Patrocinadores"
 
-#: build/lib/opac/webapp/templates/admin/index.html:92
 #: opac/webapp/templates/admin/index.html:92
 msgid "Press Releases"
 msgstr "Comunicado de prensa "
 
-#: build/lib/opac/webapp/templates/admin/auth/reset.html:9
-#: build/lib/opac/webapp/templates/admin/auth/reset_with_token.html:9
-#: build/lib/opac/webapp/templates/admin/opac_base.html:13
 #: opac/webapp/templates/admin/auth/reset.html:9
 #: opac/webapp/templates/admin/auth/reset_with_token.html:9
 #: opac/webapp/templates/admin/opac_base.html:13
 msgid "Recuperar a senha"
 msgstr "Recuperar contraseña"
 
-#: build/lib/opac/webapp/templates/admin/opac_base.html:14
 #: opac/webapp/templates/admin/opac_base.html:14
 msgid "Terminar sessão"
 msgstr "Cerrar sesión"
 
-#: build/lib/opac/webapp/templates/admin/auth/login.html:11
-#: build/lib/opac/webapp/templates/admin/auth/login.html:20
-#: build/lib/opac/webapp/templates/admin/opac_base.html:18
 #: opac/webapp/templates/admin/auth/login.html:11
 #: opac/webapp/templates/admin/auth/login.html:20
 #: opac/webapp/templates/admin/opac_base.html:18
 msgid "Iniciar sessão"
 msgstr "Inicial sesión"
 
-#: build/lib/opac/webapp/templates/admin/audit_log/fields_data_table.html:4
 #: opac/webapp/templates/admin/audit_log/fields_data_table.html:4
 msgid "Campo: "
 msgstr ""
 
-#: build/lib/opac/webapp/templates/admin/audit_log/fields_data_table.html:5
 #: opac/webapp/templates/admin/audit_log/fields_data_table.html:5
 msgid "Valor anterior: "
 msgstr ""
 
-#: build/lib/opac/webapp/templates/admin/audit_log/fields_data_table.html:6
 #: opac/webapp/templates/admin/audit_log/fields_data_table.html:6
 msgid "Valor novo: "
 msgstr ""
 
-#: build/lib/opac/webapp/templates/admin/auth/login.html:13
 #: opac/webapp/templates/admin/auth/login.html:13
 msgid "Você já iniciou sessão!"
 msgstr "Usted ya inició sesión!"
 
-#: build/lib/opac/webapp/templates/admin/auth/login.html:24
-#: build/lib/opac/webapp/templates/admin/auth/reset.html:13
-#: build/lib/opac/webapp/templates/admin/auth/reset_with_token.html:13
-#: build/lib/opac/webapp/templates/includes/error_form.html:60
 #: opac/webapp/templates/admin/auth/login.html:24
 #: opac/webapp/templates/admin/auth/reset.html:13
 #: opac/webapp/templates/admin/auth/reset_with_token.html:13
@@ -1367,17 +1154,14 @@ msgstr "Usted ya inició sesión!"
 msgid "Enviar"
 msgstr "Enviar"
 
-#: build/lib/opac/webapp/templates/admin/auth/login.html:28
 #: opac/webapp/templates/admin/auth/login.html:28
 msgid "Esqueci a senha?"
 msgstr "Olvidé mi contraseña?"
 
-#: build/lib/opac/webapp/templates/admin/auth/unconfirm_email.html:7
 #: opac/webapp/templates/admin/auth/unconfirm_email.html:7
 msgid "Email não confirmado!"
 msgstr "Email no confirmado!"
 
-#: build/lib/opac/webapp/templates/admin/auth/unconfirm_email.html:9
 #: opac/webapp/templates/admin/auth/unconfirm_email.html:9
 msgid ""
 "Você <strong>deve</strong> confirmar seu email.<br>\n"
@@ -1388,7 +1172,6 @@ msgstr ""
 "            <strong>Por favor entre en contacto con el "
 "administrador.</strong>"
 
-#: build/lib/opac/webapp/templates/admin/pages/edit.html:7
 #: opac/webapp/templates/admin/pages/edit.html:7
 msgid ""
 "<strong>Atenção:</strong> ao selecionar um <strong>periódico</strong> "
@@ -1401,11 +1184,6 @@ msgstr ""
 "caso contrario será una página de la colección, verifique las páginas de "
 "la colección em <em>Acerca de SciELO</em>. "
 
-#: build/lib/opac/webapp/templates/article/includes/alternative_header.html:7
-#: build/lib/opac/webapp/templates/collection/includes/header.html:7
-#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:7
-#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:7
-#: build/lib/opac/webapp/templates/journal/includes/header.html:8
 #: opac/webapp/templates/article/includes/alternative_header.html:7
 #: opac/webapp/templates/collection/includes/header.html:7
 #: opac/webapp/templates/issue/includes/alternative_header.html:7
@@ -1414,10 +1192,6 @@ msgstr ""
 msgid "Abrir menu"
 msgstr "Abrir menú"
 
-#: build/lib/opac/webapp/templates/article/includes/alternative_header.html:9
-#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:9
-#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:9
-#: build/lib/opac/webapp/templates/journal/includes/header.html:10
 #: opac/webapp/templates/article/includes/alternative_header.html:9
 #: opac/webapp/templates/issue/includes/alternative_header.html:9
 #: opac/webapp/templates/journal/includes/alternative_header.html:9
@@ -1425,11 +1199,6 @@ msgstr "Abrir menú"
 msgid "Ir para a homepage da coleção: "
 msgstr "Ir a la página de inicio de la colección:"
 
-#: build/lib/opac/webapp/templates/article/includes/alternative_header.html:42
-#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:7
-#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:121
-#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:117
-#: build/lib/opac/webapp/templates/journal/includes/header.html:118
 #: opac/webapp/templates/article/includes/alternative_header.html:42
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:7
 #: opac/webapp/templates/issue/includes/alternative_header.html:121
@@ -1438,11 +1207,6 @@ msgstr "Ir a la página de inicio de la colección:"
 msgid "Submissão de manuscritos"
 msgstr "Envío de manuscritos"
 
-#: build/lib/opac/webapp/templates/article/includes/alternative_header.html:48
-#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:16
-#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:127
-#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:123
-#: build/lib/opac/webapp/templates/journal/includes/header.html:124
 #: opac/webapp/templates/article/includes/alternative_header.html:48
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:16
 #: opac/webapp/templates/issue/includes/alternative_header.html:127
@@ -1451,11 +1215,6 @@ msgstr "Envío de manuscritos"
 msgid "Sobre o periódico"
 msgstr "Acerca de la revista"
 
-#: build/lib/opac/webapp/templates/article/includes/alternative_header.html:53
-#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:10
-#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:132
-#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:128
-#: build/lib/opac/webapp/templates/journal/includes/header.html:129
 #: opac/webapp/templates/article/includes/alternative_header.html:53
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:10
 #: opac/webapp/templates/issue/includes/alternative_header.html:132
@@ -1464,11 +1223,6 @@ msgstr "Acerca de la revista"
 msgid "Corpo Editorial"
 msgstr "Cuerpo Editorial"
 
-#: build/lib/opac/webapp/templates/article/includes/alternative_header.html:58
-#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:13
-#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:137
-#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:133
-#: build/lib/opac/webapp/templates/journal/includes/header.html:134
 #: opac/webapp/templates/article/includes/alternative_header.html:58
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:13
 #: opac/webapp/templates/issue/includes/alternative_header.html:137
@@ -1477,11 +1231,6 @@ msgstr "Cuerpo Editorial"
 msgid "Instruções aos autores"
 msgstr "Instrucciones a los autores"
 
-#: build/lib/opac/webapp/templates/article/includes/alternative_header.html:63
-#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:19
-#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:142
-#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:138
-#: build/lib/opac/webapp/templates/journal/includes/header.html:140
 #: opac/webapp/templates/article/includes/alternative_header.html:63
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:19
 #: opac/webapp/templates/issue/includes/alternative_header.html:142
@@ -1490,81 +1239,56 @@ msgstr "Instrucciones a los autores"
 msgid "Contato"
 msgstr "Contacto"
 
-#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:2
-#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:60
 #: opac/webapp/templates/article/includes/floating_menu.html:2
 #: opac/webapp/templates/article/includes/floating_menu.html:60
 msgid "Ir para o topo"
 msgstr "Ir para arriba"
 
-#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:6
-#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:65
 #: opac/webapp/templates/article/includes/floating_menu.html:6
 #: opac/webapp/templates/article/includes/floating_menu.html:65
 msgid "PDFs"
 msgstr "PDFs"
 
-#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:26
-#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:77
 #: opac/webapp/templates/article/includes/floating_menu.html:26
 #: opac/webapp/templates/article/includes/floating_menu.html:77
 msgid "Figuras e tabelas"
 msgstr "Figuras y tablas"
 
-#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:32
-#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:83
 #: opac/webapp/templates/article/includes/floating_menu.html:32
 #: opac/webapp/templates/article/includes/floating_menu.html:83
 msgid "Versões e traduções"
 msgstr "Versiones y traducciones"
 
-#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:37
-#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:88
 #: opac/webapp/templates/article/includes/floating_menu.html:37
 #: opac/webapp/templates/article/includes/floating_menu.html:88
 msgid "Como citar este artigo"
 msgstr "Como citar este artículo"
 
-#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:42
-#: build/lib/opac/webapp/templates/article/includes/modal/related_article.html:9
 #: opac/webapp/templates/article/includes/floating_menu.html:42
 #: opac/webapp/templates/article/includes/modal/related_article.html:9
 msgid "Artigos relacionados"
 msgstr "Artículos relacionados"
 
-#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:93
 #: opac/webapp/templates/article/includes/floating_menu.html:93
 msgid "Artigos e similares"
 msgstr "Artículos y similares"
 
-#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:9
 #: opac/webapp/templates/article/includes/levelMenu.html:9
 msgid "home do periodico"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:17
-#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:70
-#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:123
 #: opac/webapp/templates/article/includes/levelMenu.html:17
 #: opac/webapp/templates/article/includes/levelMenu.html:70
 #: opac/webapp/templates/article/includes/levelMenu.html:123
 msgid "sumário"
 msgstr "tabla de contenidos"
 
-#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:30
-#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:75
-#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:71
 #: opac/webapp/templates/article/includes/levelMenu.html:30
 #: opac/webapp/templates/issue/includes/alternative_header.html:75
 #: opac/webapp/templates/journal/includes/alternative_header.html:71
 msgid "anterior"
 msgstr "anterior"
 
-#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:35
-#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:88
-#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:141
-#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:82
-#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:78
 #: opac/webapp/templates/article/includes/levelMenu.html:35
 #: opac/webapp/templates/article/includes/levelMenu.html:88
 #: opac/webapp/templates/article/includes/levelMenu.html:141
@@ -1573,15 +1297,10 @@ msgstr "anterior"
 msgid "atual"
 msgstr "actual"
 
-#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:48
 #: opac/webapp/templates/article/includes/levelMenu.html:48
 msgid "seguinte"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:193
-#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:219
-#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:264
-#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:290
 #: opac/webapp/templates/article/includes/levelMenu.html:193
 #: opac/webapp/templates/article/includes/levelMenu.html:219
 #: opac/webapp/templates/article/includes/levelMenu.html:264
@@ -1589,10 +1308,6 @@ msgstr ""
 msgid "Download PDF (Espanhol)"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:195
-#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:221
-#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:266
-#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:292
 #: opac/webapp/templates/article/includes/levelMenu.html:195
 #: opac/webapp/templates/article/includes/levelMenu.html:221
 #: opac/webapp/templates/article/includes/levelMenu.html:266
@@ -1600,10 +1315,6 @@ msgstr ""
 msgid "Download PDF (Inglês)"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:197
-#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:223
-#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:268
-#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:294
 #: opac/webapp/templates/article/includes/levelMenu.html:197
 #: opac/webapp/templates/article/includes/levelMenu.html:223
 #: opac/webapp/templates/article/includes/levelMenu.html:268
@@ -1611,13 +1322,6 @@ msgstr ""
 msgid "Download PDF (Português)"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:310
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu.html:38
-#: build/lib/opac/webapp/templates/collection/includes/list_journals_section_title.html:14
-#: build/lib/opac/webapp/templates/issue/grid.html:14
-#: build/lib/opac/webapp/templates/issue/toc.html:13
-#: build/lib/opac/webapp/templates/journal/about.html:16
-#: build/lib/opac/webapp/templates/journal/detail.html:11
 #: opac/webapp/templates/article/includes/levelMenu.html:310
 #: opac/webapp/templates/collection/includes/levelMenu.html:38
 #: opac/webapp/templates/collection/includes/list_journals_section_title.html:14
@@ -1628,11 +1332,6 @@ msgstr ""
 msgid "Compartilhe"
 msgstr "Compartir"
 
-#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:311
-#: build/lib/opac/webapp/templates/collection/includes/list_journals_section_title.html:16
-#: build/lib/opac/webapp/templates/issue/toc.html:14
-#: build/lib/opac/webapp/templates/journal/about.html:17
-#: build/lib/opac/webapp/templates/journal/detail.html:12
 #: opac/webapp/templates/article/includes/levelMenu.html:311
 #: opac/webapp/templates/collection/includes/list_journals_section_title.html:16
 #: opac/webapp/templates/issue/toc.html:14
@@ -1641,11 +1340,6 @@ msgstr "Compartir"
 msgid "Enviar link por e-mail"
 msgstr "Enviar vínculo por e-mail"
 
-#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:314
-#: build/lib/opac/webapp/templates/collection/includes/list_journals_section_title.html:19
-#: build/lib/opac/webapp/templates/issue/toc.html:15
-#: build/lib/opac/webapp/templates/journal/about.html:18
-#: build/lib/opac/webapp/templates/journal/detail.html:13
 #: opac/webapp/templates/article/includes/levelMenu.html:314
 #: opac/webapp/templates/collection/includes/list_journals_section_title.html:19
 #: opac/webapp/templates/issue/toc.html:15
@@ -1654,11 +1348,6 @@ msgstr "Enviar vínculo por e-mail"
 msgid "Compartilhar no Facebook"
 msgstr "Compartir en Facebook"
 
-#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:317
-#: build/lib/opac/webapp/templates/collection/includes/list_journals_section_title.html:22
-#: build/lib/opac/webapp/templates/issue/toc.html:16
-#: build/lib/opac/webapp/templates/journal/about.html:19
-#: build/lib/opac/webapp/templates/journal/detail.html:14
 #: opac/webapp/templates/article/includes/levelMenu.html:317
 #: opac/webapp/templates/collection/includes/list_journals_section_title.html:22
 #: opac/webapp/templates/issue/toc.html:16
@@ -1667,18 +1356,6 @@ msgstr "Compartir en Facebook"
 msgid "Compartilhar no Twitter"
 msgstr "Compartir en Twitter"
 
-#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:320
-#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:325
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu.html:46
-#: build/lib/opac/webapp/templates/collection/includes/list_journals_section_title.html:25
-#: build/lib/opac/webapp/templates/collection/includes/list_journals_section_title.html:30
-#: build/lib/opac/webapp/templates/issue/grid.html:20
-#: build/lib/opac/webapp/templates/issue/toc.html:17
-#: build/lib/opac/webapp/templates/issue/toc.html:19
-#: build/lib/opac/webapp/templates/journal/about.html:20
-#: build/lib/opac/webapp/templates/journal/about.html:22
-#: build/lib/opac/webapp/templates/journal/detail.html:15
-#: build/lib/opac/webapp/templates/journal/detail.html:17
 #: opac/webapp/templates/article/includes/levelMenu.html:320
 #: opac/webapp/templates/article/includes/levelMenu.html:325
 #: opac/webapp/templates/collection/includes/levelMenu.html:46
@@ -1694,24 +1371,16 @@ msgstr "Compartir en Twitter"
 msgid "Outras redes sociais"
 msgstr "Otras redes sociales"
 
-#: build/lib/opac/webapp/templates/article/includes/recent_articles_row.html:6
-#: build/lib/opac/webapp/templates/issue/toc.html:149
 #: opac/webapp/templates/article/includes/recent_articles_row.html:6
 #: opac/webapp/templates/issue/toc.html:149
 msgid "Documento sem título"
 msgstr "Documento sin título"
 
-#: build/lib/opac/webapp/templates/article/includes/recent_articles_row.html:13
-#: build/lib/opac/webapp/templates/news/includes/journal_news_row.html:14
 #: opac/webapp/templates/article/includes/recent_articles_row.html:13
 #: opac/webapp/templates/news/includes/journal_news_row.html:14
 msgid "Continue lendo"
 msgstr "Continúe leyendo"
 
-#: build/lib/opac/webapp/templates/article/includes/modal/download.html:6
-#: build/lib/opac/webapp/templates/article/includes/modal/related_article.html:7
-#: build/lib/opac/webapp/templates/email/email_form.html:7
-#: build/lib/opac/webapp/templates/includes/metric_modal.html:6
 #: opac/webapp/templates/article/includes/modal/download.html:6
 #: opac/webapp/templates/article/includes/modal/related_article.html:7
 #: opac/webapp/templates/email/email_form.html:7
@@ -1719,416 +1388,317 @@ msgstr "Continúe leyendo"
 msgid "Fechar"
 msgstr "Cerrar"
 
-#: build/lib/opac/webapp/templates/article/includes/modal/download.html:8
 #: opac/webapp/templates/article/includes/modal/download.html:8
 msgid "Versão para download de PDF"
 msgstr "Versión para descarga de PDF"
 
-#: build/lib/opac/webapp/templates/article/includes/modal/translate_version.html:6
 #: opac/webapp/templates/article/includes/modal/translate_version.html:6
 msgid "Versões e tradução automática"
 msgstr "Versiones y traducción automática"
 
-#: build/lib/opac/webapp/templates/article/includes/modal/translate_version.html:11
 #: opac/webapp/templates/article/includes/modal/translate_version.html:11
 msgid "Versão original do texto"
 msgstr "Versión original del texto"
 
-#: build/lib/opac/webapp/templates/collection/about.html:23
-#: build/lib/opac/webapp/templates/collection/pages.html:21
 #: opac/webapp/templates/collection/about.html:23
-#: opac/webapp/templates/collection/pages.html:21
 #, python-format
 msgid " %(page)s "
 msgstr " %(page)s"
 
-#: build/lib/opac/webapp/templates/collection/about.html:38
-#: build/lib/opac/webapp/templates/collection/pages.html:36
 #: opac/webapp/templates/collection/about.html:38
-#: opac/webapp/templates/collection/pages.html:36
 msgid " Conteúdo não cadastrado "
 msgstr "Contenido no registrado"
 
-#: build/lib/opac/webapp/templates/collection/index.html:17
 #: opac/webapp/templates/collection/index.html:17
 msgid "em números | Métricas"
 msgstr "en números | Métricas"
 
-#: build/lib/opac/webapp/templates/collection/index.html:27
 #: opac/webapp/templates/collection/index.html:27
 msgid "períodicos"
 msgstr "revistas"
 
-#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:31
-#: build/lib/opac/webapp/templates/collection/index.html:31
-#: build/lib/opac/webapp/templates/collection/list_feed_content.html:7
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:31
 #: opac/webapp/templates/collection/index.html:31
 #: opac/webapp/templates/collection/list_feed_content.html:7
 msgid "números"
 msgstr "números"
 
-#: build/lib/opac/webapp/templates/collection/index.html:35
-#: build/lib/opac/webapp/templates/issue/grid.html:68
 #: opac/webapp/templates/collection/index.html:35
 #: opac/webapp/templates/issue/grid.html:68
 msgid "artigos"
 msgstr "artículos"
 
-#: build/lib/opac/webapp/templates/collection/index.html:39
 #: opac/webapp/templates/collection/index.html:39
 msgid "referências"
 msgstr "referencias"
 
-#: build/lib/opac/webapp/templates/collection/index.html:45
 #: opac/webapp/templates/collection/index.html:45
 msgid "Downloads"
 msgstr "Descargas"
 
-#: build/lib/opac/webapp/templates/collection/index.html:48
 #: opac/webapp/templates/collection/index.html:48
 msgid "Citações"
 msgstr "Citaciones"
 
-#: build/lib/opac/webapp/templates/collection/index.html:51
 #: opac/webapp/templates/collection/index.html:51
 msgid "Outros indicadores"
 msgstr "Otros indicadores"
 
-#: build/lib/opac/webapp/templates/collection/index.html:62
-#: build/lib/opac/webapp/templates/collection/list_journal.html:3
 #: opac/webapp/templates/collection/index.html:62
 #: opac/webapp/templates/collection/list_journal.html:3
 msgid "Lista de periódicos"
 msgstr "Listado de revistas"
 
-#: build/lib/opac/webapp/templates/collection/index.html:66
-#: build/lib/opac/webapp/templates/collection/list_journal.html:21
 #: opac/webapp/templates/collection/index.html:66
 #: opac/webapp/templates/collection/list_journal.html:21
 msgid "Alfabética"
 msgstr "Alfabética"
 
-#: build/lib/opac/webapp/templates/collection/index.html:69
-#: build/lib/opac/webapp/templates/collection/list_journal.html:24
 #: opac/webapp/templates/collection/index.html:69
 #: opac/webapp/templates/collection/list_journal.html:24
 msgid "Temática"
 msgstr "Temática"
 
-#: build/lib/opac/webapp/templates/collection/index.html:77
 #: opac/webapp/templates/collection/index.html:77
 msgid "Busca por periódicos"
 msgstr "Búsqueda por periódicos"
 
-#: build/lib/opac/webapp/templates/collection/index.html:105
 #: opac/webapp/templates/collection/index.html:105
 msgid "Números <span>mais recentes</span>"
 msgstr "Números <span>más recientes</span>"
 
-#: build/lib/opac/webapp/templates/collection/index.html:149
 #: opac/webapp/templates/collection/index.html:149
 msgid "em perspectiva"
 msgstr "en perspectiva"
 
-#: build/lib/opac/webapp/templates/collection/list_feed_content.html:1
 #: opac/webapp/templates/collection/list_feed_content.html:1
 msgid "Último número"
 msgstr "último número"
 
-#: build/lib/opac/webapp/templates/collection/list_feed_content.html:4
 #: opac/webapp/templates/collection/list_feed_content.html:4
 msgid "Nº"
 msgstr "Nº"
 
-#: build/lib/opac/webapp/templates/collection/list_feed_content.html:6
 #: opac/webapp/templates/collection/list_feed_content.html:6
 msgid "descontinuado"
 msgstr "discontinuado"
 
-#: build/lib/opac/webapp/templates/collection/list_feed_content.html:7
 #: opac/webapp/templates/collection/list_feed_content.html:7
 msgid "de"
 msgstr "de"
 
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu.html:11
-#: build/lib/opac/webapp/templates/collection/list_journal.html:16
 #: opac/webapp/templates/collection/includes/levelMenu.html:11
 #: opac/webapp/templates/collection/list_journal.html:16
 msgid "Home"
 msgstr "Inicio"
 
-#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_grouper_table_container.html:14
-#: build/lib/opac/webapp/templates/collection/list_journal.html:52
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_grouper_table_container.html:14
 #: opac/webapp/templates/collection/list_journal.html:52
 msgid "download da lista"
 msgstr "descarga de la lista"
 
-#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_grouper_table_container.html:15
-#: build/lib/opac/webapp/templates/collection/list_journal.html:53
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_grouper_table_container.html:15
 #: opac/webapp/templates/collection/list_journal.html:53
 msgid "Lista em arquivo para Excel"
 msgstr "Lista en archivo para Excel"
 
-#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_grouper_table_container.html:18
-#: build/lib/opac/webapp/templates/collection/list_journal.html:56
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_grouper_table_container.html:18
 #: opac/webapp/templates/collection/list_journal.html:56
 msgid "Lista em arquivo CSV"
 msgstr "Lista en archivo CSV"
 
-#: build/lib/opac/webapp/templates/collection/list_journal.html:80
-#: build/lib/opac/webapp/templates/collection/list_journal.html:84
 #: opac/webapp/templates/collection/list_journal.html:80
 #: opac/webapp/templates/collection/list_journal.html:84
 msgid "Grandes áreas do conhecimento"
 msgstr "Grandes áreas del conocimiento"
 
-#: build/lib/opac/webapp/templates/collection/list_journal.html:85
 #: opac/webapp/templates/collection/list_journal.html:85
 msgid "Áreas temáticas do Web of Science"
 msgstr "Áreas temáticas de Web of Science"
 
-#: build/lib/opac/webapp/templates/collection/list_journal.html:222
 #: opac/webapp/templates/collection/list_journal.html:222
 msgid "grandes áreas"
 msgstr "grandes áreas"
 
-#: build/lib/opac/webapp/templates/collection/list_journal.html:236
 #: opac/webapp/templates/collection/list_journal.html:236
 msgid "áreas WOS"
 msgstr "áreas WOS"
 
-#: build/lib/opac/webapp/templates/collection/list_journal.html:248
 #: opac/webapp/templates/collection/list_journal.html:248
 msgid "Editoras"
 msgstr "Editoriales"
 
-#: build/lib/opac/webapp/templates/collection/list_journal.html:249
 #: opac/webapp/templates/collection/list_journal.html:249
 msgid "editoras"
 msgstr "editoriales"
 
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:7
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:7
 msgid "Sobre o"
 msgstr "Sobre el"
 
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:19
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:62
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:19
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:62
 msgid "Entre uma ou mais palavras"
 msgstr "Ingrese una o más palabras"
 
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:24
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:67
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:24
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:67
 msgid "Todos os índices"
 msgstr "Todos los índices"
 
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:26
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:69
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:26
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:69
 msgid "Autor"
 msgstr "Autor"
 
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:38
-#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:95
-#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:91
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:38
 #: opac/webapp/templates/issue/includes/alternative_header.html:95
 #: opac/webapp/templates/journal/includes/alternative_header.html:91
 msgid "Buscar"
 msgstr "Buscar"
 
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:44
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:44
 msgid "Adicionar outro campo"
 msgstr "Agregar otro campo"
 
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:49
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:49
 msgid "Apagar campo"
 msgstr "Remover campo"
 
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:63
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:63
 msgid "Limpar expressão"
 msgstr "Borrar expresión"
 
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:92
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:92
 msgid "Sem resultados"
 msgstr "Sin resultados"
 
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:96
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:96
 msgid "Não foram encontrados documentos para sua pesquisa"
 msgstr "No fueron encontrados documentos para su búsqueda"
 
-#: build/lib/opac/webapp/templates/collection/includes/list_journals_search_input.html:5
 #: opac/webapp/templates/collection/includes/list_journals_search_input.html:5
 msgid "Todos"
 msgstr "Todos"
 
-#: build/lib/opac/webapp/templates/collection/includes/list_journals_search_input.html:9
 #: opac/webapp/templates/collection/includes/list_journals_search_input.html:9
 msgid "Periódicos ativos"
 msgstr "Revistas activas"
 
-#: build/lib/opac/webapp/templates/collection/includes/list_journals_search_input.html:13
 #: opac/webapp/templates/collection/includes/list_journals_search_input.html:13
 msgid "Periódicos descontinuados"
 msgstr "Revistas discontinuadas"
 
-#: build/lib/opac/webapp/templates/collection/includes/list_journals_search_input.html:24
 #: opac/webapp/templates/collection/includes/list_journals_search_input.html:24
 msgid "Digite uma ou mais palavras para filtrar a lista"
 msgstr "Ingrese una o más palabras para filtrar en la lista"
 
-#: build/lib/opac/webapp/templates/collection/includes/nav.html:22
-#: build/lib/opac/webapp/templates/collection/includes/nav.html:64
 #: opac/webapp/templates/collection/includes/nav.html:22
 #: opac/webapp/templates/collection/includes/nav.html:64
 msgid "Busca"
 msgstr "Buscar"
 
-#: build/lib/opac/webapp/templates/collection/includes/nav.html:32
 #: opac/webapp/templates/collection/includes/nav.html:32
 msgid "Sobre:"
 msgstr "Acerca de:"
 
-#: build/lib/opac/webapp/templates/collection/includes/nav.html:44
 #: opac/webapp/templates/collection/includes/nav.html:44
 msgid "SciELO.org - Rede SciELO"
 msgstr "SciELO.org - Rede SciELO"
 
-#: build/lib/opac/webapp/templates/collection/includes/nav.html:95
 #: opac/webapp/templates/collection/includes/nav.html:95
 msgid "Blog SciELO em Perspectiva"
 msgstr "Blog SciELO en Perspectiva"
 
-#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_empty.html:3
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_empty.html:3
 msgid "Nenhum periódico encontrado."
 msgstr "Ninguna revista encontrada."
 
-#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_error.html:3
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_error.html:3
 msgid "Ocorreu um erro obtendo a lista de periódicos."
 msgstr "Ocurrió un error obteniendo la lista de revistas."
 
-#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_grouper_table_container.html:10
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_grouper_table_container.html:10
 msgid "periódicos"
 msgstr "revistas"
 
-#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:3
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:3
 msgid "Homepage"
 msgstr "Página de inicio"
 
-#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:25
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:25
 msgid "Título do periódico"
 msgstr "Título de la revista"
 
-#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:29
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:29
 msgid "Grade de número"
 msgstr "Grilla de fascículo"
 
-#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:36
-#: build/lib/opac/webapp/templates/journal/detail.html:89
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:36
 #: opac/webapp/templates/journal/detail.html:89
 msgid "Número mais recente"
 msgstr "Número más reciente"
 
-#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:37
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:37
 msgid "Último"
 msgstr "Último"
 
-#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:45
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:45
 msgid "Continua como "
 msgstr "Sigue como "
 
-#: build/lib/opac/webapp/templates/email/email_form.html:10
 #: opac/webapp/templates/email/email_form.html:10
 msgid "Enviar página por e-mail"
 msgstr "Enviar pagina por e-mail"
 
-#: build/lib/opac/webapp/templates/email/email_form.html:18
-#: build/lib/opac/webapp/templates/includes/error_form.html:26
-#: build/lib/opac/webapp/templates/journal/includes/contact_form.html:20
 #: opac/webapp/templates/email/email_form.html:18
 #: opac/webapp/templates/includes/error_form.html:26
 #: opac/webapp/templates/journal/includes/contact_form.html:20
 msgid "Seu e-mail"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/email/email_form.html:23
 #: opac/webapp/templates/email/email_form.html:23
 msgid "Para"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/email/email_form.html:27
 #: opac/webapp/templates/email/email_form.html:27
 msgid "Utilize ; (ponto e vírgula) para inserir mais emails."
 msgstr ""
 
-#: build/lib/opac/webapp/templates/email/email_form.html:36
 #: opac/webapp/templates/email/email_form.html:36
 msgid "Alterar assunto e comentários"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/email/email_form.html:41
 #: opac/webapp/templates/email/email_form.html:41
 msgid "Assunto"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/email/email_form.html:45
 #: opac/webapp/templates/email/email_form.html:45
 msgid "Comentário"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/email/email_form.html:49
 #: opac/webapp/templates/email/email_form.html:49
 msgid "Remover remetente, assunto e comentários"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/email/email_form.html:75
 #: opac/webapp/templates/email/email_form.html:75
 msgid "Email enviado com sucesso."
 msgstr ""
 
-#: build/lib/opac/webapp/templates/email/email_form.html:76
-#: build/lib/opac/webapp/templates/includes/error_form.html:86
-#: build/lib/opac/webapp/templates/journal/includes/contact_form.html:77
 #: opac/webapp/templates/email/email_form.html:76
 #: opac/webapp/templates/includes/error_form.html:86
 #: opac/webapp/templates/journal/includes/contact_form.html:77
 msgid "Erro ao tentar enviar e-mail, por favor tente mais tarde."
 msgstr ""
 
-#: build/lib/opac/webapp/templates/errors/400.html:7
 #: opac/webapp/templates/errors/400.html:7
 msgid "Ação inválida"
 msgstr "Acción no válida"
 
-#: build/lib/opac/webapp/templates/errors/403.html:7
 #: opac/webapp/templates/errors/403.html:7
 msgid "Acesso não autorizado!"
 msgstr "Acceso no autorizado!"
 
-#: build/lib/opac/webapp/templates/errors/404.html:7
 #: opac/webapp/templates/errors/404.html:7
 msgid ""
 "A URL solicitada não foi encontrada no servidor. Se você digitou a URL "
@@ -2137,7 +1707,6 @@ msgstr ""
 "La URL no fue encontrada en el servidor. Si Ud. la escribió manualmente, "
 "por favor, revise e intente nuevamente."
 
-#: build/lib/opac/webapp/templates/errors/500.html:5
 #: opac/webapp/templates/errors/500.html:5
 msgid ""
 "Erro interno do servidor. Tente novamente mais tarde. Nossos engenheiros "
@@ -2146,368 +1715,302 @@ msgstr ""
 "Error interno del servidor. Intente nuevamente luego. Nuestros ingenieros"
 " fueron notificados."
 
-#: build/lib/opac/webapp/templates/errors/500.html:9
 #: opac/webapp/templates/errors/500.html:9
 msgid "Id. do erro"
 msgstr "Id. del error"
 
-#: build/lib/opac/webapp/templates/errors/base.html:24
 #: opac/webapp/templates/errors/base.html:24
 msgid "Erro"
 msgstr "Error"
 
-#: build/lib/opac/webapp/templates/errors/base.html:27
 #: opac/webapp/templates/errors/base.html:27
 msgid "Qualquer dúvida, por favor entre em contato com o administrador"
 msgstr "En caso de duda, por favor contacte el administrador"
 
-#: build/lib/opac/webapp/templates/includes/error_form.html:5
 #: opac/webapp/templates/includes/error_form.html:5
 msgid " Reportar erro "
 msgstr ""
 
-#: build/lib/opac/webapp/templates/includes/error_form.html:20
-#: build/lib/opac/webapp/templates/journal/includes/contact_form.html:14
 #: opac/webapp/templates/includes/error_form.html:20
 #: opac/webapp/templates/journal/includes/contact_form.html:14
 msgid "Seu Nome"
 msgstr "Su nombre"
 
-#: build/lib/opac/webapp/templates/includes/error_form.html:21
 #: opac/webapp/templates/includes/error_form.html:21
 msgid "Digite seu Nome"
 msgstr "Introduzca su nombre"
 
-#: build/lib/opac/webapp/templates/includes/error_form.html:32
 #: opac/webapp/templates/includes/error_form.html:32
 msgid "Erro referente"
 msgstr "Error de referencia"
 
-#: build/lib/opac/webapp/templates/includes/error_form.html:35
 #: opac/webapp/templates/includes/error_form.html:35
 msgid "ao conteúdo"
 msgstr "al contenido"
 
-#: build/lib/opac/webapp/templates/includes/error_form.html:39
 #: opac/webapp/templates/includes/error_form.html:39
 msgid "à aplicação"
 msgstr "a la aplicación"
 
-#: build/lib/opac/webapp/templates/includes/error_form.html:46
 #: opac/webapp/templates/includes/error_form.html:46
 msgid "Descrição do erro"
 msgstr "Descripción del error"
 
-#: build/lib/opac/webapp/templates/includes/error_form.html:47
 #: opac/webapp/templates/includes/error_form.html:47
 msgid "Digite sua mensagem"
 msgstr "Introduzca su mensaje"
 
-#: build/lib/opac/webapp/templates/includes/error_form.html:49
 #: opac/webapp/templates/includes/error_form.html:49
 msgid "Obs.: Link e título da página são enviados automaticamente"
 msgstr "Nota: El enlace y el título de la página se envían automáticamente"
 
-#: build/lib/opac/webapp/templates/includes/error_form.html:85
 #: opac/webapp/templates/includes/error_form.html:85
 msgid "Email de erro enviado com sucesso."
 msgstr "Correo electrónico de error enviado correctamente."
 
-#: build/lib/opac/webapp/templates/includes/footer.html:36
 #: opac/webapp/templates/includes/footer.html:36
 msgid "Open Access"
 msgstr "Acceso Abierto"
 
-#: build/lib/opac/webapp/templates/includes/footer.html:38
 #: opac/webapp/templates/includes/footer.html:38
 msgid "Leia"
 msgstr "Lea"
 
-#: build/lib/opac/webapp/templates/includes/footer.html:38
 #: opac/webapp/templates/includes/footer.html:38
 msgid "a Declaração de Acesso Aberto"
 msgstr "la Declaración de Acceso abierto"
 
-#: build/lib/opac/webapp/templates/issue/grid.html:4
 #: opac/webapp/templates/issue/grid.html:4
 msgid "Fascículos"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/issue/grid.html:33
 #: opac/webapp/templates/issue/grid.html:33
 msgid "Todos os números"
 msgstr "Todos los números"
 
-#: build/lib/opac/webapp/templates/issue/grid.html:79
 #: opac/webapp/templates/issue/grid.html:79
 msgid "supl."
 msgstr ""
 
-#: build/lib/opac/webapp/templates/issue/grid.html:98
 #: opac/webapp/templates/issue/grid.html:98
 msgid "Nenhum número encontrado para esse periódico"
 msgstr "Ningún fascículo fue encontrado para esta revista"
 
-#: build/lib/opac/webapp/templates/issue/grid.html:101
 #: opac/webapp/templates/issue/grid.html:101
 msgid "Histórico deste periódico na coleção"
 msgstr "Historial de esta revista en la colección"
 
-#: build/lib/opac/webapp/templates/issue/grid.html:105
 #: opac/webapp/templates/issue/grid.html:105
 msgid " admitido na coleção da SciELO"
 msgstr "admitido en la colección de SciELO"
 
-#: build/lib/opac/webapp/templates/issue/toc.html:10
-#: build/lib/opac/webapp/templates/journal/detail.html:8
 #: opac/webapp/templates/issue/toc.html:10
 #: opac/webapp/templates/journal/detail.html:8
 msgid "Imprimir"
 msgstr "Imprimir"
 
-#: build/lib/opac/webapp/templates/issue/toc.html:41
 #: opac/webapp/templates/issue/toc.html:41
 msgid "Editor científico"
 msgstr "Editor científico"
 
-#: build/lib/opac/webapp/templates/issue/toc.html:45
 #: opac/webapp/templates/issue/toc.html:45
 msgid "Editores associados"
 msgstr "Editores asociados"
 
-#: build/lib/opac/webapp/templates/issue/toc.html:52
 #: opac/webapp/templates/issue/toc.html:52
 msgid "Veja toda a equipe editorial"
 msgstr "Vea todo el equipo editorial"
 
-#: build/lib/opac/webapp/templates/issue/toc.html:63
 #: opac/webapp/templates/issue/toc.html:63
 msgid "Expandir/recolher conteúdo"
 msgstr "Expandir/reducir contenido"
 
-#: build/lib/opac/webapp/templates/issue/toc.html:72
-#: build/lib/opac/webapp/templates/journal/detail.html:96
 #: opac/webapp/templates/issue/toc.html:72
 #: opac/webapp/templates/journal/detail.html:96
 msgid "Sumário"
 msgstr "Sumario"
 
-#: build/lib/opac/webapp/templates/issue/toc.html:79
 #: opac/webapp/templates/issue/toc.html:79
 msgid "Ordenar publicações por"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/issue/toc.html:82
 #: opac/webapp/templates/issue/toc.html:82
 msgid "Ordem do fascículo"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/issue/toc.html:83
 #: opac/webapp/templates/issue/toc.html:83
 msgid "Mais novos primeiro"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/issue/toc.html:84
 #: opac/webapp/templates/issue/toc.html:84
 msgid "Mais antigos primeiro"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/issue/toc.html:102
-#: build/lib/opac/webapp/templates/issue/toc.html:104
 #: opac/webapp/templates/issue/toc.html:102
 #: opac/webapp/templates/issue/toc.html:104
 msgid "Todas as seções"
 msgstr "Todas las secciones"
 
-#: build/lib/opac/webapp/templates/issue/toc.html:187
-#: opac/webapp/templates/issue/toc.html:187
+#: opac/webapp/templates/issue/toc.html:182
 msgid "Texto"
 msgstr "Texto"
 
-#: build/lib/opac/webapp/templates/issue/toc.html:214
-#: opac/webapp/templates/issue/toc.html:214
+#: opac/webapp/templates/issue/toc.html:195
+msgid "PDF"
+msgstr ""
+
+#: opac/webapp/templates/issue/toc.html:210
+msgid "ePDF"
+msgstr ""
+
+#: opac/webapp/templates/issue/toc.html:232
 msgid "Resumo em"
 msgstr "Resumen en"
 
-#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:31
-#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:31
 #: opac/webapp/templates/issue/includes/alternative_header.html:31
 #: opac/webapp/templates/journal/includes/alternative_header.html:31
 msgid "Número atual"
 msgstr "Número actual"
 
-#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:51
-#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:47
 #: opac/webapp/templates/issue/includes/alternative_header.html:51
 #: opac/webapp/templates/journal/includes/alternative_header.html:47
 msgid "Homepage do periódico"
 msgstr "Inicio de la revista"
 
-#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:62
-#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:58
 #: opac/webapp/templates/issue/includes/alternative_header.html:62
 #: opac/webapp/templates/journal/includes/alternative_header.html:58
 msgid "Números"
 msgstr "Números"
 
-#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:68
-#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:64
-#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:90
 #: opac/webapp/templates/issue/includes/alternative_header.html:68
 #: opac/webapp/templates/journal/includes/alternative_header.html:64
 #: opac/webapp/templates/journal/includes/levelMenu.html:90
 msgid "todos"
 msgstr "todos"
 
-#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:89
-#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:85
 #: opac/webapp/templates/issue/includes/alternative_header.html:89
 #: opac/webapp/templates/journal/includes/alternative_header.html:85
 msgid "próximo"
 msgstr "próximo"
 
-#: build/lib/opac/webapp/templates/journal/about.html:39
 #: opac/webapp/templates/journal/about.html:39
 msgid "Conteúdo não cadastrado"
 msgstr "Contenido no registrado"
 
-#: build/lib/opac/webapp/templates/journal/about.html:55
-#: build/lib/opac/webapp/templates/journal/includes/contact_footer.html:48
 #: opac/webapp/templates/journal/about.html:55
 #: opac/webapp/templates/journal/includes/contact_footer.html:48
 msgid "Siga este periódico nas redes sociais"
 msgstr "Siga a esta revista en las redes sociales"
 
-#: build/lib/opac/webapp/templates/journal/detail.html:32
+#: opac/webapp/templates/journal/detail.html:9
+#: opac/webapp/templates/journal/includes/contact_footer.html:53
+msgid "RSS do número mais recente do periódico"
+msgstr "RSS del número más reciente de la revista"
+
 #: opac/webapp/templates/journal/detail.html:32
 msgid "Nossa Missão"
 msgstr "Nuestra misión"
 
-#: build/lib/opac/webapp/templates/journal/detail.html:34
 #: opac/webapp/templates/journal/detail.html:34
 msgid "Periódico sem missão cadastrada"
 msgstr "Revista sin misión registrada"
 
-#: build/lib/opac/webapp/templates/journal/detail.html:42
 #: opac/webapp/templates/journal/detail.html:42
 msgid "Métricas deste periódico"
 msgstr "Métricas de esta revista"
 
-#: build/lib/opac/webapp/templates/journal/detail.html:52
 #: opac/webapp/templates/journal/detail.html:52
 msgid "Índice h5"
 msgstr "Índice h5"
 
-#: build/lib/opac/webapp/templates/journal/detail.html:54
-#: build/lib/opac/webapp/templates/journal/detail.html:66
 #: opac/webapp/templates/journal/detail.html:54
 #: opac/webapp/templates/journal/detail.html:66
 msgid "ano"
 msgstr "año"
 
-#: build/lib/opac/webapp/templates/journal/detail.html:58
-#: build/lib/opac/webapp/templates/journal/detail.html:70
 #: opac/webapp/templates/journal/detail.html:58
 #: opac/webapp/templates/journal/detail.html:70
 msgid "Não possui"
 msgstr "No contiene"
 
-#: build/lib/opac/webapp/templates/journal/detail.html:63
 #: opac/webapp/templates/journal/detail.html:63
 msgid "Mediana h5"
 msgstr "Mediana h5"
 
-#: build/lib/opac/webapp/templates/journal/detail.html:86
 #: opac/webapp/templates/journal/detail.html:86
 msgid "Capa do número mais recente"
 msgstr "Tapa del número más reciente"
 
-#: build/lib/opac/webapp/templates/journal/detail.html:138
-#: opac/webapp/templates/journal/detail.html:138
+#: opac/webapp/templates/journal/detail.html:117
+#: opac/webapp/templates/journal/detail.html:119
+msgid "RSS dos Press Releases mais recentes desse periódico"
+msgstr "RSS de los últimos informes de prensa de esta revista"
+
+#: opac/webapp/templates/journal/detail.html:145
 msgid "Artigos mais recentes"
 msgstr "Artículos más recientes"
 
-#: build/lib/opac/webapp/templates/journal/includes/contact_footer.html:57
 #: opac/webapp/templates/journal/includes/contact_footer.html:57
 msgid "Acompanhe os números deste periódico no seu leitor de RSS"
 msgstr "Acompañe los números de esta revista en su lector de RSS"
 
-#: build/lib/opac/webapp/templates/journal/includes/contact_form.html:26
 #: opac/webapp/templates/journal/includes/contact_form.html:26
 msgid "Mensagem"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/journal/includes/contact_form.html:76
 #: opac/webapp/templates/journal/includes/contact_form.html:76
 msgid "Email enviado para "
 msgstr ""
 
-#: build/lib/opac/webapp/templates/journal/includes/contact_form.html:76
 #: opac/webapp/templates/journal/includes/contact_form.html:76
 msgid "com sucesso."
 msgstr ""
 
-#: build/lib/opac/webapp/templates/journal/includes/header.html:42
 #: opac/webapp/templates/journal/includes/header.html:42
 msgid "Publicação de:"
 msgstr "Publicación de:"
 
-#: build/lib/opac/webapp/templates/journal/includes/header.html:47
 #: opac/webapp/templates/journal/includes/header.html:47
 msgid "Área:"
 msgstr "Área:"
 
-#: build/lib/opac/webapp/templates/journal/includes/header.html:51
 #: opac/webapp/templates/journal/includes/header.html:51
 msgid "Multidisciplinar"
 msgstr "Multidisciplinaria"
 
-#: build/lib/opac/webapp/templates/journal/includes/header.html:60
 #: opac/webapp/templates/journal/includes/header.html:60
 msgid "Versão impressa ISSN:"
 msgstr "Versión impresa ISSN:"
 
-#: build/lib/opac/webapp/templates/journal/includes/header.html:67
 #: opac/webapp/templates/journal/includes/header.html:67
 msgid "Versão on-line ISSN:"
 msgstr "Versión on-line ISSN:"
 
-#: build/lib/opac/webapp/templates/journal/includes/header.html:76
 #: opac/webapp/templates/journal/includes/header.html:76
 msgid "Novo título:"
 msgstr "Nuevo titulo:"
 
-#: build/lib/opac/webapp/templates/journal/includes/header.html:93
 #: opac/webapp/templates/journal/includes/header.html:93
 msgid "Título anterior:"
 msgstr "Titulo anterior"
 
-#: build/lib/opac/webapp/templates/journal/includes/header.html:148
 #: opac/webapp/templates/journal/includes/header.html:148
 msgid "Siga-nos"
 msgstr "Síganos"
 
-#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:10
 #: opac/webapp/templates/journal/includes/levelMenu.html:10
 msgid "home do periódico"
 msgstr "página de la revista"
 
-#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:19
 #: opac/webapp/templates/journal/includes/levelMenu.html:19
 msgid "todos os números"
 msgstr "todos los números"
 
-#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:25
-#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:29
 #: opac/webapp/templates/journal/includes/levelMenu.html:25
 #: opac/webapp/templates/journal/includes/levelMenu.html:29
 msgid "número anterior"
 msgstr "número anterior"
 
-#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:36
-#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:40
-#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:107
-#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:111
 #: opac/webapp/templates/journal/includes/levelMenu.html:36
 #: opac/webapp/templates/journal/includes/levelMenu.html:40
 #: opac/webapp/templates/journal/includes/levelMenu.html:107
@@ -2515,24 +2018,16 @@ msgstr "número anterior"
 msgid "número atual"
 msgstr "número actual"
 
-#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:47
-#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:51
 #: opac/webapp/templates/journal/includes/levelMenu.html:47
 #: opac/webapp/templates/journal/includes/levelMenu.html:51
 msgid "número seguinte"
 msgstr "número siguiente"
 
-#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:59
-#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:130
 #: opac/webapp/templates/journal/includes/levelMenu.html:59
 #: opac/webapp/templates/journal/includes/levelMenu.html:130
 msgid "buscar"
 msgstr "buscar"
 
-#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:65
-#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:69
-#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:136
-#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:140
 #: opac/webapp/templates/journal/includes/levelMenu.html:65
 #: opac/webapp/templates/journal/includes/levelMenu.html:69
 #: opac/webapp/templates/journal/includes/levelMenu.html:136
@@ -2540,27 +2035,22 @@ msgstr "buscar"
 msgid "métricas"
 msgstr "métricas"
 
-#: build/lib/opac/webapp/templates/macros/issue.html:5
 #: opac/webapp/templates/macros/issue.html:5
 msgid " número especial "
 msgstr ""
 
-#: build/lib/opac/webapp/templates/macros/issue.html:10
 #: opac/webapp/templates/macros/issue.html:10
 msgid "número especial"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/news/includes/collection_news_row.html:16
 #: opac/webapp/templates/news/includes/collection_news_row.html:16
 msgid "continue lendo"
 msgstr "seguir leyendo"
 
-#: build/lib/opac/webapp/templates/news/includes/issue_last_row.html:15
 #: opac/webapp/templates/news/includes/issue_last_row.html:15
 msgid "Suplemento"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/news/includes/issue_last_row.html:20
 #: opac/webapp/templates/news/includes/issue_last_row.html:20
 msgid "Ver"
 msgstr "Ver"

--- a/opac/webapp/translations/es_ES/LC_MESSAGES/messages.po
+++ b/opac/webapp/translations/es_ES/LC_MESSAGES/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-05-09 17:02-0300\n"
+"POT-Creation-Date: 2019-05-31 21:18+0000\n"
 "PO-Revision-Date: 2016-02-09 09:39-0600\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es_ES\n"
@@ -19,30 +19,13 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.6.0\n"
 
-#: build/lib/opac/tests/test_admin_custom_filters.py:100
-#: build/lib/opac/tests/test_admin_custom_filters.py:114
-#: build/lib/opac/tests/test_admin_custom_filters.py:129
-#: build/lib/opac/tests/test_admin_custom_filters.py:144
-#: build/lib/opac/tests/test_admin_custom_filters.py:158
-#: build/lib/opac/webapp/__init__.py:119
-#: build/lib/opac/webapp/admin/views.py:533
-#: build/lib/opac/webapp/admin/views.py:610
-#: build/lib/opac/webapp/admin/views.py:680
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:28
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:71
-#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_grouper_table_row.html:15
-#: build/lib/opac/webapp/templates/collection/list_journal.html:49
-#: build/lib/opac/webapp/templates/collection/list_journal.html:221
-#: build/lib/opac/webapp/templates/collection/list_journal.html:235
-#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:116
-#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:112
 #: opac/tests/test_admin_custom_filters.py:100
 #: opac/tests/test_admin_custom_filters.py:114
 #: opac/tests/test_admin_custom_filters.py:129
 #: opac/tests/test_admin_custom_filters.py:144
 #: opac/tests/test_admin_custom_filters.py:158 opac/webapp/__init__.py:119
-#: opac/webapp/admin/views.py:533 opac/webapp/admin/views.py:610
-#: opac/webapp/admin/views.py:680
+#: opac/webapp/admin/views.py:534 opac/webapp/admin/views.py:611
+#: opac/webapp/admin/views.py:681
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:28
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:71
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_grouper_table_row.html:15
@@ -54,38 +37,21 @@ msgstr ""
 msgid "Periódico"
 msgstr ""
 
-#: build/lib/opac/tests/test_interface_menu.py:51
 #: opac/tests/test_interface_menu.py:51
 msgid "NOME DA COLEÇÃO!!"
 msgstr ""
 
-#: build/lib/opac/tests/test_interface_menu.py:53
-#: build/lib/opac/tests/test_interface_menu.py:75
-#: build/lib/opac/webapp/templates/collection/includes/nav.html:12
-#: build/lib/opac/webapp/templates/collection/includes/nav.html:54
 #: opac/tests/test_interface_menu.py:53 opac/tests/test_interface_menu.py:75
 #: opac/webapp/templates/collection/includes/nav.html:12
 #: opac/webapp/templates/collection/includes/nav.html:54
 msgid "Lista alfabética de periódicos"
 msgstr ""
 
-#: build/lib/opac/tests/test_interface_menu.py:55
-#: build/lib/opac/webapp/templates/collection/includes/nav.html:17
 #: opac/tests/test_interface_menu.py:55
 #: opac/webapp/templates/collection/includes/nav.html:17
 msgid "Lista temática de periódicos"
 msgstr ""
 
-#: build/lib/opac/tests/test_interface_menu.py:61
-#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:11
-#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:70
-#: build/lib/opac/webapp/templates/collection/includes/nav.html:27
-#: build/lib/opac/webapp/templates/collection/includes/nav.html:69
-#: build/lib/opac/webapp/templates/includes/metric_modal.html:7
-#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:101
-#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:105
-#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:97
-#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:101
 #: opac/tests/test_interface_menu.py:61
 #: opac/webapp/templates/article/includes/floating_menu.html:11
 #: opac/webapp/templates/article/includes/floating_menu.html:70
@@ -99,383 +65,332 @@ msgstr ""
 msgid "Métricas"
 msgstr ""
 
-#: build/lib/opac/tests/test_interface_menu.py:63
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu.html:12
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu.html:29
 #: opac/tests/test_interface_menu.py:63
 #: opac/webapp/templates/collection/includes/levelMenu.html:12
 #: opac/webapp/templates/collection/includes/levelMenu.html:29
 msgid "Sobre o SciELO"
 msgstr ""
 
-#: build/lib/opac/tests/test_interface_menu.py:65
-#: build/lib/opac/tests/test_interface_menu.py:99
-#: build/lib/opac/webapp/templates/collection/includes/nav.html:37
-#: build/lib/opac/webapp/templates/collection/includes/nav.html:84
 #: opac/tests/test_interface_menu.py:65 opac/tests/test_interface_menu.py:99
 #: opac/webapp/templates/collection/includes/nav.html:37
 #: opac/webapp/templates/collection/includes/nav.html:84
 msgid "Contatos"
 msgstr ""
 
-#: build/lib/opac/tests/test_interface_menu.py:67
 #: opac/tests/test_interface_menu.py:67
 msgid "Rede SciELO"
 msgstr ""
 
-#: build/lib/opac/tests/test_interface_menu.py:71
-#: build/lib/opac/webapp/templates/collection/includes/nav.html:49
 #: opac/tests/test_interface_menu.py:71
 #: opac/webapp/templates/collection/includes/nav.html:49
 msgid "Coleções nacionais e temáticas"
 msgstr ""
 
-#: build/lib/opac/tests/test_interface_menu.py:79
-#: build/lib/opac/webapp/templates/collection/includes/nav.html:59
 #: opac/tests/test_interface_menu.py:79
 #: opac/webapp/templates/collection/includes/nav.html:59
 msgid "Lista de periódicos por assunto"
 msgstr ""
 
-#: build/lib/opac/tests/test_interface_menu.py:91
-#: build/lib/opac/webapp/templates/collection/includes/nav.html:74
 #: opac/tests/test_interface_menu.py:91
 #: opac/webapp/templates/collection/includes/nav.html:74
 msgid "Acesso OAI e RSS"
 msgstr ""
 
-#: build/lib/opac/tests/test_interface_menu.py:95
-#: build/lib/opac/webapp/templates/collection/includes/nav.html:79
 #: opac/tests/test_interface_menu.py:95
 #: opac/webapp/templates/collection/includes/nav.html:79
 msgid "Sobre a Rede SciELO"
 msgstr ""
 
-#: build/lib/opac/tests/test_main_errors.py:8 opac/tests/test_main_errors.py:8
+#: opac/tests/test_main_errors.py:8
 msgid "Mensagem de erro explicativo para o usuário"
 msgstr ""
 
-#: build/lib/opac/webapp/__init__.py:118 build/lib/opac/webapp/__init__.py:119
-#: build/lib/opac/webapp/__init__.py:120 build/lib/opac/webapp/__init__.py:121
-#: build/lib/opac/webapp/__init__.py:122 build/lib/opac/webapp/__init__.py:123
 #: opac/webapp/__init__.py:118 opac/webapp/__init__.py:119
 #: opac/webapp/__init__.py:120 opac/webapp/__init__.py:121
 #: opac/webapp/__init__.py:122 opac/webapp/__init__.py:123
 msgid "Catálogo"
 msgstr ""
 
-#: build/lib/opac/webapp/__init__.py:118
-#: build/lib/opac/webapp/admin/views.py:452 opac/webapp/__init__.py:118
-#: opac/webapp/admin/views.py:452
+#: opac/webapp/__init__.py:118 opac/webapp/admin/views.py:453
 msgid "Coleção"
 msgstr ""
 
-#: build/lib/opac/webapp/__init__.py:120
-#: build/lib/opac/webapp/admin/views.py:537
-#: build/lib/opac/webapp/admin/views.py:609
-#: build/lib/opac/webapp/templates/issue/grid.html:41
-#: build/lib/opac/webapp/templates/news/includes/issue_last_row.html:11
-#: opac/webapp/__init__.py:120 opac/webapp/admin/views.py:537
-#: opac/webapp/admin/views.py:609 opac/webapp/templates/issue/grid.html:41
+#: opac/webapp/__init__.py:120 opac/webapp/admin/views.py:538
+#: opac/webapp/admin/views.py:610 opac/webapp/templates/issue/grid.html:41
 #: opac/webapp/templates/news/includes/issue_last_row.html:11
 msgid "Número"
 msgstr ""
 
-#: build/lib/opac/webapp/__init__.py:121 opac/webapp/__init__.py:121
+#: opac/webapp/__init__.py:121
 msgid "Artigo"
 msgstr ""
 
-#: build/lib/opac/webapp/__init__.py:122
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:27
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:70
 #: opac/webapp/__init__.py:122
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:27
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:70
 msgid "Financiador"
 msgstr ""
 
-#: build/lib/opac/webapp/__init__.py:123 opac/webapp/__init__.py:123
+#: opac/webapp/__init__.py:123
 msgid "Press Release"
 msgstr ""
 
-#: build/lib/opac/webapp/__init__.py:124
-#: build/lib/opac/webapp/templates/journal/detail.html:160
-#: opac/webapp/__init__.py:124 opac/webapp/templates/journal/detail.html:160
+#: opac/webapp/__init__.py:124 opac/webapp/templates/journal/detail.html:167
 msgid "Notícias"
 msgstr ""
 
-#: build/lib/opac/webapp/__init__.py:125 build/lib/opac/webapp/__init__.py:126
 #: opac/webapp/__init__.py:125 opac/webapp/__init__.py:126
 msgid "Ativos"
 msgstr ""
 
-#: build/lib/opac/webapp/__init__.py:127 opac/webapp/__init__.py:127
+#: opac/webapp/__init__.py:127
 msgid "Páginas"
 msgstr ""
 
-#: build/lib/opac/webapp/__init__.py:128 build/lib/opac/webapp/__init__.py:129
 #: opac/webapp/__init__.py:128 opac/webapp/__init__.py:129
 msgid "Gestão"
 msgstr ""
 
-#: build/lib/opac/webapp/__init__.py:128 opac/webapp/__init__.py:128
+#: opac/webapp/__init__.py:128
 msgid "Auditoria: Páginas"
 msgstr ""
 
-#: build/lib/opac/webapp/__init__.py:129
-#: build/lib/opac/webapp/admin/views.py:896 opac/webapp/__init__.py:129
-#: opac/webapp/admin/views.py:896
+#: opac/webapp/__init__.py:129 opac/webapp/admin/views.py:897
 msgid "Usuário"
 msgstr ""
 
-#: build/lib/opac/webapp/choices.py:7 opac/webapp/choices.py:7
+#: opac/webapp/choices.py:7
 msgid "Conteúdo temporariamente indisponível"
 msgstr ""
 
-#: build/lib/opac/webapp/choices.py:11 build/lib/opac/webapp/choices.py:23
-#: build/lib/opac/webapp/templates/article/includes/modal/download.html:26
 #: opac/webapp/choices.py:11 opac/webapp/choices.py:23
 #: opac/webapp/templates/article/includes/modal/download.html:26
 msgid "Português"
 msgstr ""
 
-#: build/lib/opac/webapp/choices.py:12 build/lib/opac/webapp/choices.py:24
-#: build/lib/opac/webapp/templates/article/includes/modal/download.html:24
 #: opac/webapp/choices.py:12 opac/webapp/choices.py:24
 #: opac/webapp/templates/article/includes/modal/download.html:24
 msgid "Inglês"
 msgstr ""
 
-#: build/lib/opac/webapp/choices.py:13 build/lib/opac/webapp/choices.py:25
-#: build/lib/opac/webapp/templates/article/includes/modal/download.html:22
 #: opac/webapp/choices.py:13 opac/webapp/choices.py:25
 #: opac/webapp/templates/article/includes/modal/download.html:22
 msgid "Espanhol"
 msgstr ""
 
-#: build/lib/opac/webapp/choices.py:26 opac/webapp/choices.py:26
+#: opac/webapp/choices.py:26
 msgid "Albanês"
 msgstr ""
 
-#: build/lib/opac/webapp/choices.py:27 build/lib/opac/webapp/choices.py:33
 #: opac/webapp/choices.py:27 opac/webapp/choices.py:33
 msgid "Chinês"
 msgstr ""
 
-#: build/lib/opac/webapp/choices.py:28 opac/webapp/choices.py:28
+#: opac/webapp/choices.py:28
 msgid "Romeno"
 msgstr ""
 
-#: build/lib/opac/webapp/choices.py:29 opac/webapp/choices.py:29
+#: opac/webapp/choices.py:29
 msgid "Francês"
 msgstr ""
 
-#: build/lib/opac/webapp/choices.py:30 opac/webapp/choices.py:30
+#: opac/webapp/choices.py:30
 msgid "Italiano"
 msgstr ""
 
-#: build/lib/opac/webapp/choices.py:31 opac/webapp/choices.py:31
+#: opac/webapp/choices.py:31
 msgid "Russo"
 msgstr ""
 
-#: build/lib/opac/webapp/choices.py:32 opac/webapp/choices.py:32
+#: opac/webapp/choices.py:32
 msgid "Árabe"
 msgstr ""
 
-#: build/lib/opac/webapp/choices.py:37 opac/webapp/choices.py:37
+#: opac/webapp/choices.py:37
 msgid "corrente"
 msgstr ""
 
-#: build/lib/opac/webapp/choices.py:38 opac/webapp/choices.py:38
+#: opac/webapp/choices.py:38
 msgid "terminado"
 msgstr ""
 
-#: build/lib/opac/webapp/choices.py:39 opac/webapp/choices.py:39
+#: opac/webapp/choices.py:39
 msgid "indexação interrompida"
 msgstr ""
 
-#: build/lib/opac/webapp/choices.py:40 opac/webapp/choices.py:40
+#: opac/webapp/choices.py:40
 msgid "indexação interrompida pelo Comitê"
 msgstr ""
 
-#: build/lib/opac/webapp/choices.py:41 opac/webapp/choices.py:41
+#: opac/webapp/choices.py:41
 msgid "publicação finalizada"
 msgstr ""
 
-#: build/lib/opac/webapp/choices.py:45 opac/webapp/choices.py:45
+#: opac/webapp/choices.py:45
 msgid "Ciências Agrárias"
 msgstr ""
 
-#: build/lib/opac/webapp/choices.py:46 opac/webapp/choices.py:46
+#: opac/webapp/choices.py:46
 msgid "Ciências Sociais Aplicadas"
 msgstr ""
 
-#: build/lib/opac/webapp/choices.py:47 opac/webapp/choices.py:47
+#: opac/webapp/choices.py:47
 msgid "Ciências Biológicas"
 msgstr ""
 
-#: build/lib/opac/webapp/choices.py:48 opac/webapp/choices.py:48
+#: opac/webapp/choices.py:48
 msgid "Engenharias"
 msgstr ""
 
-#: build/lib/opac/webapp/choices.py:49 opac/webapp/choices.py:49
+#: opac/webapp/choices.py:49
 msgid "Ciências Exatas e da Terra"
 msgstr ""
 
-#: build/lib/opac/webapp/choices.py:50 opac/webapp/choices.py:50
+#: opac/webapp/choices.py:50
 msgid "Ciências da Saúde"
 msgstr ""
 
-#: build/lib/opac/webapp/choices.py:51 opac/webapp/choices.py:51
+#: opac/webapp/choices.py:51
 msgid "Ciências Humanas"
 msgstr ""
 
-#: build/lib/opac/webapp/choices.py:52 build/lib/opac/webapp/choices.py:53
 #: opac/webapp/choices.py:52 opac/webapp/choices.py:53
 msgid "Lingüística, Letras e Artes"
 msgstr ""
 
-#: build/lib/opac/webapp/controllers.py:353 opac/webapp/controllers.py:353
+#: opac/webapp/controllers.py:353
 msgid "Lista Alfabética"
 msgstr ""
 
-#: build/lib/opac/webapp/controllers.py:357 opac/webapp/controllers.py:357
+#: opac/webapp/controllers.py:357
 msgid "Lista Temática"
 msgstr ""
 
-#: build/lib/opac/webapp/controllers.py:361 opac/webapp/controllers.py:361
+#: opac/webapp/controllers.py:361
 msgid "Lista Web of Science"
 msgstr ""
 
-#: build/lib/opac/webapp/controllers.py:365 opac/webapp/controllers.py:365
+#: opac/webapp/controllers.py:365
 msgid "Lista by Institution"
 msgstr ""
 
-#: build/lib/opac/webapp/controllers.py:424 opac/webapp/controllers.py:424
+#: opac/webapp/controllers.py:424
 msgid "Obrigatório um jid."
 msgstr ""
 
-#: build/lib/opac/webapp/controllers.py:440 opac/webapp/controllers.py:440
+#: opac/webapp/controllers.py:440
 msgid "Obrigatório um acronym."
 msgstr ""
 
-#: build/lib/opac/webapp/controllers.py:456 opac/webapp/controllers.py:456
+#: opac/webapp/controllers.py:456
 msgid "Obrigatório um url_seg."
 msgstr ""
 
-#: build/lib/opac/webapp/controllers.py:472 opac/webapp/controllers.py:472
+#: opac/webapp/controllers.py:472
 msgid "Obrigatório um issn."
 msgstr ""
 
-#: build/lib/opac/webapp/controllers.py:487 opac/webapp/controllers.py:487
+#: opac/webapp/controllers.py:487
 msgid "Obrigatório um title."
 msgstr ""
 
-#: build/lib/opac/webapp/controllers.py:525
-#: build/lib/opac/webapp/controllers.py:669
-#: build/lib/opac/webapp/controllers.py:830 opac/webapp/controllers.py:525
-#: opac/webapp/controllers.py:669 opac/webapp/controllers.py:830
+#: opac/webapp/controllers.py:525 opac/webapp/controllers.py:669
+#: opac/webapp/controllers.py:830
 msgid "Obrigatório uma lista de ids."
 msgstr ""
 
-#: build/lib/opac/webapp/controllers.py:631
-#: build/lib/opac/webapp/controllers.py:851 opac/webapp/controllers.py:631
-#: opac/webapp/controllers.py:851
+#: opac/webapp/controllers.py:631 opac/webapp/controllers.py:851
 msgid "Obrigatório um iid."
 msgstr ""
 
-#: build/lib/opac/webapp/controllers.py:688 opac/webapp/controllers.py:688
+#: opac/webapp/controllers.py:688
 msgid "Obrigatório um jacron e issue_label."
 msgstr ""
 
-#: build/lib/opac/webapp/controllers.py:701 opac/webapp/controllers.py:701
+#: opac/webapp/controllers.py:701
 msgid "Obrigatório um PID."
 msgstr ""
 
-#: build/lib/opac/webapp/controllers.py:717 opac/webapp/controllers.py:717
+#: opac/webapp/controllers.py:717
 msgid "Obrigatório um url_seg e url_seg_issue."
 msgstr ""
 
-#: build/lib/opac/webapp/controllers.py:724 opac/webapp/controllers.py:724
+#: opac/webapp/controllers.py:724
 msgid "Obrigatório um assets_code."
 msgstr ""
 
-#: build/lib/opac/webapp/controllers.py:727 opac/webapp/controllers.py:727
+#: opac/webapp/controllers.py:727
 msgid "Obrigatório um journal."
 msgstr ""
 
-#: build/lib/opac/webapp/controllers.py:743 opac/webapp/controllers.py:743
+#: opac/webapp/controllers.py:743
 msgid "Obrigatório um aid."
 msgstr ""
 
-#: build/lib/opac/webapp/controllers.py:757 opac/webapp/controllers.py:757
+#: opac/webapp/controllers.py:757
 msgid "Obrigatório um url_seg_article."
 msgstr ""
 
-#: build/lib/opac/webapp/controllers.py:772 opac/webapp/controllers.py:772
+#: opac/webapp/controllers.py:772
 msgid "Obrigatório um iid and url_seg_article."
 msgstr ""
 
-#: build/lib/opac/webapp/controllers.py:788 opac/webapp/controllers.py:788
+#: opac/webapp/controllers.py:788
 msgid "Obrigatório um jid, url_seg_issue and url_seg_article."
 msgstr ""
 
-#: build/lib/opac/webapp/controllers.py:889 opac/webapp/controllers.py:889
+#: opac/webapp/controllers.py:889
 msgid "Obrigatório um pid."
 msgstr ""
 
-#: build/lib/opac/webapp/controllers.py:902 opac/webapp/controllers.py:902
+#: opac/webapp/controllers.py:902
 msgid "Obrigatório um aop_pid."
 msgstr ""
 
-#: build/lib/opac/webapp/controllers.py:913 opac/webapp/controllers.py:913
+#: opac/webapp/controllers.py:913
 msgid "Parámetro obrigatório: issue_iid."
 msgstr ""
 
-#: build/lib/opac/webapp/controllers.py:961 opac/webapp/controllers.py:961
+#: opac/webapp/controllers.py:961
 msgid "Parâmetro email deve ser uma string"
 msgstr ""
 
-#: build/lib/opac/webapp/controllers.py:972 opac/webapp/controllers.py:972
+#: opac/webapp/controllers.py:972
 msgid "Parâmetro email deve ser uma inteiro"
 msgstr ""
 
-#: build/lib/opac/webapp/controllers.py:984
-#: build/lib/opac/webapp/controllers.py:998 opac/webapp/controllers.py:984
-#: opac/webapp/controllers.py:998
+#: opac/webapp/controllers.py:984 opac/webapp/controllers.py:998
 #, python-format
 msgid "Usuário deve ser do tipo %s"
 msgstr ""
 
-#: build/lib/opac/webapp/controllers.py:1054 opac/webapp/controllers.py:1054
+#: opac/webapp/controllers.py:1054
 msgid "Compartilhamento de link SciELO"
 msgstr ""
 
-#: build/lib/opac/webapp/controllers.py:1055 opac/webapp/controllers.py:1055
+#: opac/webapp/controllers.py:1055
 #, python-format
 msgid "O usuário %s compartilha este link: %s, da SciELO"
 msgstr ""
 
-#: build/lib/opac/webapp/controllers.py:1063
-#: build/lib/opac/webapp/controllers.py:1099
-#: build/lib/opac/webapp/controllers.py:1121 opac/webapp/controllers.py:1063
-#: opac/webapp/controllers.py:1099 opac/webapp/controllers.py:1121
+#: opac/webapp/controllers.py:1063 opac/webapp/controllers.py:1099
+#: opac/webapp/controllers.py:1121
 msgid "Mensagem enviada!"
 msgstr ""
 
-#: build/lib/opac/webapp/controllers.py:1080 opac/webapp/controllers.py:1080
+#: opac/webapp/controllers.py:1080
 msgid "[Erro] Erro informado pelo usuário no site SciELO"
 msgstr ""
 
-#: build/lib/opac/webapp/controllers.py:1083 opac/webapp/controllers.py:1083
+#: opac/webapp/controllers.py:1083
 msgid "aplicação"
 msgstr ""
 
-#: build/lib/opac/webapp/controllers.py:1085 opac/webapp/controllers.py:1085
+#: opac/webapp/controllers.py:1085
 msgid "conteúdo"
 msgstr ""
 
-#: build/lib/opac/webapp/controllers.py:1090 opac/webapp/controllers.py:1090
+#: opac/webapp/controllers.py:1090
 #, python-format
 msgid ""
 "O usuário <b>%s</b> com e-mail: <b>%s</b>, informa que existe um erro na "
@@ -483,463 +398,412 @@ msgid ""
 " %s"
 msgstr ""
 
-#: build/lib/opac/webapp/controllers.py:1111 opac/webapp/controllers.py:1111
+#: opac/webapp/controllers.py:1111
 msgid "Contato de usuário via site SciELO"
 msgstr ""
 
-#: build/lib/opac/webapp/controllers.py:1113 opac/webapp/controllers.py:1113
+#: opac/webapp/controllers.py:1113
 #, python-format
 msgid "O usuário %s, com e-mail: %s, entra em contato com a seguinte mensagem:"
 msgstr ""
 
-#: build/lib/opac/webapp/controllers.py:1145 opac/webapp/controllers.py:1145
+#: opac/webapp/controllers.py:1145
 msgid "Obrigatório um slug_name."
 msgstr ""
 
-#: build/lib/opac/webapp/forms.py:29 opac/webapp/forms.py:29
+#: opac/webapp/forms.py:29
 msgid "Endereço de e-mail inválido."
 msgstr ""
 
-#: build/lib/opac/webapp/admin/forms.py:9
-#: build/lib/opac/webapp/admin/forms.py:21 opac/webapp/admin/forms.py:9
-#: opac/webapp/admin/forms.py:21
+#: opac/webapp/admin/forms.py:9 opac/webapp/admin/forms.py:21
 msgid "Email"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/forms.py:10
-#: build/lib/opac/webapp/admin/forms.py:25 opac/webapp/admin/forms.py:10
-#: opac/webapp/admin/forms.py:25
+#: opac/webapp/admin/forms.py:10 opac/webapp/admin/forms.py:25
 msgid "Senha"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/forms.py:15 opac/webapp/admin/forms.py:15
+#: opac/webapp/admin/forms.py:15
 msgid "Usuário inválido"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/forms.py:17 opac/webapp/admin/forms.py:17
+#: opac/webapp/admin/forms.py:17
 msgid "Senha inválida"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:28 opac/webapp/admin/views.py:28
+#: opac/webapp/admin/views.py:28
 msgid "Tem certeza que quer publicar os itens selecionados?"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:29 opac/webapp/admin/views.py:29
+#: opac/webapp/admin/views.py:29
 msgid "Tem certeza que quer despublicar os itens selecionados?"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:30 opac/webapp/admin/views.py:30
+#: opac/webapp/admin/views.py:30
 msgid "Tem certeza que quer reconstruir os artigos selecionados?"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:31 opac/webapp/admin/views.py:31
+#: opac/webapp/admin/views.py:31
 msgid ""
 "Tem certeza que quer enviar email de confirmação aos usuários "
 "selecionados?"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:91
-#: build/lib/opac/webapp/admin/views.py:104 opac/webapp/admin/views.py:91
-#: opac/webapp/admin/views.py:104
+#: opac/webapp/admin/views.py:91 opac/webapp/admin/views.py:104
 msgid "Usuário não encontrado"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:94 opac/webapp/admin/views.py:94
+#: opac/webapp/admin/views.py:94
 #, python-format
 msgid "Email: %(email)s confirmado com sucesso!"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:110 opac/webapp/admin/views.py:110
+#: opac/webapp/admin/views.py:110
 #, python-format
 msgid "Enviamos as instruções para recuperar a senha para: %(email)s"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:113 opac/webapp/admin/views.py:113
+#: opac/webapp/admin/views.py:113
 #, python-format
 msgid ""
 "Ocorreu um erro no envio das instruções por email para: %(email)s. Erro: "
 "%(error)s"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:139 opac/webapp/admin/views.py:139
+#: opac/webapp/admin/views.py:139
 msgid "Nova senha salva com sucesso!!"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:167
-#: build/lib/opac/webapp/admin/views.py:186 opac/webapp/admin/views.py:167
-#: opac/webapp/admin/views.py:186
+#: opac/webapp/admin/views.py:167 opac/webapp/admin/views.py:186
 #, python-format
 msgid "Enviamos o email de confirmação para: %(email)s"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:170 opac/webapp/admin/views.py:170
+#: opac/webapp/admin/views.py:170
 #, python-format
 msgid ""
 "Ocorreu um erro no envio do email de confirmação para: %(email)s "
 "%(error_msg)s"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:177 opac/webapp/admin/views.py:177
+#: opac/webapp/admin/views.py:177
 msgid "Enviar email de confirmação"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:189 opac/webapp/admin/views.py:189
+#: opac/webapp/admin/views.py:189
 #, python-format
 msgid "Ocorreu um erro no envio do email de confirmação para: %(email)s"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:193 opac/webapp/admin/views.py:193
+#: opac/webapp/admin/views.py:193
 #, python-format
 msgid "%(count)s usuários foram notificados com sucesso!"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:196 opac/webapp/admin/views.py:196
+#: opac/webapp/admin/views.py:196
 #, python-format
 msgid "Ocorreu um erro no envio do emails de confirmação. Erro: %(ex)s"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:231
-#: build/lib/opac/webapp/admin/views.py:265
-#: build/lib/opac/webapp/admin/views.py:363
-#: build/lib/opac/webapp/admin/views.py:393
-#: build/lib/opac/webapp/admin/views.py:677 opac/webapp/admin/views.py:231
-#: opac/webapp/admin/views.py:265 opac/webapp/admin/views.py:363
-#: opac/webapp/admin/views.py:393 opac/webapp/admin/views.py:677
+#: opac/webapp/admin/views.py:231 opac/webapp/admin/views.py:265
+#: opac/webapp/admin/views.py:363 opac/webapp/admin/views.py:393
+#: opac/webapp/admin/views.py:678
 msgid "Nome"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:232
-#: build/lib/opac/webapp/admin/views.py:267 opac/webapp/admin/views.py:232
-#: opac/webapp/admin/views.py:267
+#: opac/webapp/admin/views.py:232 opac/webapp/admin/views.py:267
 msgid "Link"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:233
-#: build/lib/opac/webapp/admin/views.py:268
-#: build/lib/opac/webapp/admin/views.py:678 opac/webapp/admin/views.py:233
-#: opac/webapp/admin/views.py:268 opac/webapp/admin/views.py:678
+#: opac/webapp/admin/views.py:233 opac/webapp/admin/views.py:268
+#: opac/webapp/admin/views.py:679
 msgid "Idioma"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:266 opac/webapp/admin/views.py:266
+#: opac/webapp/admin/views.py:266
 msgid "Previsualização"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:362
-#: build/lib/opac/webapp/admin/views.py:547
-#: build/lib/opac/webapp/admin/views.py:627 opac/webapp/admin/views.py:362
-#: opac/webapp/admin/views.py:547 opac/webapp/admin/views.py:627
+#: opac/webapp/admin/views.py:362 opac/webapp/admin/views.py:548
+#: opac/webapp/admin/views.py:628
 msgid "Ordem"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:364 opac/webapp/admin/views.py:364
+#: opac/webapp/admin/views.py:364
 msgid "URL"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:365 opac/webapp/admin/views.py:365
+#: opac/webapp/admin/views.py:365
 msgid "URL da logomarca"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:375 opac/webapp/admin/views.py:375
+#: opac/webapp/admin/views.py:375
 msgid "Financiador com Ordem ou Nome já cadastrado!"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:394 opac/webapp/admin/views.py:394
+#: opac/webapp/admin/views.py:394
 msgid "Acerca de"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:395
-#: build/lib/opac/webapp/admin/views.py:462 opac/webapp/admin/views.py:395
-#: opac/webapp/admin/views.py:462
+#: opac/webapp/admin/views.py:395 opac/webapp/admin/views.py:463
 msgid "Acrônimo"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:396 opac/webapp/admin/views.py:396
+#: opac/webapp/admin/views.py:396
 msgid "Endereço principal"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:397 opac/webapp/admin/views.py:397
+#: opac/webapp/admin/views.py:397
 msgid "Endereço secundário"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:398 opac/webapp/admin/views.py:398
+#: opac/webapp/admin/views.py:398
 msgid "Logo da Home (PT)"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:399 opac/webapp/admin/views.py:399
+#: opac/webapp/admin/views.py:399
 msgid "Logo da Home (EN)"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:400 opac/webapp/admin/views.py:400
+#: opac/webapp/admin/views.py:400
 msgid "Logo da Home (ES)"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:401 opac/webapp/admin/views.py:401
+#: opac/webapp/admin/views.py:401
 msgid "Logo do cabeçalho (PT)"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:402 opac/webapp/admin/views.py:402
+#: opac/webapp/admin/views.py:402
 msgid "Logo do cabeçalho (EN)"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:403 opac/webapp/admin/views.py:403
+#: opac/webapp/admin/views.py:403
 msgid "Logo do cabeçalho (ES)"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:404 opac/webapp/admin/views.py:404
+#: opac/webapp/admin/views.py:404
 msgid "Logo do menu (PT)"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:405
-#: build/lib/opac/webapp/admin/views.py:406 opac/webapp/admin/views.py:405
-#: opac/webapp/admin/views.py:406
+#: opac/webapp/admin/views.py:405 opac/webapp/admin/views.py:406
 msgid "Logo do menu (ES)"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:407 opac/webapp/admin/views.py:407
+#: opac/webapp/admin/views.py:407
 msgid "Logo do menu (drop)"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:408 opac/webapp/admin/views.py:408
+#: opac/webapp/admin/views.py:408
 msgid "Logo do rodapé"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:451 opac/webapp/admin/views.py:451
+#: opac/webapp/admin/views.py:452
 msgid "Id Periódico"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:453 opac/webapp/admin/views.py:453
+#: opac/webapp/admin/views.py:454
 msgid "Linha do tempo"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:454 opac/webapp/admin/views.py:454
+#: opac/webapp/admin/views.py:455
 msgid "Categorias de assunto"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:455 opac/webapp/admin/views.py:455
+#: opac/webapp/admin/views.py:456
 msgid "Áreas de estudo"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:456 opac/webapp/admin/views.py:456
+#: opac/webapp/admin/views.py:457
 msgid "Redes sociais"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:457
-#: build/lib/opac/webapp/admin/views.py:611
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:30
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:73
-#: opac/webapp/admin/views.py:457 opac/webapp/admin/views.py:611
+#: opac/webapp/admin/views.py:458 opac/webapp/admin/views.py:612
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:30
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:73
 msgid "Título"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:458 opac/webapp/admin/views.py:458
+#: opac/webapp/admin/views.py:459
 msgid "Título ISO"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:459 opac/webapp/admin/views.py:459
+#: opac/webapp/admin/views.py:460
 msgid "Título curto"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:460
-#: build/lib/opac/webapp/admin/views.py:538
-#: build/lib/opac/webapp/admin/views.py:614 opac/webapp/admin/views.py:460
-#: opac/webapp/admin/views.py:538 opac/webapp/admin/views.py:614
+#: opac/webapp/admin/views.py:461 opac/webapp/admin/views.py:539
+#: opac/webapp/admin/views.py:615
 msgid "Criado"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:461
-#: build/lib/opac/webapp/admin/views.py:539
-#: build/lib/opac/webapp/admin/views.py:615 opac/webapp/admin/views.py:461
-#: opac/webapp/admin/views.py:539 opac/webapp/admin/views.py:615
+#: opac/webapp/admin/views.py:462 opac/webapp/admin/views.py:540
+#: opac/webapp/admin/views.py:616
 msgid "Atualizado"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:463 opac/webapp/admin/views.py:463
+#: opac/webapp/admin/views.py:464
 msgid "ISSN SciELO"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:464 opac/webapp/admin/views.py:464
+#: opac/webapp/admin/views.py:465
 msgid "ISSN impresso"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:465 opac/webapp/admin/views.py:465
+#: opac/webapp/admin/views.py:466
 msgid "ISSN eletrônico"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:466 opac/webapp/admin/views.py:466
+#: opac/webapp/admin/views.py:467
 msgid "Descritores de assunto"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:467 opac/webapp/admin/views.py:467
+#: opac/webapp/admin/views.py:468
 msgid "Url da submissão online"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:468 opac/webapp/admin/views.py:468
+#: opac/webapp/admin/views.py:469
 msgid "Url do capa"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:469 opac/webapp/admin/views.py:469
+#: opac/webapp/admin/views.py:470
 msgid "Url do logotipo"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:470 opac/webapp/admin/views.py:470
+#: opac/webapp/admin/views.py:471
 msgid "Outros títulos"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:471 opac/webapp/admin/views.py:471
+#: opac/webapp/admin/views.py:472
 msgid "Nome da editora"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:472 opac/webapp/admin/views.py:472
+#: opac/webapp/admin/views.py:473
 msgid "País da editora"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:473 opac/webapp/admin/views.py:473
+#: opac/webapp/admin/views.py:474
 msgid "Estado da editora"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:474 opac/webapp/admin/views.py:474
+#: opac/webapp/admin/views.py:475
 msgid "Cidade da editora"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:475 opac/webapp/admin/views.py:475
+#: opac/webapp/admin/views.py:476
 msgid "Endereço da editora"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:476 opac/webapp/admin/views.py:476
+#: opac/webapp/admin/views.py:477
 msgid "Telefone da editora"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:477 opac/webapp/admin/views.py:477
+#: opac/webapp/admin/views.py:478
 msgid "Missão"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:478 opac/webapp/admin/views.py:478
+#: opac/webapp/admin/views.py:479
 msgid "No índice"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:479 opac/webapp/admin/views.py:479
+#: opac/webapp/admin/views.py:480
 msgid "Patrocinadores"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:480 opac/webapp/admin/views.py:480
+#: opac/webapp/admin/views.py:481
 msgid "Ref periódico anterior"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:481 opac/webapp/admin/views.py:481
+#: opac/webapp/admin/views.py:482
 msgid "Situação atual"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:482 opac/webapp/admin/views.py:482
+#: opac/webapp/admin/views.py:483
 msgid "Total de números"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:483
-#: build/lib/opac/webapp/admin/views.py:548
-#: build/lib/opac/webapp/admin/views.py:618 opac/webapp/admin/views.py:483
-#: opac/webapp/admin/views.py:548 opac/webapp/admin/views.py:618
+#: opac/webapp/admin/views.py:484 opac/webapp/admin/views.py:549
+#: opac/webapp/admin/views.py:619
 msgid "Publicado?"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:484
-#: build/lib/opac/webapp/admin/views.py:549
-#: build/lib/opac/webapp/admin/views.py:619 opac/webapp/admin/views.py:484
-#: opac/webapp/admin/views.py:549 opac/webapp/admin/views.py:619
+#: opac/webapp/admin/views.py:485 opac/webapp/admin/views.py:550
+#: opac/webapp/admin/views.py:620
 msgid "Motivo de despublicação"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:485
-#: build/lib/opac/webapp/admin/views.py:551
-#: build/lib/opac/webapp/admin/views.py:620 opac/webapp/admin/views.py:485
-#: opac/webapp/admin/views.py:551 opac/webapp/admin/views.py:620
+#: opac/webapp/admin/views.py:486 opac/webapp/admin/views.py:552
+#: opac/webapp/admin/views.py:621
 msgid "Segmento de URL"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:488
-#: build/lib/opac/webapp/admin/views.py:554
-#: build/lib/opac/webapp/admin/views.py:633 opac/webapp/admin/views.py:488
-#: opac/webapp/admin/views.py:554 opac/webapp/admin/views.py:633
+#: opac/webapp/admin/views.py:489 opac/webapp/admin/views.py:555
+#: opac/webapp/admin/views.py:634
 msgid "Publicar"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:493 opac/webapp/admin/views.py:493
+#: opac/webapp/admin/views.py:494
 msgid "Periódico(s) publicado(s) com sucesso!!"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:495 opac/webapp/admin/views.py:495
+#: opac/webapp/admin/views.py:496
 msgid "Ocorreu um erro tentando publicar o(s) periódico(s)!!"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:501 opac/webapp/admin/views.py:501
+#: opac/webapp/admin/views.py:502
 msgid "Periódico(s) despublicado com sucesso!!"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:504 opac/webapp/admin/views.py:504
+#: opac/webapp/admin/views.py:505
 #, python-format
 msgid "Ocorreu um erro tentando despublicar o(s) periódico(s)!!. Erro: %(ex)s"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:508
-#: build/lib/opac/webapp/admin/views.py:576
-#: build/lib/opac/webapp/admin/views.py:656 opac/webapp/admin/views.py:508
-#: opac/webapp/admin/views.py:576 opac/webapp/admin/views.py:656
+#: opac/webapp/admin/views.py:509 opac/webapp/admin/views.py:577
+#: opac/webapp/admin/views.py:657
 #, python-format
 msgid "Despublicar por %s"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:532 opac/webapp/admin/views.py:532
+#: opac/webapp/admin/views.py:533
 msgid "Id Número"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:534
-#: build/lib/opac/webapp/admin/views.py:624 opac/webapp/admin/views.py:534
-#: opac/webapp/admin/views.py:624
+#: opac/webapp/admin/views.py:535 opac/webapp/admin/views.py:625
 msgid "Seções"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:535 opac/webapp/admin/views.py:535
+#: opac/webapp/admin/views.py:536
 msgid "Url da capa"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:536
-#: build/lib/opac/webapp/templates/collection/list_feed_content.html:3
-#: build/lib/opac/webapp/templates/issue/grid.html:40
-#: build/lib/opac/webapp/templates/news/includes/issue_last_row.html:7
-#: opac/webapp/admin/views.py:536
+#: opac/webapp/admin/views.py:537
 #: opac/webapp/templates/collection/list_feed_content.html:3
 #: opac/webapp/templates/issue/grid.html:40
 #: opac/webapp/templates/news/includes/issue_last_row.html:7
 msgid "Volume"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:540 opac/webapp/admin/views.py:540
+#: opac/webapp/admin/views.py:541
 msgid "Tipo"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:541 opac/webapp/admin/views.py:541
+#: opac/webapp/admin/views.py:542
 msgid "Texto do suplemento"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:542 opac/webapp/admin/views.py:542
+#: opac/webapp/admin/views.py:543
 msgid "Texto do especial"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:543 opac/webapp/admin/views.py:543
+#: opac/webapp/admin/views.py:544
 msgid "Mês inicial"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:544 opac/webapp/admin/views.py:544
+#: opac/webapp/admin/views.py:545
 msgid "Mês final"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:545
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:25
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:68
-#: build/lib/opac/webapp/templates/issue/grid.html:39
-#: build/lib/opac/webapp/templates/news/includes/issue_last_row.html:5
-#: opac/webapp/admin/views.py:545
+#: opac/webapp/admin/views.py:546
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:25
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:68
 #: opac/webapp/templates/issue/grid.html:39
@@ -947,305 +811,254 @@ msgstr ""
 msgid "Ano"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:546 opac/webapp/admin/views.py:546
+#: opac/webapp/admin/views.py:547
 msgid "Etiqueta"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:550
-#: build/lib/opac/webapp/admin/views.py:621 opac/webapp/admin/views.py:550
-#: opac/webapp/admin/views.py:621
+#: opac/webapp/admin/views.py:551 opac/webapp/admin/views.py:622
 msgid "PID"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:559 opac/webapp/admin/views.py:559
+#: opac/webapp/admin/views.py:560
 msgid "Número(s) publicado(s) com sucesso!!"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:562
-#: build/lib/opac/webapp/admin/views.py:642 opac/webapp/admin/views.py:562
-#: opac/webapp/admin/views.py:642
+#: opac/webapp/admin/views.py:563 opac/webapp/admin/views.py:643
 #, python-format
 msgid "Ocorreu um erro tentando publicar o(s) número(s)!!. Erro: %(ex)s"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:569 opac/webapp/admin/views.py:569
+#: opac/webapp/admin/views.py:570
 msgid "Número(s) despublicado(s) com sucesso!!"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:572
-#: build/lib/opac/webapp/admin/views.py:652 opac/webapp/admin/views.py:572
-#: opac/webapp/admin/views.py:652
+#: opac/webapp/admin/views.py:573 opac/webapp/admin/views.py:653
 #, python-format
 msgid "Ocorreu um erro tentando despublicar o(s) número(s)!!. Erro: %(ex)s"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:608 opac/webapp/admin/views.py:608
+#: opac/webapp/admin/views.py:609
 msgid "Id Artigo"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:612 opac/webapp/admin/views.py:612
+#: opac/webapp/admin/views.py:613
 msgid "Seção"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:613 opac/webapp/admin/views.py:613
+#: opac/webapp/admin/views.py:614
 msgid "É Ahead of Print?"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:616 opac/webapp/admin/views.py:616
+#: opac/webapp/admin/views.py:617
 msgid "HTML's"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:617 opac/webapp/admin/views.py:617
+#: opac/webapp/admin/views.py:618
 msgid "Chave de domínio"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:622 opac/webapp/admin/views.py:622
+#: opac/webapp/admin/views.py:623
 msgid "Idioma original"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:623 opac/webapp/admin/views.py:623
+#: opac/webapp/admin/views.py:624
 msgid "Idiomas das traduções"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:625 opac/webapp/admin/views.py:625
+#: opac/webapp/admin/views.py:626
 msgid "Autores"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:626
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:29
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:72
-#: build/lib/opac/webapp/templates/issue/toc.html:176
-#: opac/webapp/admin/views.py:626
+#: opac/webapp/admin/views.py:627
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:29
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:72
-#: opac/webapp/templates/issue/toc.html:176
+#: opac/webapp/templates/issue/toc.html:169
 msgid "Resumo"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:628 opac/webapp/admin/views.py:628
+#: opac/webapp/admin/views.py:629
 msgid "DOI"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:629 opac/webapp/admin/views.py:629
+#: opac/webapp/admin/views.py:630
 msgid "Idiomas"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:630 opac/webapp/admin/views.py:630
+#: opac/webapp/admin/views.py:631
 msgid "Idiomas dos resumos"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:638 opac/webapp/admin/views.py:638
+#: opac/webapp/admin/views.py:639
 msgid "Artigo(s) publicado com sucesso!!"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:649 opac/webapp/admin/views.py:649
+#: opac/webapp/admin/views.py:650
 msgid "Artigo(s) despublicado com sucesso!!"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:679 opac/webapp/admin/views.py:679
+#: opac/webapp/admin/views.py:680
 msgid "Conteúdo"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:681
-#: build/lib/opac/webapp/admin/views.py:901 opac/webapp/admin/views.py:681
-#: opac/webapp/admin/views.py:901
+#: opac/webapp/admin/views.py:682 opac/webapp/admin/views.py:902
 msgid "Descrição"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:682
-#: build/lib/opac/webapp/admin/views.py:898 opac/webapp/admin/views.py:682
-#: opac/webapp/admin/views.py:898
+#: opac/webapp/admin/views.py:683 opac/webapp/admin/views.py:899
 msgid "Data de Criação"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:683 opac/webapp/admin/views.py:683
+#: opac/webapp/admin/views.py:684
 msgid "Data de Atualização"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:897 opac/webapp/admin/views.py:897
+#: opac/webapp/admin/views.py:898
 msgid "Ação"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:899 opac/webapp/admin/views.py:899
+#: opac/webapp/admin/views.py:900
 msgid "Modelo Auditado"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:900 opac/webapp/admin/views.py:900
+#: opac/webapp/admin/views.py:901
 msgid "Id Auditado"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:902 opac/webapp/admin/views.py:902
+#: opac/webapp/admin/views.py:903
 msgid "Dados dos campos"
 msgstr ""
 
-#: build/lib/opac/webapp/main/views.py:34 opac/webapp/main/views.py:34
+#: opac/webapp/main/views.py:34
 msgid "O periódico está indisponível por motivo de: "
 msgstr ""
 
-#: build/lib/opac/webapp/main/views.py:35 opac/webapp/main/views.py:35
+#: opac/webapp/main/views.py:35
 msgid "O número está indisponível por motivo de: "
 msgstr ""
 
-#: build/lib/opac/webapp/main/views.py:36 opac/webapp/main/views.py:36
+#: opac/webapp/main/views.py:36
 msgid "O artigo está indisponível por motivo de: "
 msgstr ""
 
-#: build/lib/opac/webapp/main/views.py:127 opac/webapp/main/views.py:127
+#: opac/webapp/main/views.py:127
 msgid "Código de idioma inválido"
 msgstr ""
 
-#: build/lib/opac/webapp/main/views.py:197 opac/webapp/main/views.py:197
+#: opac/webapp/main/views.py:197
 msgid "Últimos periódicos inseridos na coleção"
 msgstr ""
 
-#: build/lib/opac/webapp/main/views.py:198 opac/webapp/main/views.py:198
+#: opac/webapp/main/views.py:198
 #, python-format
 msgid "10 últimos periódicos inseridos na coleção %s"
 msgstr ""
 
-#: build/lib/opac/webapp/main/views.py:257 opac/webapp/main/views.py:257
+#: opac/webapp/main/views.py:257
 msgid "Página não encontrada"
 msgstr ""
 
-#: build/lib/opac/webapp/main/views.py:281
-#: build/lib/opac/webapp/main/views.py:371 opac/webapp/main/views.py:281
-#: opac/webapp/main/views.py:371
+#: opac/webapp/main/views.py:281 opac/webapp/main/views.py:371
 #, python-format
 msgid "Requsição inválida ao tentar acessar o artigo com pid: %s"
 msgstr ""
 
-#: build/lib/opac/webapp/main/views.py:289
-#: build/lib/opac/webapp/main/views.py:339
-#: build/lib/opac/webapp/main/views.py:383
-#: build/lib/opac/webapp/main/views.py:452
-#: build/lib/opac/webapp/main/views.py:500
-#: build/lib/opac/webapp/main/views.py:647
-#: build/lib/opac/webapp/main/views.py:664
-#: build/lib/opac/webapp/main/views.py:1127 opac/webapp/main/views.py:289
-#: opac/webapp/main/views.py:339 opac/webapp/main/views.py:383
-#: opac/webapp/main/views.py:452 opac/webapp/main/views.py:500
-#: opac/webapp/main/views.py:647 opac/webapp/main/views.py:664
-#: opac/webapp/main/views.py:1127
+#: opac/webapp/main/views.py:289 opac/webapp/main/views.py:339
+#: opac/webapp/main/views.py:383 opac/webapp/main/views.py:452
+#: opac/webapp/main/views.py:500 opac/webapp/main/views.py:647
+#: opac/webapp/main/views.py:664 opac/webapp/main/views.py:1127
 msgid "Periódico não encontrado"
 msgstr ""
 
-#: build/lib/opac/webapp/main/views.py:301
-#: build/lib/opac/webapp/main/views.py:714
-#: build/lib/opac/webapp/main/views.py:773
-#: build/lib/opac/webapp/main/views.py:1136 opac/webapp/main/views.py:301
-#: opac/webapp/main/views.py:714 opac/webapp/main/views.py:773
-#: opac/webapp/main/views.py:1136
+#: opac/webapp/main/views.py:301 opac/webapp/main/views.py:714
+#: opac/webapp/main/views.py:773 opac/webapp/main/views.py:1136
 msgid "Número não encontrado"
 msgstr ""
 
-#: build/lib/opac/webapp/main/views.py:319
-#: build/lib/opac/webapp/main/views.py:354
-#: build/lib/opac/webapp/main/views.py:825
-#: build/lib/opac/webapp/main/views.py:910
-#: build/lib/opac/webapp/main/views.py:1060 opac/webapp/main/views.py:319
-#: opac/webapp/main/views.py:354 opac/webapp/main/views.py:825
-#: opac/webapp/main/views.py:910 opac/webapp/main/views.py:1060
+#: opac/webapp/main/views.py:319 opac/webapp/main/views.py:354
+#: opac/webapp/main/views.py:825 opac/webapp/main/views.py:910
+#: opac/webapp/main/views.py:1060
 msgid "Artigo não encontrado"
 msgstr ""
 
-#: build/lib/opac/webapp/main/views.py:476 opac/webapp/main/views.py:476
+#: opac/webapp/main/views.py:476
 msgid "Artigo sem título"
 msgstr ""
 
-#: build/lib/opac/webapp/main/views.py:548
-#: build/lib/opac/webapp/main/views.py:565 opac/webapp/main/views.py:548
-#: opac/webapp/main/views.py:565
+#: opac/webapp/main/views.py:548 opac/webapp/main/views.py:565
 msgid "Requisição inválida. Deve ser por ajax"
 msgstr ""
 
-#: build/lib/opac/webapp/main/views.py:581 opac/webapp/main/views.py:581
+#: opac/webapp/main/views.py:581
 msgid ""
 "Parámetro \"filter\" é inválido, deve ser \"areas\", \"wos\" ou "
 "\"publisher\"."
 msgstr ""
 
-#: build/lib/opac/webapp/main/views.py:590 opac/webapp/main/views.py:590
+#: opac/webapp/main/views.py:590
 msgid "Parámetro \"extension\" é inválido, deve ser \"csv\" ou \"xls\"."
 msgstr ""
 
-#: build/lib/opac/webapp/main/views.py:592 opac/webapp/main/views.py:592
+#: opac/webapp/main/views.py:592
 msgid ""
 "Parámetro \"list_type\" é inválido, deve ser: \"alpha\", \"areas\", "
 "\"wos\" ou \"publisher\"."
 msgstr ""
 
-#: build/lib/opac/webapp/main/views.py:613 opac/webapp/main/views.py:613
+#: opac/webapp/main/views.py:613
 msgid "Requisição inválida, deve ser ajax."
 msgstr ""
 
-#: build/lib/opac/webapp/main/views.py:622 opac/webapp/main/views.py:622
+#: opac/webapp/main/views.py:622
 msgid "Periódico não permite envio de email."
 msgstr ""
 
-#: build/lib/opac/webapp/main/views.py:640 opac/webapp/main/views.py:640
+#: opac/webapp/main/views.py:640
 msgid "Requisição inválida, captcha inválido."
 msgstr ""
 
-#: build/lib/opac/webapp/main/views.py:901
-#: build/lib/opac/webapp/main/views.py:1055 opac/webapp/main/views.py:901
-#: opac/webapp/main/views.py:1055
+#: opac/webapp/main/views.py:901 opac/webapp/main/views.py:1055
 msgid "Issue não encontrado"
 msgstr ""
 
-#: build/lib/opac/webapp/main/views.py:943
-#: build/lib/opac/webapp/main/views.py:949
-#: build/lib/opac/webapp/main/views.py:1092
-#: build/lib/opac/webapp/main/views.py:1100
-#: build/lib/opac/webapp/main/views.py:1102 opac/webapp/main/views.py:943
-#: opac/webapp/main/views.py:949 opac/webapp/main/views.py:1092
-#: opac/webapp/main/views.py:1100 opac/webapp/main/views.py:1102
+#: opac/webapp/main/views.py:943 opac/webapp/main/views.py:949
+#: opac/webapp/main/views.py:1092 opac/webapp/main/views.py:1100
+#: opac/webapp/main/views.py:1102
 msgid "PDF do Artigo não encontrado"
 msgstr ""
 
-#: build/lib/opac/webapp/main/views.py:954 opac/webapp/main/views.py:954
+#: opac/webapp/main/views.py:954
 msgid "HTML do Artigo não encontrado ou indisponível"
 msgstr ""
 
-#: build/lib/opac/webapp/main/views.py:1001 opac/webapp/main/views.py:1001
+#: opac/webapp/main/views.py:1001
 msgid "Parâmetros insuficientes para obter o EPDF do artigo"
 msgstr ""
 
-#: build/lib/opac/webapp/main/views.py:1022 opac/webapp/main/views.py:1022
+#: opac/webapp/main/views.py:1022
 msgid "Recruso não encontrado"
 msgstr ""
 
-#: build/lib/opac/webapp/main/views.py:1041 opac/webapp/main/views.py:1041
+#: opac/webapp/main/views.py:1041
 msgid "Recurso do Artigo não encontrado. Caminho inválido!"
 msgstr ""
 
-#: build/lib/opac/webapp/main/views.py:1154 opac/webapp/main/views.py:1154
+#: opac/webapp/main/views.py:1154
 msgid "PDF do artigo não foi encontrado"
 msgstr ""
 
-#: build/lib/opac/webapp/main/views.py:1169
-#: build/lib/opac/webapp/main/views.py:1200 opac/webapp/main/views.py:1169
-#: opac/webapp/main/views.py:1200
+#: opac/webapp/main/views.py:1169 opac/webapp/main/views.py:1200
 msgid "Requisição inválida."
 msgstr ""
 
-#: build/lib/opac/webapp/templates/admin/index.html:7
 #: opac/webapp/templates/admin/index.html:7
 msgid "da coleção"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/admin/index.html:12
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu.html:31
 #: opac/webapp/templates/admin/index.html:12
 #: opac/webapp/templates/collection/includes/levelMenu.html:31
 msgid "Periódicos"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/admin/index.html:15
-#: build/lib/opac/webapp/templates/admin/index.html:22
-#: build/lib/opac/webapp/templates/admin/index.html:35
-#: build/lib/opac/webapp/templates/admin/index.html:42
-#: build/lib/opac/webapp/templates/admin/index.html:55
-#: build/lib/opac/webapp/templates/admin/index.html:62
 #: opac/webapp/templates/admin/index.html:15
 #: opac/webapp/templates/admin/index.html:22
 #: opac/webapp/templates/admin/index.html:35
@@ -1255,12 +1068,6 @@ msgstr ""
 msgid "Publicados"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/admin/index.html:16
-#: build/lib/opac/webapp/templates/admin/index.html:36
-#: build/lib/opac/webapp/templates/admin/index.html:56
-#: build/lib/opac/webapp/templates/admin/index.html:75
-#: build/lib/opac/webapp/templates/admin/index.html:85
-#: build/lib/opac/webapp/templates/admin/index.html:95
 #: opac/webapp/templates/admin/index.html:16
 #: opac/webapp/templates/admin/index.html:36
 #: opac/webapp/templates/admin/index.html:56
@@ -1270,78 +1077,58 @@ msgstr ""
 msgid "Total"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/admin/index.html:32
 #: opac/webapp/templates/admin/index.html:32
 msgid "Fascícluos"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/admin/index.html:52
 #: opac/webapp/templates/admin/index.html:52
 msgid "Artigos"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/admin/index.html:72
 #: opac/webapp/templates/admin/index.html:72
 msgid "News"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/admin/index.html:82
 #: opac/webapp/templates/admin/index.html:82
 msgid "Sponsors"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/admin/index.html:92
 #: opac/webapp/templates/admin/index.html:92
 msgid "Press Releases"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/admin/auth/reset.html:9
-#: build/lib/opac/webapp/templates/admin/auth/reset_with_token.html:9
-#: build/lib/opac/webapp/templates/admin/opac_base.html:13
 #: opac/webapp/templates/admin/auth/reset.html:9
 #: opac/webapp/templates/admin/auth/reset_with_token.html:9
 #: opac/webapp/templates/admin/opac_base.html:13
 msgid "Recuperar a senha"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/admin/opac_base.html:14
 #: opac/webapp/templates/admin/opac_base.html:14
 msgid "Terminar sessão"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/admin/auth/login.html:11
-#: build/lib/opac/webapp/templates/admin/auth/login.html:20
-#: build/lib/opac/webapp/templates/admin/opac_base.html:18
 #: opac/webapp/templates/admin/auth/login.html:11
 #: opac/webapp/templates/admin/auth/login.html:20
 #: opac/webapp/templates/admin/opac_base.html:18
 msgid "Iniciar sessão"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/admin/audit_log/fields_data_table.html:4
 #: opac/webapp/templates/admin/audit_log/fields_data_table.html:4
 msgid "Campo: "
 msgstr ""
 
-#: build/lib/opac/webapp/templates/admin/audit_log/fields_data_table.html:5
 #: opac/webapp/templates/admin/audit_log/fields_data_table.html:5
 msgid "Valor anterior: "
 msgstr ""
 
-#: build/lib/opac/webapp/templates/admin/audit_log/fields_data_table.html:6
 #: opac/webapp/templates/admin/audit_log/fields_data_table.html:6
 msgid "Valor novo: "
 msgstr ""
 
-#: build/lib/opac/webapp/templates/admin/auth/login.html:13
 #: opac/webapp/templates/admin/auth/login.html:13
 msgid "Você já iniciou sessão!"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/admin/auth/login.html:24
-#: build/lib/opac/webapp/templates/admin/auth/reset.html:13
-#: build/lib/opac/webapp/templates/admin/auth/reset_with_token.html:13
-#: build/lib/opac/webapp/templates/includes/error_form.html:60
 #: opac/webapp/templates/admin/auth/login.html:24
 #: opac/webapp/templates/admin/auth/reset.html:13
 #: opac/webapp/templates/admin/auth/reset_with_token.html:13
@@ -1349,17 +1136,14 @@ msgstr ""
 msgid "Enviar"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/admin/auth/login.html:28
 #: opac/webapp/templates/admin/auth/login.html:28
 msgid "Esqueci a senha?"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/admin/auth/unconfirm_email.html:7
 #: opac/webapp/templates/admin/auth/unconfirm_email.html:7
 msgid "Email não confirmado!"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/admin/auth/unconfirm_email.html:9
 #: opac/webapp/templates/admin/auth/unconfirm_email.html:9
 msgid ""
 "Você <strong>deve</strong> confirmar seu email.<br>\n"
@@ -1367,7 +1151,6 @@ msgid ""
 "administrador.</strong>"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/admin/pages/edit.html:7
 #: opac/webapp/templates/admin/pages/edit.html:7
 msgid ""
 "<strong>Atenção:</strong> ao selecionar um <strong>periódico</strong> "
@@ -1376,11 +1159,6 @@ msgid ""
 "<em>Sobre o SciELO</em>. "
 msgstr ""
 
-#: build/lib/opac/webapp/templates/article/includes/alternative_header.html:7
-#: build/lib/opac/webapp/templates/collection/includes/header.html:7
-#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:7
-#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:7
-#: build/lib/opac/webapp/templates/journal/includes/header.html:8
 #: opac/webapp/templates/article/includes/alternative_header.html:7
 #: opac/webapp/templates/collection/includes/header.html:7
 #: opac/webapp/templates/issue/includes/alternative_header.html:7
@@ -1389,10 +1167,6 @@ msgstr ""
 msgid "Abrir menu"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/article/includes/alternative_header.html:9
-#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:9
-#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:9
-#: build/lib/opac/webapp/templates/journal/includes/header.html:10
 #: opac/webapp/templates/article/includes/alternative_header.html:9
 #: opac/webapp/templates/issue/includes/alternative_header.html:9
 #: opac/webapp/templates/journal/includes/alternative_header.html:9
@@ -1400,11 +1174,6 @@ msgstr ""
 msgid "Ir para a homepage da coleção: "
 msgstr ""
 
-#: build/lib/opac/webapp/templates/article/includes/alternative_header.html:42
-#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:7
-#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:121
-#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:117
-#: build/lib/opac/webapp/templates/journal/includes/header.html:118
 #: opac/webapp/templates/article/includes/alternative_header.html:42
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:7
 #: opac/webapp/templates/issue/includes/alternative_header.html:121
@@ -1413,11 +1182,6 @@ msgstr ""
 msgid "Submissão de manuscritos"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/article/includes/alternative_header.html:48
-#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:16
-#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:127
-#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:123
-#: build/lib/opac/webapp/templates/journal/includes/header.html:124
 #: opac/webapp/templates/article/includes/alternative_header.html:48
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:16
 #: opac/webapp/templates/issue/includes/alternative_header.html:127
@@ -1426,11 +1190,6 @@ msgstr ""
 msgid "Sobre o periódico"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/article/includes/alternative_header.html:53
-#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:10
-#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:132
-#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:128
-#: build/lib/opac/webapp/templates/journal/includes/header.html:129
 #: opac/webapp/templates/article/includes/alternative_header.html:53
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:10
 #: opac/webapp/templates/issue/includes/alternative_header.html:132
@@ -1439,11 +1198,6 @@ msgstr ""
 msgid "Corpo Editorial"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/article/includes/alternative_header.html:58
-#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:13
-#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:137
-#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:133
-#: build/lib/opac/webapp/templates/journal/includes/header.html:134
 #: opac/webapp/templates/article/includes/alternative_header.html:58
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:13
 #: opac/webapp/templates/issue/includes/alternative_header.html:137
@@ -1452,11 +1206,6 @@ msgstr ""
 msgid "Instruções aos autores"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/article/includes/alternative_header.html:63
-#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:19
-#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:142
-#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:138
-#: build/lib/opac/webapp/templates/journal/includes/header.html:140
 #: opac/webapp/templates/article/includes/alternative_header.html:63
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:19
 #: opac/webapp/templates/issue/includes/alternative_header.html:142
@@ -1465,81 +1214,56 @@ msgstr ""
 msgid "Contato"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:2
-#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:60
 #: opac/webapp/templates/article/includes/floating_menu.html:2
 #: opac/webapp/templates/article/includes/floating_menu.html:60
 msgid "Ir para o topo"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:6
-#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:65
 #: opac/webapp/templates/article/includes/floating_menu.html:6
 #: opac/webapp/templates/article/includes/floating_menu.html:65
 msgid "PDFs"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:26
-#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:77
 #: opac/webapp/templates/article/includes/floating_menu.html:26
 #: opac/webapp/templates/article/includes/floating_menu.html:77
 msgid "Figuras e tabelas"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:32
-#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:83
 #: opac/webapp/templates/article/includes/floating_menu.html:32
 #: opac/webapp/templates/article/includes/floating_menu.html:83
 msgid "Versões e traduções"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:37
-#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:88
 #: opac/webapp/templates/article/includes/floating_menu.html:37
 #: opac/webapp/templates/article/includes/floating_menu.html:88
 msgid "Como citar este artigo"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:42
-#: build/lib/opac/webapp/templates/article/includes/modal/related_article.html:9
 #: opac/webapp/templates/article/includes/floating_menu.html:42
 #: opac/webapp/templates/article/includes/modal/related_article.html:9
 msgid "Artigos relacionados"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:93
 #: opac/webapp/templates/article/includes/floating_menu.html:93
 msgid "Artigos e similares"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:9
 #: opac/webapp/templates/article/includes/levelMenu.html:9
 msgid "home do periodico"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:17
-#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:70
-#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:123
 #: opac/webapp/templates/article/includes/levelMenu.html:17
 #: opac/webapp/templates/article/includes/levelMenu.html:70
 #: opac/webapp/templates/article/includes/levelMenu.html:123
 msgid "sumário"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:30
-#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:75
-#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:71
 #: opac/webapp/templates/article/includes/levelMenu.html:30
 #: opac/webapp/templates/issue/includes/alternative_header.html:75
 #: opac/webapp/templates/journal/includes/alternative_header.html:71
 msgid "anterior"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:35
-#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:88
-#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:141
-#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:82
-#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:78
 #: opac/webapp/templates/article/includes/levelMenu.html:35
 #: opac/webapp/templates/article/includes/levelMenu.html:88
 #: opac/webapp/templates/article/includes/levelMenu.html:141
@@ -1548,15 +1272,10 @@ msgstr ""
 msgid "atual"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:48
 #: opac/webapp/templates/article/includes/levelMenu.html:48
 msgid "seguinte"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:193
-#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:219
-#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:264
-#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:290
 #: opac/webapp/templates/article/includes/levelMenu.html:193
 #: opac/webapp/templates/article/includes/levelMenu.html:219
 #: opac/webapp/templates/article/includes/levelMenu.html:264
@@ -1564,10 +1283,6 @@ msgstr ""
 msgid "Download PDF (Espanhol)"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:195
-#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:221
-#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:266
-#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:292
 #: opac/webapp/templates/article/includes/levelMenu.html:195
 #: opac/webapp/templates/article/includes/levelMenu.html:221
 #: opac/webapp/templates/article/includes/levelMenu.html:266
@@ -1575,10 +1290,6 @@ msgstr ""
 msgid "Download PDF (Inglês)"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:197
-#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:223
-#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:268
-#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:294
 #: opac/webapp/templates/article/includes/levelMenu.html:197
 #: opac/webapp/templates/article/includes/levelMenu.html:223
 #: opac/webapp/templates/article/includes/levelMenu.html:268
@@ -1586,13 +1297,6 @@ msgstr ""
 msgid "Download PDF (Português)"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:310
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu.html:38
-#: build/lib/opac/webapp/templates/collection/includes/list_journals_section_title.html:14
-#: build/lib/opac/webapp/templates/issue/grid.html:14
-#: build/lib/opac/webapp/templates/issue/toc.html:13
-#: build/lib/opac/webapp/templates/journal/about.html:16
-#: build/lib/opac/webapp/templates/journal/detail.html:11
 #: opac/webapp/templates/article/includes/levelMenu.html:310
 #: opac/webapp/templates/collection/includes/levelMenu.html:38
 #: opac/webapp/templates/collection/includes/list_journals_section_title.html:14
@@ -1603,11 +1307,6 @@ msgstr ""
 msgid "Compartilhe"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:311
-#: build/lib/opac/webapp/templates/collection/includes/list_journals_section_title.html:16
-#: build/lib/opac/webapp/templates/issue/toc.html:14
-#: build/lib/opac/webapp/templates/journal/about.html:17
-#: build/lib/opac/webapp/templates/journal/detail.html:12
 #: opac/webapp/templates/article/includes/levelMenu.html:311
 #: opac/webapp/templates/collection/includes/list_journals_section_title.html:16
 #: opac/webapp/templates/issue/toc.html:14
@@ -1616,11 +1315,6 @@ msgstr ""
 msgid "Enviar link por e-mail"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:314
-#: build/lib/opac/webapp/templates/collection/includes/list_journals_section_title.html:19
-#: build/lib/opac/webapp/templates/issue/toc.html:15
-#: build/lib/opac/webapp/templates/journal/about.html:18
-#: build/lib/opac/webapp/templates/journal/detail.html:13
 #: opac/webapp/templates/article/includes/levelMenu.html:314
 #: opac/webapp/templates/collection/includes/list_journals_section_title.html:19
 #: opac/webapp/templates/issue/toc.html:15
@@ -1629,11 +1323,6 @@ msgstr ""
 msgid "Compartilhar no Facebook"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:317
-#: build/lib/opac/webapp/templates/collection/includes/list_journals_section_title.html:22
-#: build/lib/opac/webapp/templates/issue/toc.html:16
-#: build/lib/opac/webapp/templates/journal/about.html:19
-#: build/lib/opac/webapp/templates/journal/detail.html:14
 #: opac/webapp/templates/article/includes/levelMenu.html:317
 #: opac/webapp/templates/collection/includes/list_journals_section_title.html:22
 #: opac/webapp/templates/issue/toc.html:16
@@ -1642,18 +1331,6 @@ msgstr ""
 msgid "Compartilhar no Twitter"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:320
-#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:325
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu.html:46
-#: build/lib/opac/webapp/templates/collection/includes/list_journals_section_title.html:25
-#: build/lib/opac/webapp/templates/collection/includes/list_journals_section_title.html:30
-#: build/lib/opac/webapp/templates/issue/grid.html:20
-#: build/lib/opac/webapp/templates/issue/toc.html:17
-#: build/lib/opac/webapp/templates/issue/toc.html:19
-#: build/lib/opac/webapp/templates/journal/about.html:20
-#: build/lib/opac/webapp/templates/journal/about.html:22
-#: build/lib/opac/webapp/templates/journal/detail.html:15
-#: build/lib/opac/webapp/templates/journal/detail.html:17
 #: opac/webapp/templates/article/includes/levelMenu.html:320
 #: opac/webapp/templates/article/includes/levelMenu.html:325
 #: opac/webapp/templates/collection/includes/levelMenu.html:46
@@ -1669,24 +1346,16 @@ msgstr ""
 msgid "Outras redes sociais"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/article/includes/recent_articles_row.html:6
-#: build/lib/opac/webapp/templates/issue/toc.html:149
 #: opac/webapp/templates/article/includes/recent_articles_row.html:6
 #: opac/webapp/templates/issue/toc.html:149
 msgid "Documento sem título"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/article/includes/recent_articles_row.html:13
-#: build/lib/opac/webapp/templates/news/includes/journal_news_row.html:14
 #: opac/webapp/templates/article/includes/recent_articles_row.html:13
 #: opac/webapp/templates/news/includes/journal_news_row.html:14
 msgid "Continue lendo"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/article/includes/modal/download.html:6
-#: build/lib/opac/webapp/templates/article/includes/modal/related_article.html:7
-#: build/lib/opac/webapp/templates/email/email_form.html:7
-#: build/lib/opac/webapp/templates/includes/metric_modal.html:6
 #: opac/webapp/templates/article/includes/modal/download.html:6
 #: opac/webapp/templates/article/includes/modal/related_article.html:7
 #: opac/webapp/templates/email/email_form.html:7
@@ -1694,791 +1363,625 @@ msgstr ""
 msgid "Fechar"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/article/includes/modal/download.html:8
 #: opac/webapp/templates/article/includes/modal/download.html:8
 msgid "Versão para download de PDF"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/article/includes/modal/translate_version.html:6
 #: opac/webapp/templates/article/includes/modal/translate_version.html:6
 msgid "Versões e tradução automática"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/article/includes/modal/translate_version.html:11
 #: opac/webapp/templates/article/includes/modal/translate_version.html:11
 msgid "Versão original do texto"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/about.html:23
-#: build/lib/opac/webapp/templates/collection/pages.html:21
 #: opac/webapp/templates/collection/about.html:23
-#: opac/webapp/templates/collection/pages.html:21
 #, python-format
 msgid " %(page)s "
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/about.html:38
-#: build/lib/opac/webapp/templates/collection/pages.html:36
 #: opac/webapp/templates/collection/about.html:38
-#: opac/webapp/templates/collection/pages.html:36
 msgid " Conteúdo não cadastrado "
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/index.html:17
 #: opac/webapp/templates/collection/index.html:17
 msgid "em números | Métricas"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/index.html:27
 #: opac/webapp/templates/collection/index.html:27
 msgid "períodicos"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:31
-#: build/lib/opac/webapp/templates/collection/index.html:31
-#: build/lib/opac/webapp/templates/collection/list_feed_content.html:7
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:31
 #: opac/webapp/templates/collection/index.html:31
 #: opac/webapp/templates/collection/list_feed_content.html:7
 msgid "números"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/index.html:35
-#: build/lib/opac/webapp/templates/issue/grid.html:68
 #: opac/webapp/templates/collection/index.html:35
 #: opac/webapp/templates/issue/grid.html:68
 msgid "artigos"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/index.html:39
 #: opac/webapp/templates/collection/index.html:39
 msgid "referências"
 msgstr "referencias"
 
-#: build/lib/opac/webapp/templates/collection/index.html:45
 #: opac/webapp/templates/collection/index.html:45
 msgid "Downloads"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/index.html:48
 #: opac/webapp/templates/collection/index.html:48
 msgid "Citações"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/index.html:51
 #: opac/webapp/templates/collection/index.html:51
 msgid "Outros indicadores"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/index.html:62
-#: build/lib/opac/webapp/templates/collection/list_journal.html:3
 #: opac/webapp/templates/collection/index.html:62
 #: opac/webapp/templates/collection/list_journal.html:3
 msgid "Lista de periódicos"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/index.html:66
-#: build/lib/opac/webapp/templates/collection/list_journal.html:21
 #: opac/webapp/templates/collection/index.html:66
 #: opac/webapp/templates/collection/list_journal.html:21
 msgid "Alfabética"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/index.html:69
-#: build/lib/opac/webapp/templates/collection/list_journal.html:24
 #: opac/webapp/templates/collection/index.html:69
 #: opac/webapp/templates/collection/list_journal.html:24
 msgid "Temática"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/index.html:77
 #: opac/webapp/templates/collection/index.html:77
 msgid "Busca por periódicos"
 msgstr "Búsqueda por periódicos"
 
-#: build/lib/opac/webapp/templates/collection/index.html:105
 #: opac/webapp/templates/collection/index.html:105
 msgid "Números <span>mais recentes</span>"
 msgstr "Números <span>más recientes</span>"
 
-#: build/lib/opac/webapp/templates/collection/index.html:149
 #: opac/webapp/templates/collection/index.html:149
 msgid "em perspectiva"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/list_feed_content.html:1
 #: opac/webapp/templates/collection/list_feed_content.html:1
 msgid "Último número"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/list_feed_content.html:4
 #: opac/webapp/templates/collection/list_feed_content.html:4
 msgid "Nº"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/list_feed_content.html:6
 #: opac/webapp/templates/collection/list_feed_content.html:6
 msgid "descontinuado"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/list_feed_content.html:7
 #: opac/webapp/templates/collection/list_feed_content.html:7
 msgid "de"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu.html:11
-#: build/lib/opac/webapp/templates/collection/list_journal.html:16
 #: opac/webapp/templates/collection/includes/levelMenu.html:11
 #: opac/webapp/templates/collection/list_journal.html:16
 msgid "Home"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_grouper_table_container.html:14
-#: build/lib/opac/webapp/templates/collection/list_journal.html:52
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_grouper_table_container.html:14
 #: opac/webapp/templates/collection/list_journal.html:52
 msgid "download da lista"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_grouper_table_container.html:15
-#: build/lib/opac/webapp/templates/collection/list_journal.html:53
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_grouper_table_container.html:15
 #: opac/webapp/templates/collection/list_journal.html:53
 msgid "Lista em arquivo para Excel"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_grouper_table_container.html:18
-#: build/lib/opac/webapp/templates/collection/list_journal.html:56
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_grouper_table_container.html:18
 #: opac/webapp/templates/collection/list_journal.html:56
 msgid "Lista em arquivo CSV"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/list_journal.html:80
-#: build/lib/opac/webapp/templates/collection/list_journal.html:84
 #: opac/webapp/templates/collection/list_journal.html:80
 #: opac/webapp/templates/collection/list_journal.html:84
 msgid "Grandes áreas do conhecimento"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/list_journal.html:85
 #: opac/webapp/templates/collection/list_journal.html:85
 msgid "Áreas temáticas do Web of Science"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/list_journal.html:222
 #: opac/webapp/templates/collection/list_journal.html:222
 msgid "grandes áreas"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/list_journal.html:236
 #: opac/webapp/templates/collection/list_journal.html:236
 msgid "áreas WOS"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/list_journal.html:248
 #: opac/webapp/templates/collection/list_journal.html:248
 msgid "Editoras"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/list_journal.html:249
 #: opac/webapp/templates/collection/list_journal.html:249
 msgid "editoras"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:7
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:7
 msgid "Sobre o"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:19
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:62
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:19
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:62
 msgid "Entre uma ou mais palavras"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:24
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:67
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:24
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:67
 msgid "Todos os índices"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:26
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:69
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:26
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:69
 msgid "Autor"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:38
-#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:95
-#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:91
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:38
 #: opac/webapp/templates/issue/includes/alternative_header.html:95
 #: opac/webapp/templates/journal/includes/alternative_header.html:91
 msgid "Buscar"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:44
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:44
 msgid "Adicionar outro campo"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:49
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:49
 msgid "Apagar campo"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:63
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:63
 msgid "Limpar expressão"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:92
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:92
 msgid "Sem resultados"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:96
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:96
 msgid "Não foram encontrados documentos para sua pesquisa"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/includes/list_journals_search_input.html:5
 #: opac/webapp/templates/collection/includes/list_journals_search_input.html:5
 msgid "Todos"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/includes/list_journals_search_input.html:9
 #: opac/webapp/templates/collection/includes/list_journals_search_input.html:9
 msgid "Periódicos ativos"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/includes/list_journals_search_input.html:13
 #: opac/webapp/templates/collection/includes/list_journals_search_input.html:13
 msgid "Periódicos descontinuados"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/includes/list_journals_search_input.html:24
 #: opac/webapp/templates/collection/includes/list_journals_search_input.html:24
 msgid "Digite uma ou mais palavras para filtrar a lista"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/includes/nav.html:22
-#: build/lib/opac/webapp/templates/collection/includes/nav.html:64
 #: opac/webapp/templates/collection/includes/nav.html:22
 #: opac/webapp/templates/collection/includes/nav.html:64
 msgid "Busca"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/includes/nav.html:32
 #: opac/webapp/templates/collection/includes/nav.html:32
 msgid "Sobre:"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/includes/nav.html:44
 #: opac/webapp/templates/collection/includes/nav.html:44
 msgid "SciELO.org - Rede SciELO"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/includes/nav.html:95
 #: opac/webapp/templates/collection/includes/nav.html:95
 msgid "Blog SciELO em Perspectiva"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_empty.html:3
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_empty.html:3
 msgid "Nenhum periódico encontrado."
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_error.html:3
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_error.html:3
 msgid "Ocorreu um erro obtendo a lista de periódicos."
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_grouper_table_container.html:10
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_grouper_table_container.html:10
 msgid "periódicos"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:3
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:3
 msgid "Homepage"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:25
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:25
 msgid "Título do periódico"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:29
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:29
 msgid "Grade de número"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:36
-#: build/lib/opac/webapp/templates/journal/detail.html:89
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:36
 #: opac/webapp/templates/journal/detail.html:89
 msgid "Número mais recente"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:37
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:37
 msgid "Último"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:45
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:45
 msgid "Continua como "
 msgstr ""
 
-#: build/lib/opac/webapp/templates/email/email_form.html:10
 #: opac/webapp/templates/email/email_form.html:10
 msgid "Enviar página por e-mail"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/email/email_form.html:18
-#: build/lib/opac/webapp/templates/includes/error_form.html:26
-#: build/lib/opac/webapp/templates/journal/includes/contact_form.html:20
 #: opac/webapp/templates/email/email_form.html:18
 #: opac/webapp/templates/includes/error_form.html:26
 #: opac/webapp/templates/journal/includes/contact_form.html:20
 msgid "Seu e-mail"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/email/email_form.html:23
 #: opac/webapp/templates/email/email_form.html:23
 msgid "Para"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/email/email_form.html:27
 #: opac/webapp/templates/email/email_form.html:27
 msgid "Utilize ; (ponto e vírgula) para inserir mais emails."
 msgstr ""
 
-#: build/lib/opac/webapp/templates/email/email_form.html:36
 #: opac/webapp/templates/email/email_form.html:36
 msgid "Alterar assunto e comentários"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/email/email_form.html:41
 #: opac/webapp/templates/email/email_form.html:41
 msgid "Assunto"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/email/email_form.html:45
 #: opac/webapp/templates/email/email_form.html:45
 msgid "Comentário"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/email/email_form.html:49
 #: opac/webapp/templates/email/email_form.html:49
 msgid "Remover remetente, assunto e comentários"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/email/email_form.html:75
 #: opac/webapp/templates/email/email_form.html:75
 msgid "Email enviado com sucesso."
 msgstr ""
 
-#: build/lib/opac/webapp/templates/email/email_form.html:76
-#: build/lib/opac/webapp/templates/includes/error_form.html:86
-#: build/lib/opac/webapp/templates/journal/includes/contact_form.html:77
 #: opac/webapp/templates/email/email_form.html:76
 #: opac/webapp/templates/includes/error_form.html:86
 #: opac/webapp/templates/journal/includes/contact_form.html:77
 msgid "Erro ao tentar enviar e-mail, por favor tente mais tarde."
 msgstr ""
 
-#: build/lib/opac/webapp/templates/errors/400.html:7
 #: opac/webapp/templates/errors/400.html:7
 msgid "Ação inválida"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/errors/403.html:7
 #: opac/webapp/templates/errors/403.html:7
 msgid "Acesso não autorizado!"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/errors/404.html:7
 #: opac/webapp/templates/errors/404.html:7
 msgid ""
 "A URL solicitada não foi encontrada no servidor. Se você digitou a URL "
 "manualmente, por favor verifique e tente novamente."
 msgstr ""
 
-#: build/lib/opac/webapp/templates/errors/500.html:5
 #: opac/webapp/templates/errors/500.html:5
 msgid ""
 "Erro interno do servidor. Tente novamente mais tarde. Nossos engenheiros "
 "foram notificados."
 msgstr ""
 
-#: build/lib/opac/webapp/templates/errors/500.html:9
 #: opac/webapp/templates/errors/500.html:9
 msgid "Id. do erro"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/errors/base.html:24
 #: opac/webapp/templates/errors/base.html:24
 msgid "Erro"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/errors/base.html:27
 #: opac/webapp/templates/errors/base.html:27
 msgid "Qualquer dúvida, por favor entre em contato com o administrador"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/includes/error_form.html:5
 #: opac/webapp/templates/includes/error_form.html:5
 msgid " Reportar erro "
 msgstr ""
 
-#: build/lib/opac/webapp/templates/includes/error_form.html:20
-#: build/lib/opac/webapp/templates/journal/includes/contact_form.html:14
 #: opac/webapp/templates/includes/error_form.html:20
 #: opac/webapp/templates/journal/includes/contact_form.html:14
 msgid "Seu Nome"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/includes/error_form.html:21
 #: opac/webapp/templates/includes/error_form.html:21
 msgid "Digite seu Nome"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/includes/error_form.html:32
 #: opac/webapp/templates/includes/error_form.html:32
 msgid "Erro referente"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/includes/error_form.html:35
 #: opac/webapp/templates/includes/error_form.html:35
 msgid "ao conteúdo"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/includes/error_form.html:39
 #: opac/webapp/templates/includes/error_form.html:39
 msgid "à aplicação"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/includes/error_form.html:46
 #: opac/webapp/templates/includes/error_form.html:46
 msgid "Descrição do erro"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/includes/error_form.html:47
 #: opac/webapp/templates/includes/error_form.html:47
 msgid "Digite sua mensagem"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/includes/error_form.html:49
 #: opac/webapp/templates/includes/error_form.html:49
 msgid "Obs.: Link e título da página são enviados automaticamente"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/includes/error_form.html:85
 #: opac/webapp/templates/includes/error_form.html:85
 msgid "Email de erro enviado com sucesso."
 msgstr ""
 
-#: build/lib/opac/webapp/templates/includes/footer.html:36
 #: opac/webapp/templates/includes/footer.html:36
 msgid "Open Access"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/includes/footer.html:38
 #: opac/webapp/templates/includes/footer.html:38
 msgid "Leia"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/includes/footer.html:38
 #: opac/webapp/templates/includes/footer.html:38
 msgid "a Declaração de Acesso Aberto"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/issue/grid.html:4
 #: opac/webapp/templates/issue/grid.html:4
 msgid "Fascículos"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/issue/grid.html:33
 #: opac/webapp/templates/issue/grid.html:33
 msgid "Todos os números"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/issue/grid.html:79
 #: opac/webapp/templates/issue/grid.html:79
 msgid "supl."
 msgstr ""
 
-#: build/lib/opac/webapp/templates/issue/grid.html:98
 #: opac/webapp/templates/issue/grid.html:98
 msgid "Nenhum número encontrado para esse periódico"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/issue/grid.html:101
 #: opac/webapp/templates/issue/grid.html:101
 msgid "Histórico deste periódico na coleção"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/issue/grid.html:105
 #: opac/webapp/templates/issue/grid.html:105
 msgid " admitido na coleção da SciELO"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/issue/toc.html:10
-#: build/lib/opac/webapp/templates/journal/detail.html:8
 #: opac/webapp/templates/issue/toc.html:10
 #: opac/webapp/templates/journal/detail.html:8
 msgid "Imprimir"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/issue/toc.html:41
 #: opac/webapp/templates/issue/toc.html:41
 msgid "Editor científico"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/issue/toc.html:45
 #: opac/webapp/templates/issue/toc.html:45
 msgid "Editores associados"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/issue/toc.html:52
 #: opac/webapp/templates/issue/toc.html:52
 msgid "Veja toda a equipe editorial"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/issue/toc.html:63
 #: opac/webapp/templates/issue/toc.html:63
 msgid "Expandir/recolher conteúdo"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/issue/toc.html:72
-#: build/lib/opac/webapp/templates/journal/detail.html:96
 #: opac/webapp/templates/issue/toc.html:72
 #: opac/webapp/templates/journal/detail.html:96
 msgid "Sumário"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/issue/toc.html:79
 #: opac/webapp/templates/issue/toc.html:79
 msgid "Ordenar publicações por"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/issue/toc.html:82
 #: opac/webapp/templates/issue/toc.html:82
 msgid "Ordem do fascículo"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/issue/toc.html:83
 #: opac/webapp/templates/issue/toc.html:83
 msgid "Mais novos primeiro"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/issue/toc.html:84
 #: opac/webapp/templates/issue/toc.html:84
 msgid "Mais antigos primeiro"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/issue/toc.html:102
-#: build/lib/opac/webapp/templates/issue/toc.html:104
 #: opac/webapp/templates/issue/toc.html:102
 #: opac/webapp/templates/issue/toc.html:104
 msgid "Todas as seções"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/issue/toc.html:187
-#: opac/webapp/templates/issue/toc.html:187
+#: opac/webapp/templates/issue/toc.html:182
 msgid "Texto"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/issue/toc.html:214
-#: opac/webapp/templates/issue/toc.html:214
+#: opac/webapp/templates/issue/toc.html:195
+msgid "PDF"
+msgstr ""
+
+#: opac/webapp/templates/issue/toc.html:210
+msgid "ePDF"
+msgstr ""
+
+#: opac/webapp/templates/issue/toc.html:232
 msgid "Resumo em"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:31
-#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:31
 #: opac/webapp/templates/issue/includes/alternative_header.html:31
 #: opac/webapp/templates/journal/includes/alternative_header.html:31
 msgid "Número atual"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:51
-#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:47
 #: opac/webapp/templates/issue/includes/alternative_header.html:51
 #: opac/webapp/templates/journal/includes/alternative_header.html:47
 msgid "Homepage do periódico"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:62
-#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:58
 #: opac/webapp/templates/issue/includes/alternative_header.html:62
 #: opac/webapp/templates/journal/includes/alternative_header.html:58
 msgid "Números"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:68
-#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:64
-#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:90
 #: opac/webapp/templates/issue/includes/alternative_header.html:68
 #: opac/webapp/templates/journal/includes/alternative_header.html:64
 #: opac/webapp/templates/journal/includes/levelMenu.html:90
 msgid "todos"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:89
-#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:85
 #: opac/webapp/templates/issue/includes/alternative_header.html:89
 #: opac/webapp/templates/journal/includes/alternative_header.html:85
 msgid "próximo"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/journal/about.html:39
 #: opac/webapp/templates/journal/about.html:39
 msgid "Conteúdo não cadastrado"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/journal/about.html:55
-#: build/lib/opac/webapp/templates/journal/includes/contact_footer.html:48
 #: opac/webapp/templates/journal/about.html:55
 #: opac/webapp/templates/journal/includes/contact_footer.html:48
 msgid "Siga este periódico nas redes sociais"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/journal/detail.html:32
+#: opac/webapp/templates/journal/detail.html:9
+#: opac/webapp/templates/journal/includes/contact_footer.html:53
+msgid "RSS do número mais recente do periódico"
+msgstr ""
+
 #: opac/webapp/templates/journal/detail.html:32
 msgid "Nossa Missão"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/journal/detail.html:34
 #: opac/webapp/templates/journal/detail.html:34
 msgid "Periódico sem missão cadastrada"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/journal/detail.html:42
 #: opac/webapp/templates/journal/detail.html:42
 msgid "Métricas deste periódico"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/journal/detail.html:52
 #: opac/webapp/templates/journal/detail.html:52
 msgid "Índice h5"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/journal/detail.html:54
-#: build/lib/opac/webapp/templates/journal/detail.html:66
 #: opac/webapp/templates/journal/detail.html:54
 #: opac/webapp/templates/journal/detail.html:66
 msgid "ano"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/journal/detail.html:58
-#: build/lib/opac/webapp/templates/journal/detail.html:70
 #: opac/webapp/templates/journal/detail.html:58
 #: opac/webapp/templates/journal/detail.html:70
 msgid "Não possui"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/journal/detail.html:63
 #: opac/webapp/templates/journal/detail.html:63
 msgid "Mediana h5"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/journal/detail.html:86
 #: opac/webapp/templates/journal/detail.html:86
 msgid "Capa do número mais recente"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/journal/detail.html:138
-#: opac/webapp/templates/journal/detail.html:138
+#: opac/webapp/templates/journal/detail.html:117
+#: opac/webapp/templates/journal/detail.html:119
+msgid "RSS dos Press Releases mais recentes desse periódico"
+msgstr ""
+
+#: opac/webapp/templates/journal/detail.html:145
 msgid "Artigos mais recentes"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/journal/includes/contact_footer.html:57
 #: opac/webapp/templates/journal/includes/contact_footer.html:57
 msgid "Acompanhe os números deste periódico no seu leitor de RSS"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/journal/includes/contact_form.html:26
 #: opac/webapp/templates/journal/includes/contact_form.html:26
 msgid "Mensagem"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/journal/includes/contact_form.html:76
 #: opac/webapp/templates/journal/includes/contact_form.html:76
 msgid "Email enviado para "
 msgstr ""
 
-#: build/lib/opac/webapp/templates/journal/includes/contact_form.html:76
 #: opac/webapp/templates/journal/includes/contact_form.html:76
 msgid "com sucesso."
 msgstr ""
 
-#: build/lib/opac/webapp/templates/journal/includes/header.html:42
 #: opac/webapp/templates/journal/includes/header.html:42
 msgid "Publicação de:"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/journal/includes/header.html:47
 #: opac/webapp/templates/journal/includes/header.html:47
 msgid "Área:"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/journal/includes/header.html:51
 #: opac/webapp/templates/journal/includes/header.html:51
 msgid "Multidisciplinar"
 msgstr "Multidisciplinaria"
 
-#: build/lib/opac/webapp/templates/journal/includes/header.html:60
 #: opac/webapp/templates/journal/includes/header.html:60
 msgid "Versão impressa ISSN:"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/journal/includes/header.html:67
 #: opac/webapp/templates/journal/includes/header.html:67
 msgid "Versão on-line ISSN:"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/journal/includes/header.html:76
 #: opac/webapp/templates/journal/includes/header.html:76
 msgid "Novo título:"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/journal/includes/header.html:93
 #: opac/webapp/templates/journal/includes/header.html:93
 msgid "Título anterior:"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/journal/includes/header.html:148
 #: opac/webapp/templates/journal/includes/header.html:148
 msgid "Siga-nos"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:10
 #: opac/webapp/templates/journal/includes/levelMenu.html:10
 msgid "home do periódico"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:19
 #: opac/webapp/templates/journal/includes/levelMenu.html:19
 msgid "todos os números"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:25
-#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:29
 #: opac/webapp/templates/journal/includes/levelMenu.html:25
 #: opac/webapp/templates/journal/includes/levelMenu.html:29
 msgid "número anterior"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:36
-#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:40
-#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:107
-#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:111
 #: opac/webapp/templates/journal/includes/levelMenu.html:36
 #: opac/webapp/templates/journal/includes/levelMenu.html:40
 #: opac/webapp/templates/journal/includes/levelMenu.html:107
@@ -2486,24 +1989,16 @@ msgstr ""
 msgid "número atual"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:47
-#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:51
 #: opac/webapp/templates/journal/includes/levelMenu.html:47
 #: opac/webapp/templates/journal/includes/levelMenu.html:51
 msgid "número seguinte"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:59
-#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:130
 #: opac/webapp/templates/journal/includes/levelMenu.html:59
 #: opac/webapp/templates/journal/includes/levelMenu.html:130
 msgid "buscar"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:65
-#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:69
-#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:136
-#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:140
 #: opac/webapp/templates/journal/includes/levelMenu.html:65
 #: opac/webapp/templates/journal/includes/levelMenu.html:69
 #: opac/webapp/templates/journal/includes/levelMenu.html:136
@@ -2511,27 +2006,22 @@ msgstr ""
 msgid "métricas"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/macros/issue.html:5
 #: opac/webapp/templates/macros/issue.html:5
 msgid " número especial "
 msgstr ""
 
-#: build/lib/opac/webapp/templates/macros/issue.html:10
 #: opac/webapp/templates/macros/issue.html:10
 msgid "número especial"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/news/includes/collection_news_row.html:16
 #: opac/webapp/templates/news/includes/collection_news_row.html:16
 msgid "continue lendo"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/news/includes/issue_last_row.html:15
 #: opac/webapp/templates/news/includes/issue_last_row.html:15
 msgid "Suplemento"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/news/includes/issue_last_row.html:20
 #: opac/webapp/templates/news/includes/issue_last_row.html:20
 msgid "Ver"
 msgstr ""

--- a/opac/webapp/translations/es_MX/LC_MESSAGES/messages.po
+++ b/opac/webapp/translations/es_MX/LC_MESSAGES/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-05-09 17:02-0300\n"
+"POT-Creation-Date: 2019-05-31 21:18+0000\n"
 "PO-Revision-Date: 2016-02-09 09:39-0600\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es_MX\n"
@@ -19,30 +19,13 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.6.0\n"
 
-#: build/lib/opac/tests/test_admin_custom_filters.py:100
-#: build/lib/opac/tests/test_admin_custom_filters.py:114
-#: build/lib/opac/tests/test_admin_custom_filters.py:129
-#: build/lib/opac/tests/test_admin_custom_filters.py:144
-#: build/lib/opac/tests/test_admin_custom_filters.py:158
-#: build/lib/opac/webapp/__init__.py:119
-#: build/lib/opac/webapp/admin/views.py:533
-#: build/lib/opac/webapp/admin/views.py:610
-#: build/lib/opac/webapp/admin/views.py:680
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:28
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:71
-#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_grouper_table_row.html:15
-#: build/lib/opac/webapp/templates/collection/list_journal.html:49
-#: build/lib/opac/webapp/templates/collection/list_journal.html:221
-#: build/lib/opac/webapp/templates/collection/list_journal.html:235
-#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:116
-#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:112
 #: opac/tests/test_admin_custom_filters.py:100
 #: opac/tests/test_admin_custom_filters.py:114
 #: opac/tests/test_admin_custom_filters.py:129
 #: opac/tests/test_admin_custom_filters.py:144
 #: opac/tests/test_admin_custom_filters.py:158 opac/webapp/__init__.py:119
-#: opac/webapp/admin/views.py:533 opac/webapp/admin/views.py:610
-#: opac/webapp/admin/views.py:680
+#: opac/webapp/admin/views.py:534 opac/webapp/admin/views.py:611
+#: opac/webapp/admin/views.py:681
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:28
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:71
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_grouper_table_row.html:15
@@ -54,38 +37,21 @@ msgstr ""
 msgid "Periódico"
 msgstr ""
 
-#: build/lib/opac/tests/test_interface_menu.py:51
 #: opac/tests/test_interface_menu.py:51
 msgid "NOME DA COLEÇÃO!!"
 msgstr ""
 
-#: build/lib/opac/tests/test_interface_menu.py:53
-#: build/lib/opac/tests/test_interface_menu.py:75
-#: build/lib/opac/webapp/templates/collection/includes/nav.html:12
-#: build/lib/opac/webapp/templates/collection/includes/nav.html:54
 #: opac/tests/test_interface_menu.py:53 opac/tests/test_interface_menu.py:75
 #: opac/webapp/templates/collection/includes/nav.html:12
 #: opac/webapp/templates/collection/includes/nav.html:54
 msgid "Lista alfabética de periódicos"
 msgstr ""
 
-#: build/lib/opac/tests/test_interface_menu.py:55
-#: build/lib/opac/webapp/templates/collection/includes/nav.html:17
 #: opac/tests/test_interface_menu.py:55
 #: opac/webapp/templates/collection/includes/nav.html:17
 msgid "Lista temática de periódicos"
 msgstr ""
 
-#: build/lib/opac/tests/test_interface_menu.py:61
-#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:11
-#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:70
-#: build/lib/opac/webapp/templates/collection/includes/nav.html:27
-#: build/lib/opac/webapp/templates/collection/includes/nav.html:69
-#: build/lib/opac/webapp/templates/includes/metric_modal.html:7
-#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:101
-#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:105
-#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:97
-#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:101
 #: opac/tests/test_interface_menu.py:61
 #: opac/webapp/templates/article/includes/floating_menu.html:11
 #: opac/webapp/templates/article/includes/floating_menu.html:70
@@ -99,383 +65,332 @@ msgstr ""
 msgid "Métricas"
 msgstr ""
 
-#: build/lib/opac/tests/test_interface_menu.py:63
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu.html:12
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu.html:29
 #: opac/tests/test_interface_menu.py:63
 #: opac/webapp/templates/collection/includes/levelMenu.html:12
 #: opac/webapp/templates/collection/includes/levelMenu.html:29
 msgid "Sobre o SciELO"
 msgstr ""
 
-#: build/lib/opac/tests/test_interface_menu.py:65
-#: build/lib/opac/tests/test_interface_menu.py:99
-#: build/lib/opac/webapp/templates/collection/includes/nav.html:37
-#: build/lib/opac/webapp/templates/collection/includes/nav.html:84
 #: opac/tests/test_interface_menu.py:65 opac/tests/test_interface_menu.py:99
 #: opac/webapp/templates/collection/includes/nav.html:37
 #: opac/webapp/templates/collection/includes/nav.html:84
 msgid "Contatos"
 msgstr ""
 
-#: build/lib/opac/tests/test_interface_menu.py:67
 #: opac/tests/test_interface_menu.py:67
 msgid "Rede SciELO"
 msgstr ""
 
-#: build/lib/opac/tests/test_interface_menu.py:71
-#: build/lib/opac/webapp/templates/collection/includes/nav.html:49
 #: opac/tests/test_interface_menu.py:71
 #: opac/webapp/templates/collection/includes/nav.html:49
 msgid "Coleções nacionais e temáticas"
 msgstr ""
 
-#: build/lib/opac/tests/test_interface_menu.py:79
-#: build/lib/opac/webapp/templates/collection/includes/nav.html:59
 #: opac/tests/test_interface_menu.py:79
 #: opac/webapp/templates/collection/includes/nav.html:59
 msgid "Lista de periódicos por assunto"
 msgstr ""
 
-#: build/lib/opac/tests/test_interface_menu.py:91
-#: build/lib/opac/webapp/templates/collection/includes/nav.html:74
 #: opac/tests/test_interface_menu.py:91
 #: opac/webapp/templates/collection/includes/nav.html:74
 msgid "Acesso OAI e RSS"
 msgstr ""
 
-#: build/lib/opac/tests/test_interface_menu.py:95
-#: build/lib/opac/webapp/templates/collection/includes/nav.html:79
 #: opac/tests/test_interface_menu.py:95
 #: opac/webapp/templates/collection/includes/nav.html:79
 msgid "Sobre a Rede SciELO"
 msgstr ""
 
-#: build/lib/opac/tests/test_main_errors.py:8 opac/tests/test_main_errors.py:8
+#: opac/tests/test_main_errors.py:8
 msgid "Mensagem de erro explicativo para o usuário"
 msgstr ""
 
-#: build/lib/opac/webapp/__init__.py:118 build/lib/opac/webapp/__init__.py:119
-#: build/lib/opac/webapp/__init__.py:120 build/lib/opac/webapp/__init__.py:121
-#: build/lib/opac/webapp/__init__.py:122 build/lib/opac/webapp/__init__.py:123
 #: opac/webapp/__init__.py:118 opac/webapp/__init__.py:119
 #: opac/webapp/__init__.py:120 opac/webapp/__init__.py:121
 #: opac/webapp/__init__.py:122 opac/webapp/__init__.py:123
 msgid "Catálogo"
 msgstr ""
 
-#: build/lib/opac/webapp/__init__.py:118
-#: build/lib/opac/webapp/admin/views.py:452 opac/webapp/__init__.py:118
-#: opac/webapp/admin/views.py:452
+#: opac/webapp/__init__.py:118 opac/webapp/admin/views.py:453
 msgid "Coleção"
 msgstr ""
 
-#: build/lib/opac/webapp/__init__.py:120
-#: build/lib/opac/webapp/admin/views.py:537
-#: build/lib/opac/webapp/admin/views.py:609
-#: build/lib/opac/webapp/templates/issue/grid.html:41
-#: build/lib/opac/webapp/templates/news/includes/issue_last_row.html:11
-#: opac/webapp/__init__.py:120 opac/webapp/admin/views.py:537
-#: opac/webapp/admin/views.py:609 opac/webapp/templates/issue/grid.html:41
+#: opac/webapp/__init__.py:120 opac/webapp/admin/views.py:538
+#: opac/webapp/admin/views.py:610 opac/webapp/templates/issue/grid.html:41
 #: opac/webapp/templates/news/includes/issue_last_row.html:11
 msgid "Número"
 msgstr ""
 
-#: build/lib/opac/webapp/__init__.py:121 opac/webapp/__init__.py:121
+#: opac/webapp/__init__.py:121
 msgid "Artigo"
 msgstr ""
 
-#: build/lib/opac/webapp/__init__.py:122
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:27
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:70
 #: opac/webapp/__init__.py:122
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:27
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:70
 msgid "Financiador"
 msgstr ""
 
-#: build/lib/opac/webapp/__init__.py:123 opac/webapp/__init__.py:123
+#: opac/webapp/__init__.py:123
 msgid "Press Release"
 msgstr ""
 
-#: build/lib/opac/webapp/__init__.py:124
-#: build/lib/opac/webapp/templates/journal/detail.html:160
-#: opac/webapp/__init__.py:124 opac/webapp/templates/journal/detail.html:160
+#: opac/webapp/__init__.py:124 opac/webapp/templates/journal/detail.html:167
 msgid "Notícias"
 msgstr ""
 
-#: build/lib/opac/webapp/__init__.py:125 build/lib/opac/webapp/__init__.py:126
 #: opac/webapp/__init__.py:125 opac/webapp/__init__.py:126
 msgid "Ativos"
 msgstr ""
 
-#: build/lib/opac/webapp/__init__.py:127 opac/webapp/__init__.py:127
+#: opac/webapp/__init__.py:127
 msgid "Páginas"
 msgstr ""
 
-#: build/lib/opac/webapp/__init__.py:128 build/lib/opac/webapp/__init__.py:129
 #: opac/webapp/__init__.py:128 opac/webapp/__init__.py:129
 msgid "Gestão"
 msgstr ""
 
-#: build/lib/opac/webapp/__init__.py:128 opac/webapp/__init__.py:128
+#: opac/webapp/__init__.py:128
 msgid "Auditoria: Páginas"
 msgstr ""
 
-#: build/lib/opac/webapp/__init__.py:129
-#: build/lib/opac/webapp/admin/views.py:896 opac/webapp/__init__.py:129
-#: opac/webapp/admin/views.py:896
+#: opac/webapp/__init__.py:129 opac/webapp/admin/views.py:897
 msgid "Usuário"
 msgstr ""
 
-#: build/lib/opac/webapp/choices.py:7 opac/webapp/choices.py:7
+#: opac/webapp/choices.py:7
 msgid "Conteúdo temporariamente indisponível"
 msgstr ""
 
-#: build/lib/opac/webapp/choices.py:11 build/lib/opac/webapp/choices.py:23
-#: build/lib/opac/webapp/templates/article/includes/modal/download.html:26
 #: opac/webapp/choices.py:11 opac/webapp/choices.py:23
 #: opac/webapp/templates/article/includes/modal/download.html:26
 msgid "Português"
 msgstr ""
 
-#: build/lib/opac/webapp/choices.py:12 build/lib/opac/webapp/choices.py:24
-#: build/lib/opac/webapp/templates/article/includes/modal/download.html:24
 #: opac/webapp/choices.py:12 opac/webapp/choices.py:24
 #: opac/webapp/templates/article/includes/modal/download.html:24
 msgid "Inglês"
 msgstr ""
 
-#: build/lib/opac/webapp/choices.py:13 build/lib/opac/webapp/choices.py:25
-#: build/lib/opac/webapp/templates/article/includes/modal/download.html:22
 #: opac/webapp/choices.py:13 opac/webapp/choices.py:25
 #: opac/webapp/templates/article/includes/modal/download.html:22
 msgid "Espanhol"
 msgstr ""
 
-#: build/lib/opac/webapp/choices.py:26 opac/webapp/choices.py:26
+#: opac/webapp/choices.py:26
 msgid "Albanês"
 msgstr ""
 
-#: build/lib/opac/webapp/choices.py:27 build/lib/opac/webapp/choices.py:33
 #: opac/webapp/choices.py:27 opac/webapp/choices.py:33
 msgid "Chinês"
 msgstr ""
 
-#: build/lib/opac/webapp/choices.py:28 opac/webapp/choices.py:28
+#: opac/webapp/choices.py:28
 msgid "Romeno"
 msgstr ""
 
-#: build/lib/opac/webapp/choices.py:29 opac/webapp/choices.py:29
+#: opac/webapp/choices.py:29
 msgid "Francês"
 msgstr ""
 
-#: build/lib/opac/webapp/choices.py:30 opac/webapp/choices.py:30
+#: opac/webapp/choices.py:30
 msgid "Italiano"
 msgstr ""
 
-#: build/lib/opac/webapp/choices.py:31 opac/webapp/choices.py:31
+#: opac/webapp/choices.py:31
 msgid "Russo"
 msgstr ""
 
-#: build/lib/opac/webapp/choices.py:32 opac/webapp/choices.py:32
+#: opac/webapp/choices.py:32
 msgid "Árabe"
 msgstr ""
 
-#: build/lib/opac/webapp/choices.py:37 opac/webapp/choices.py:37
+#: opac/webapp/choices.py:37
 msgid "corrente"
 msgstr ""
 
-#: build/lib/opac/webapp/choices.py:38 opac/webapp/choices.py:38
+#: opac/webapp/choices.py:38
 msgid "terminado"
 msgstr ""
 
-#: build/lib/opac/webapp/choices.py:39 opac/webapp/choices.py:39
+#: opac/webapp/choices.py:39
 msgid "indexação interrompida"
 msgstr ""
 
-#: build/lib/opac/webapp/choices.py:40 opac/webapp/choices.py:40
+#: opac/webapp/choices.py:40
 msgid "indexação interrompida pelo Comitê"
 msgstr ""
 
-#: build/lib/opac/webapp/choices.py:41 opac/webapp/choices.py:41
+#: opac/webapp/choices.py:41
 msgid "publicação finalizada"
 msgstr ""
 
-#: build/lib/opac/webapp/choices.py:45 opac/webapp/choices.py:45
+#: opac/webapp/choices.py:45
 msgid "Ciências Agrárias"
 msgstr ""
 
-#: build/lib/opac/webapp/choices.py:46 opac/webapp/choices.py:46
+#: opac/webapp/choices.py:46
 msgid "Ciências Sociais Aplicadas"
 msgstr ""
 
-#: build/lib/opac/webapp/choices.py:47 opac/webapp/choices.py:47
+#: opac/webapp/choices.py:47
 msgid "Ciências Biológicas"
 msgstr ""
 
-#: build/lib/opac/webapp/choices.py:48 opac/webapp/choices.py:48
+#: opac/webapp/choices.py:48
 msgid "Engenharias"
 msgstr ""
 
-#: build/lib/opac/webapp/choices.py:49 opac/webapp/choices.py:49
+#: opac/webapp/choices.py:49
 msgid "Ciências Exatas e da Terra"
 msgstr ""
 
-#: build/lib/opac/webapp/choices.py:50 opac/webapp/choices.py:50
+#: opac/webapp/choices.py:50
 msgid "Ciências da Saúde"
 msgstr ""
 
-#: build/lib/opac/webapp/choices.py:51 opac/webapp/choices.py:51
+#: opac/webapp/choices.py:51
 msgid "Ciências Humanas"
 msgstr ""
 
-#: build/lib/opac/webapp/choices.py:52 build/lib/opac/webapp/choices.py:53
 #: opac/webapp/choices.py:52 opac/webapp/choices.py:53
 msgid "Lingüística, Letras e Artes"
 msgstr ""
 
-#: build/lib/opac/webapp/controllers.py:353 opac/webapp/controllers.py:353
+#: opac/webapp/controllers.py:353
 msgid "Lista Alfabética"
 msgstr ""
 
-#: build/lib/opac/webapp/controllers.py:357 opac/webapp/controllers.py:357
+#: opac/webapp/controllers.py:357
 msgid "Lista Temática"
 msgstr ""
 
-#: build/lib/opac/webapp/controllers.py:361 opac/webapp/controllers.py:361
+#: opac/webapp/controllers.py:361
 msgid "Lista Web of Science"
 msgstr ""
 
-#: build/lib/opac/webapp/controllers.py:365 opac/webapp/controllers.py:365
+#: opac/webapp/controllers.py:365
 msgid "Lista by Institution"
 msgstr ""
 
-#: build/lib/opac/webapp/controllers.py:424 opac/webapp/controllers.py:424
+#: opac/webapp/controllers.py:424
 msgid "Obrigatório um jid."
 msgstr ""
 
-#: build/lib/opac/webapp/controllers.py:440 opac/webapp/controllers.py:440
+#: opac/webapp/controllers.py:440
 msgid "Obrigatório um acronym."
 msgstr ""
 
-#: build/lib/opac/webapp/controllers.py:456 opac/webapp/controllers.py:456
+#: opac/webapp/controllers.py:456
 msgid "Obrigatório um url_seg."
 msgstr ""
 
-#: build/lib/opac/webapp/controllers.py:472 opac/webapp/controllers.py:472
+#: opac/webapp/controllers.py:472
 msgid "Obrigatório um issn."
 msgstr ""
 
-#: build/lib/opac/webapp/controllers.py:487 opac/webapp/controllers.py:487
+#: opac/webapp/controllers.py:487
 msgid "Obrigatório um title."
 msgstr ""
 
-#: build/lib/opac/webapp/controllers.py:525
-#: build/lib/opac/webapp/controllers.py:669
-#: build/lib/opac/webapp/controllers.py:830 opac/webapp/controllers.py:525
-#: opac/webapp/controllers.py:669 opac/webapp/controllers.py:830
+#: opac/webapp/controllers.py:525 opac/webapp/controllers.py:669
+#: opac/webapp/controllers.py:830
 msgid "Obrigatório uma lista de ids."
 msgstr ""
 
-#: build/lib/opac/webapp/controllers.py:631
-#: build/lib/opac/webapp/controllers.py:851 opac/webapp/controllers.py:631
-#: opac/webapp/controllers.py:851
+#: opac/webapp/controllers.py:631 opac/webapp/controllers.py:851
 msgid "Obrigatório um iid."
 msgstr ""
 
-#: build/lib/opac/webapp/controllers.py:688 opac/webapp/controllers.py:688
+#: opac/webapp/controllers.py:688
 msgid "Obrigatório um jacron e issue_label."
 msgstr ""
 
-#: build/lib/opac/webapp/controllers.py:701 opac/webapp/controllers.py:701
+#: opac/webapp/controllers.py:701
 msgid "Obrigatório um PID."
 msgstr ""
 
-#: build/lib/opac/webapp/controllers.py:717 opac/webapp/controllers.py:717
+#: opac/webapp/controllers.py:717
 msgid "Obrigatório um url_seg e url_seg_issue."
 msgstr ""
 
-#: build/lib/opac/webapp/controllers.py:724 opac/webapp/controllers.py:724
+#: opac/webapp/controllers.py:724
 msgid "Obrigatório um assets_code."
 msgstr ""
 
-#: build/lib/opac/webapp/controllers.py:727 opac/webapp/controllers.py:727
+#: opac/webapp/controllers.py:727
 msgid "Obrigatório um journal."
 msgstr ""
 
-#: build/lib/opac/webapp/controllers.py:743 opac/webapp/controllers.py:743
+#: opac/webapp/controllers.py:743
 msgid "Obrigatório um aid."
 msgstr ""
 
-#: build/lib/opac/webapp/controllers.py:757 opac/webapp/controllers.py:757
+#: opac/webapp/controllers.py:757
 msgid "Obrigatório um url_seg_article."
 msgstr ""
 
-#: build/lib/opac/webapp/controllers.py:772 opac/webapp/controllers.py:772
+#: opac/webapp/controllers.py:772
 msgid "Obrigatório um iid and url_seg_article."
 msgstr ""
 
-#: build/lib/opac/webapp/controllers.py:788 opac/webapp/controllers.py:788
+#: opac/webapp/controllers.py:788
 msgid "Obrigatório um jid, url_seg_issue and url_seg_article."
 msgstr ""
 
-#: build/lib/opac/webapp/controllers.py:889 opac/webapp/controllers.py:889
+#: opac/webapp/controllers.py:889
 msgid "Obrigatório um pid."
 msgstr ""
 
-#: build/lib/opac/webapp/controllers.py:902 opac/webapp/controllers.py:902
+#: opac/webapp/controllers.py:902
 msgid "Obrigatório um aop_pid."
 msgstr ""
 
-#: build/lib/opac/webapp/controllers.py:913 opac/webapp/controllers.py:913
+#: opac/webapp/controllers.py:913
 msgid "Parámetro obrigatório: issue_iid."
 msgstr ""
 
-#: build/lib/opac/webapp/controllers.py:961 opac/webapp/controllers.py:961
+#: opac/webapp/controllers.py:961
 msgid "Parâmetro email deve ser uma string"
 msgstr ""
 
-#: build/lib/opac/webapp/controllers.py:972 opac/webapp/controllers.py:972
+#: opac/webapp/controllers.py:972
 msgid "Parâmetro email deve ser uma inteiro"
 msgstr ""
 
-#: build/lib/opac/webapp/controllers.py:984
-#: build/lib/opac/webapp/controllers.py:998 opac/webapp/controllers.py:984
-#: opac/webapp/controllers.py:998
+#: opac/webapp/controllers.py:984 opac/webapp/controllers.py:998
 #, python-format
 msgid "Usuário deve ser do tipo %s"
 msgstr ""
 
-#: build/lib/opac/webapp/controllers.py:1054 opac/webapp/controllers.py:1054
+#: opac/webapp/controllers.py:1054
 msgid "Compartilhamento de link SciELO"
 msgstr ""
 
-#: build/lib/opac/webapp/controllers.py:1055 opac/webapp/controllers.py:1055
+#: opac/webapp/controllers.py:1055
 #, python-format
 msgid "O usuário %s compartilha este link: %s, da SciELO"
 msgstr ""
 
-#: build/lib/opac/webapp/controllers.py:1063
-#: build/lib/opac/webapp/controllers.py:1099
-#: build/lib/opac/webapp/controllers.py:1121 opac/webapp/controllers.py:1063
-#: opac/webapp/controllers.py:1099 opac/webapp/controllers.py:1121
+#: opac/webapp/controllers.py:1063 opac/webapp/controllers.py:1099
+#: opac/webapp/controllers.py:1121
 msgid "Mensagem enviada!"
 msgstr ""
 
-#: build/lib/opac/webapp/controllers.py:1080 opac/webapp/controllers.py:1080
+#: opac/webapp/controllers.py:1080
 msgid "[Erro] Erro informado pelo usuário no site SciELO"
 msgstr ""
 
-#: build/lib/opac/webapp/controllers.py:1083 opac/webapp/controllers.py:1083
+#: opac/webapp/controllers.py:1083
 msgid "aplicação"
 msgstr ""
 
-#: build/lib/opac/webapp/controllers.py:1085 opac/webapp/controllers.py:1085
+#: opac/webapp/controllers.py:1085
 msgid "conteúdo"
 msgstr ""
 
-#: build/lib/opac/webapp/controllers.py:1090 opac/webapp/controllers.py:1090
+#: opac/webapp/controllers.py:1090
 #, python-format
 msgid ""
 "O usuário <b>%s</b> com e-mail: <b>%s</b>, informa que existe um erro na "
@@ -483,463 +398,412 @@ msgid ""
 " %s"
 msgstr ""
 
-#: build/lib/opac/webapp/controllers.py:1111 opac/webapp/controllers.py:1111
+#: opac/webapp/controllers.py:1111
 msgid "Contato de usuário via site SciELO"
 msgstr ""
 
-#: build/lib/opac/webapp/controllers.py:1113 opac/webapp/controllers.py:1113
+#: opac/webapp/controllers.py:1113
 #, python-format
 msgid "O usuário %s, com e-mail: %s, entra em contato com a seguinte mensagem:"
 msgstr ""
 
-#: build/lib/opac/webapp/controllers.py:1145 opac/webapp/controllers.py:1145
+#: opac/webapp/controllers.py:1145
 msgid "Obrigatório um slug_name."
 msgstr ""
 
-#: build/lib/opac/webapp/forms.py:29 opac/webapp/forms.py:29
+#: opac/webapp/forms.py:29
 msgid "Endereço de e-mail inválido."
 msgstr ""
 
-#: build/lib/opac/webapp/admin/forms.py:9
-#: build/lib/opac/webapp/admin/forms.py:21 opac/webapp/admin/forms.py:9
-#: opac/webapp/admin/forms.py:21
+#: opac/webapp/admin/forms.py:9 opac/webapp/admin/forms.py:21
 msgid "Email"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/forms.py:10
-#: build/lib/opac/webapp/admin/forms.py:25 opac/webapp/admin/forms.py:10
-#: opac/webapp/admin/forms.py:25
+#: opac/webapp/admin/forms.py:10 opac/webapp/admin/forms.py:25
 msgid "Senha"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/forms.py:15 opac/webapp/admin/forms.py:15
+#: opac/webapp/admin/forms.py:15
 msgid "Usuário inválido"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/forms.py:17 opac/webapp/admin/forms.py:17
+#: opac/webapp/admin/forms.py:17
 msgid "Senha inválida"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:28 opac/webapp/admin/views.py:28
+#: opac/webapp/admin/views.py:28
 msgid "Tem certeza que quer publicar os itens selecionados?"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:29 opac/webapp/admin/views.py:29
+#: opac/webapp/admin/views.py:29
 msgid "Tem certeza que quer despublicar os itens selecionados?"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:30 opac/webapp/admin/views.py:30
+#: opac/webapp/admin/views.py:30
 msgid "Tem certeza que quer reconstruir os artigos selecionados?"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:31 opac/webapp/admin/views.py:31
+#: opac/webapp/admin/views.py:31
 msgid ""
 "Tem certeza que quer enviar email de confirmação aos usuários "
 "selecionados?"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:91
-#: build/lib/opac/webapp/admin/views.py:104 opac/webapp/admin/views.py:91
-#: opac/webapp/admin/views.py:104
+#: opac/webapp/admin/views.py:91 opac/webapp/admin/views.py:104
 msgid "Usuário não encontrado"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:94 opac/webapp/admin/views.py:94
+#: opac/webapp/admin/views.py:94
 #, python-format
 msgid "Email: %(email)s confirmado com sucesso!"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:110 opac/webapp/admin/views.py:110
+#: opac/webapp/admin/views.py:110
 #, python-format
 msgid "Enviamos as instruções para recuperar a senha para: %(email)s"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:113 opac/webapp/admin/views.py:113
+#: opac/webapp/admin/views.py:113
 #, python-format
 msgid ""
 "Ocorreu um erro no envio das instruções por email para: %(email)s. Erro: "
 "%(error)s"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:139 opac/webapp/admin/views.py:139
+#: opac/webapp/admin/views.py:139
 msgid "Nova senha salva com sucesso!!"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:167
-#: build/lib/opac/webapp/admin/views.py:186 opac/webapp/admin/views.py:167
-#: opac/webapp/admin/views.py:186
+#: opac/webapp/admin/views.py:167 opac/webapp/admin/views.py:186
 #, python-format
 msgid "Enviamos o email de confirmação para: %(email)s"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:170 opac/webapp/admin/views.py:170
+#: opac/webapp/admin/views.py:170
 #, python-format
 msgid ""
 "Ocorreu um erro no envio do email de confirmação para: %(email)s "
 "%(error_msg)s"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:177 opac/webapp/admin/views.py:177
+#: opac/webapp/admin/views.py:177
 msgid "Enviar email de confirmação"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:189 opac/webapp/admin/views.py:189
+#: opac/webapp/admin/views.py:189
 #, python-format
 msgid "Ocorreu um erro no envio do email de confirmação para: %(email)s"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:193 opac/webapp/admin/views.py:193
+#: opac/webapp/admin/views.py:193
 #, python-format
 msgid "%(count)s usuários foram notificados com sucesso!"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:196 opac/webapp/admin/views.py:196
+#: opac/webapp/admin/views.py:196
 #, python-format
 msgid "Ocorreu um erro no envio do emails de confirmação. Erro: %(ex)s"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:231
-#: build/lib/opac/webapp/admin/views.py:265
-#: build/lib/opac/webapp/admin/views.py:363
-#: build/lib/opac/webapp/admin/views.py:393
-#: build/lib/opac/webapp/admin/views.py:677 opac/webapp/admin/views.py:231
-#: opac/webapp/admin/views.py:265 opac/webapp/admin/views.py:363
-#: opac/webapp/admin/views.py:393 opac/webapp/admin/views.py:677
+#: opac/webapp/admin/views.py:231 opac/webapp/admin/views.py:265
+#: opac/webapp/admin/views.py:363 opac/webapp/admin/views.py:393
+#: opac/webapp/admin/views.py:678
 msgid "Nome"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:232
-#: build/lib/opac/webapp/admin/views.py:267 opac/webapp/admin/views.py:232
-#: opac/webapp/admin/views.py:267
+#: opac/webapp/admin/views.py:232 opac/webapp/admin/views.py:267
 msgid "Link"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:233
-#: build/lib/opac/webapp/admin/views.py:268
-#: build/lib/opac/webapp/admin/views.py:678 opac/webapp/admin/views.py:233
-#: opac/webapp/admin/views.py:268 opac/webapp/admin/views.py:678
+#: opac/webapp/admin/views.py:233 opac/webapp/admin/views.py:268
+#: opac/webapp/admin/views.py:679
 msgid "Idioma"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:266 opac/webapp/admin/views.py:266
+#: opac/webapp/admin/views.py:266
 msgid "Previsualização"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:362
-#: build/lib/opac/webapp/admin/views.py:547
-#: build/lib/opac/webapp/admin/views.py:627 opac/webapp/admin/views.py:362
-#: opac/webapp/admin/views.py:547 opac/webapp/admin/views.py:627
+#: opac/webapp/admin/views.py:362 opac/webapp/admin/views.py:548
+#: opac/webapp/admin/views.py:628
 msgid "Ordem"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:364 opac/webapp/admin/views.py:364
+#: opac/webapp/admin/views.py:364
 msgid "URL"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:365 opac/webapp/admin/views.py:365
+#: opac/webapp/admin/views.py:365
 msgid "URL da logomarca"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:375 opac/webapp/admin/views.py:375
+#: opac/webapp/admin/views.py:375
 msgid "Financiador com Ordem ou Nome já cadastrado!"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:394 opac/webapp/admin/views.py:394
+#: opac/webapp/admin/views.py:394
 msgid "Acerca de"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:395
-#: build/lib/opac/webapp/admin/views.py:462 opac/webapp/admin/views.py:395
-#: opac/webapp/admin/views.py:462
+#: opac/webapp/admin/views.py:395 opac/webapp/admin/views.py:463
 msgid "Acrônimo"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:396 opac/webapp/admin/views.py:396
+#: opac/webapp/admin/views.py:396
 msgid "Endereço principal"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:397 opac/webapp/admin/views.py:397
+#: opac/webapp/admin/views.py:397
 msgid "Endereço secundário"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:398 opac/webapp/admin/views.py:398
+#: opac/webapp/admin/views.py:398
 msgid "Logo da Home (PT)"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:399 opac/webapp/admin/views.py:399
+#: opac/webapp/admin/views.py:399
 msgid "Logo da Home (EN)"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:400 opac/webapp/admin/views.py:400
+#: opac/webapp/admin/views.py:400
 msgid "Logo da Home (ES)"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:401 opac/webapp/admin/views.py:401
+#: opac/webapp/admin/views.py:401
 msgid "Logo do cabeçalho (PT)"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:402 opac/webapp/admin/views.py:402
+#: opac/webapp/admin/views.py:402
 msgid "Logo do cabeçalho (EN)"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:403 opac/webapp/admin/views.py:403
+#: opac/webapp/admin/views.py:403
 msgid "Logo do cabeçalho (ES)"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:404 opac/webapp/admin/views.py:404
+#: opac/webapp/admin/views.py:404
 msgid "Logo do menu (PT)"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:405
-#: build/lib/opac/webapp/admin/views.py:406 opac/webapp/admin/views.py:405
-#: opac/webapp/admin/views.py:406
+#: opac/webapp/admin/views.py:405 opac/webapp/admin/views.py:406
 msgid "Logo do menu (ES)"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:407 opac/webapp/admin/views.py:407
+#: opac/webapp/admin/views.py:407
 msgid "Logo do menu (drop)"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:408 opac/webapp/admin/views.py:408
+#: opac/webapp/admin/views.py:408
 msgid "Logo do rodapé"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:451 opac/webapp/admin/views.py:451
+#: opac/webapp/admin/views.py:452
 msgid "Id Periódico"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:453 opac/webapp/admin/views.py:453
+#: opac/webapp/admin/views.py:454
 msgid "Linha do tempo"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:454 opac/webapp/admin/views.py:454
+#: opac/webapp/admin/views.py:455
 msgid "Categorias de assunto"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:455 opac/webapp/admin/views.py:455
+#: opac/webapp/admin/views.py:456
 msgid "Áreas de estudo"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:456 opac/webapp/admin/views.py:456
+#: opac/webapp/admin/views.py:457
 msgid "Redes sociais"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:457
-#: build/lib/opac/webapp/admin/views.py:611
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:30
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:73
-#: opac/webapp/admin/views.py:457 opac/webapp/admin/views.py:611
+#: opac/webapp/admin/views.py:458 opac/webapp/admin/views.py:612
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:30
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:73
 msgid "Título"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:458 opac/webapp/admin/views.py:458
+#: opac/webapp/admin/views.py:459
 msgid "Título ISO"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:459 opac/webapp/admin/views.py:459
+#: opac/webapp/admin/views.py:460
 msgid "Título curto"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:460
-#: build/lib/opac/webapp/admin/views.py:538
-#: build/lib/opac/webapp/admin/views.py:614 opac/webapp/admin/views.py:460
-#: opac/webapp/admin/views.py:538 opac/webapp/admin/views.py:614
+#: opac/webapp/admin/views.py:461 opac/webapp/admin/views.py:539
+#: opac/webapp/admin/views.py:615
 msgid "Criado"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:461
-#: build/lib/opac/webapp/admin/views.py:539
-#: build/lib/opac/webapp/admin/views.py:615 opac/webapp/admin/views.py:461
-#: opac/webapp/admin/views.py:539 opac/webapp/admin/views.py:615
+#: opac/webapp/admin/views.py:462 opac/webapp/admin/views.py:540
+#: opac/webapp/admin/views.py:616
 msgid "Atualizado"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:463 opac/webapp/admin/views.py:463
+#: opac/webapp/admin/views.py:464
 msgid "ISSN SciELO"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:464 opac/webapp/admin/views.py:464
+#: opac/webapp/admin/views.py:465
 msgid "ISSN impresso"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:465 opac/webapp/admin/views.py:465
+#: opac/webapp/admin/views.py:466
 msgid "ISSN eletrônico"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:466 opac/webapp/admin/views.py:466
+#: opac/webapp/admin/views.py:467
 msgid "Descritores de assunto"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:467 opac/webapp/admin/views.py:467
+#: opac/webapp/admin/views.py:468
 msgid "Url da submissão online"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:468 opac/webapp/admin/views.py:468
+#: opac/webapp/admin/views.py:469
 msgid "Url do capa"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:469 opac/webapp/admin/views.py:469
+#: opac/webapp/admin/views.py:470
 msgid "Url do logotipo"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:470 opac/webapp/admin/views.py:470
+#: opac/webapp/admin/views.py:471
 msgid "Outros títulos"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:471 opac/webapp/admin/views.py:471
+#: opac/webapp/admin/views.py:472
 msgid "Nome da editora"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:472 opac/webapp/admin/views.py:472
+#: opac/webapp/admin/views.py:473
 msgid "País da editora"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:473 opac/webapp/admin/views.py:473
+#: opac/webapp/admin/views.py:474
 msgid "Estado da editora"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:474 opac/webapp/admin/views.py:474
+#: opac/webapp/admin/views.py:475
 msgid "Cidade da editora"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:475 opac/webapp/admin/views.py:475
+#: opac/webapp/admin/views.py:476
 msgid "Endereço da editora"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:476 opac/webapp/admin/views.py:476
+#: opac/webapp/admin/views.py:477
 msgid "Telefone da editora"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:477 opac/webapp/admin/views.py:477
+#: opac/webapp/admin/views.py:478
 msgid "Missão"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:478 opac/webapp/admin/views.py:478
+#: opac/webapp/admin/views.py:479
 msgid "No índice"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:479 opac/webapp/admin/views.py:479
+#: opac/webapp/admin/views.py:480
 msgid "Patrocinadores"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:480 opac/webapp/admin/views.py:480
+#: opac/webapp/admin/views.py:481
 msgid "Ref periódico anterior"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:481 opac/webapp/admin/views.py:481
+#: opac/webapp/admin/views.py:482
 msgid "Situação atual"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:482 opac/webapp/admin/views.py:482
+#: opac/webapp/admin/views.py:483
 msgid "Total de números"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:483
-#: build/lib/opac/webapp/admin/views.py:548
-#: build/lib/opac/webapp/admin/views.py:618 opac/webapp/admin/views.py:483
-#: opac/webapp/admin/views.py:548 opac/webapp/admin/views.py:618
+#: opac/webapp/admin/views.py:484 opac/webapp/admin/views.py:549
+#: opac/webapp/admin/views.py:619
 msgid "Publicado?"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:484
-#: build/lib/opac/webapp/admin/views.py:549
-#: build/lib/opac/webapp/admin/views.py:619 opac/webapp/admin/views.py:484
-#: opac/webapp/admin/views.py:549 opac/webapp/admin/views.py:619
+#: opac/webapp/admin/views.py:485 opac/webapp/admin/views.py:550
+#: opac/webapp/admin/views.py:620
 msgid "Motivo de despublicação"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:485
-#: build/lib/opac/webapp/admin/views.py:551
-#: build/lib/opac/webapp/admin/views.py:620 opac/webapp/admin/views.py:485
-#: opac/webapp/admin/views.py:551 opac/webapp/admin/views.py:620
+#: opac/webapp/admin/views.py:486 opac/webapp/admin/views.py:552
+#: opac/webapp/admin/views.py:621
 msgid "Segmento de URL"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:488
-#: build/lib/opac/webapp/admin/views.py:554
-#: build/lib/opac/webapp/admin/views.py:633 opac/webapp/admin/views.py:488
-#: opac/webapp/admin/views.py:554 opac/webapp/admin/views.py:633
+#: opac/webapp/admin/views.py:489 opac/webapp/admin/views.py:555
+#: opac/webapp/admin/views.py:634
 msgid "Publicar"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:493 opac/webapp/admin/views.py:493
+#: opac/webapp/admin/views.py:494
 msgid "Periódico(s) publicado(s) com sucesso!!"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:495 opac/webapp/admin/views.py:495
+#: opac/webapp/admin/views.py:496
 msgid "Ocorreu um erro tentando publicar o(s) periódico(s)!!"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:501 opac/webapp/admin/views.py:501
+#: opac/webapp/admin/views.py:502
 msgid "Periódico(s) despublicado com sucesso!!"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:504 opac/webapp/admin/views.py:504
+#: opac/webapp/admin/views.py:505
 #, python-format
 msgid "Ocorreu um erro tentando despublicar o(s) periódico(s)!!. Erro: %(ex)s"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:508
-#: build/lib/opac/webapp/admin/views.py:576
-#: build/lib/opac/webapp/admin/views.py:656 opac/webapp/admin/views.py:508
-#: opac/webapp/admin/views.py:576 opac/webapp/admin/views.py:656
+#: opac/webapp/admin/views.py:509 opac/webapp/admin/views.py:577
+#: opac/webapp/admin/views.py:657
 #, python-format
 msgid "Despublicar por %s"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:532 opac/webapp/admin/views.py:532
+#: opac/webapp/admin/views.py:533
 msgid "Id Número"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:534
-#: build/lib/opac/webapp/admin/views.py:624 opac/webapp/admin/views.py:534
-#: opac/webapp/admin/views.py:624
+#: opac/webapp/admin/views.py:535 opac/webapp/admin/views.py:625
 msgid "Seções"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:535 opac/webapp/admin/views.py:535
+#: opac/webapp/admin/views.py:536
 msgid "Url da capa"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:536
-#: build/lib/opac/webapp/templates/collection/list_feed_content.html:3
-#: build/lib/opac/webapp/templates/issue/grid.html:40
-#: build/lib/opac/webapp/templates/news/includes/issue_last_row.html:7
-#: opac/webapp/admin/views.py:536
+#: opac/webapp/admin/views.py:537
 #: opac/webapp/templates/collection/list_feed_content.html:3
 #: opac/webapp/templates/issue/grid.html:40
 #: opac/webapp/templates/news/includes/issue_last_row.html:7
 msgid "Volume"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:540 opac/webapp/admin/views.py:540
+#: opac/webapp/admin/views.py:541
 msgid "Tipo"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:541 opac/webapp/admin/views.py:541
+#: opac/webapp/admin/views.py:542
 msgid "Texto do suplemento"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:542 opac/webapp/admin/views.py:542
+#: opac/webapp/admin/views.py:543
 msgid "Texto do especial"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:543 opac/webapp/admin/views.py:543
+#: opac/webapp/admin/views.py:544
 msgid "Mês inicial"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:544 opac/webapp/admin/views.py:544
+#: opac/webapp/admin/views.py:545
 msgid "Mês final"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:545
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:25
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:68
-#: build/lib/opac/webapp/templates/issue/grid.html:39
-#: build/lib/opac/webapp/templates/news/includes/issue_last_row.html:5
-#: opac/webapp/admin/views.py:545
+#: opac/webapp/admin/views.py:546
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:25
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:68
 #: opac/webapp/templates/issue/grid.html:39
@@ -947,305 +811,254 @@ msgstr ""
 msgid "Ano"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:546 opac/webapp/admin/views.py:546
+#: opac/webapp/admin/views.py:547
 msgid "Etiqueta"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:550
-#: build/lib/opac/webapp/admin/views.py:621 opac/webapp/admin/views.py:550
-#: opac/webapp/admin/views.py:621
+#: opac/webapp/admin/views.py:551 opac/webapp/admin/views.py:622
 msgid "PID"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:559 opac/webapp/admin/views.py:559
+#: opac/webapp/admin/views.py:560
 msgid "Número(s) publicado(s) com sucesso!!"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:562
-#: build/lib/opac/webapp/admin/views.py:642 opac/webapp/admin/views.py:562
-#: opac/webapp/admin/views.py:642
+#: opac/webapp/admin/views.py:563 opac/webapp/admin/views.py:643
 #, python-format
 msgid "Ocorreu um erro tentando publicar o(s) número(s)!!. Erro: %(ex)s"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:569 opac/webapp/admin/views.py:569
+#: opac/webapp/admin/views.py:570
 msgid "Número(s) despublicado(s) com sucesso!!"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:572
-#: build/lib/opac/webapp/admin/views.py:652 opac/webapp/admin/views.py:572
-#: opac/webapp/admin/views.py:652
+#: opac/webapp/admin/views.py:573 opac/webapp/admin/views.py:653
 #, python-format
 msgid "Ocorreu um erro tentando despublicar o(s) número(s)!!. Erro: %(ex)s"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:608 opac/webapp/admin/views.py:608
+#: opac/webapp/admin/views.py:609
 msgid "Id Artigo"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:612 opac/webapp/admin/views.py:612
+#: opac/webapp/admin/views.py:613
 msgid "Seção"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:613 opac/webapp/admin/views.py:613
+#: opac/webapp/admin/views.py:614
 msgid "É Ahead of Print?"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:616 opac/webapp/admin/views.py:616
+#: opac/webapp/admin/views.py:617
 msgid "HTML's"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:617 opac/webapp/admin/views.py:617
+#: opac/webapp/admin/views.py:618
 msgid "Chave de domínio"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:622 opac/webapp/admin/views.py:622
+#: opac/webapp/admin/views.py:623
 msgid "Idioma original"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:623 opac/webapp/admin/views.py:623
+#: opac/webapp/admin/views.py:624
 msgid "Idiomas das traduções"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:625 opac/webapp/admin/views.py:625
+#: opac/webapp/admin/views.py:626
 msgid "Autores"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:626
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:29
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:72
-#: build/lib/opac/webapp/templates/issue/toc.html:176
-#: opac/webapp/admin/views.py:626
+#: opac/webapp/admin/views.py:627
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:29
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:72
-#: opac/webapp/templates/issue/toc.html:176
+#: opac/webapp/templates/issue/toc.html:169
 msgid "Resumo"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:628 opac/webapp/admin/views.py:628
+#: opac/webapp/admin/views.py:629
 msgid "DOI"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:629 opac/webapp/admin/views.py:629
+#: opac/webapp/admin/views.py:630
 msgid "Idiomas"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:630 opac/webapp/admin/views.py:630
+#: opac/webapp/admin/views.py:631
 msgid "Idiomas dos resumos"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:638 opac/webapp/admin/views.py:638
+#: opac/webapp/admin/views.py:639
 msgid "Artigo(s) publicado com sucesso!!"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:649 opac/webapp/admin/views.py:649
+#: opac/webapp/admin/views.py:650
 msgid "Artigo(s) despublicado com sucesso!!"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:679 opac/webapp/admin/views.py:679
+#: opac/webapp/admin/views.py:680
 msgid "Conteúdo"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:681
-#: build/lib/opac/webapp/admin/views.py:901 opac/webapp/admin/views.py:681
-#: opac/webapp/admin/views.py:901
+#: opac/webapp/admin/views.py:682 opac/webapp/admin/views.py:902
 msgid "Descrição"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:682
-#: build/lib/opac/webapp/admin/views.py:898 opac/webapp/admin/views.py:682
-#: opac/webapp/admin/views.py:898
+#: opac/webapp/admin/views.py:683 opac/webapp/admin/views.py:899
 msgid "Data de Criação"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:683 opac/webapp/admin/views.py:683
+#: opac/webapp/admin/views.py:684
 msgid "Data de Atualização"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:897 opac/webapp/admin/views.py:897
+#: opac/webapp/admin/views.py:898
 msgid "Ação"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:899 opac/webapp/admin/views.py:899
+#: opac/webapp/admin/views.py:900
 msgid "Modelo Auditado"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:900 opac/webapp/admin/views.py:900
+#: opac/webapp/admin/views.py:901
 msgid "Id Auditado"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:902 opac/webapp/admin/views.py:902
+#: opac/webapp/admin/views.py:903
 msgid "Dados dos campos"
 msgstr ""
 
-#: build/lib/opac/webapp/main/views.py:34 opac/webapp/main/views.py:34
+#: opac/webapp/main/views.py:34
 msgid "O periódico está indisponível por motivo de: "
 msgstr ""
 
-#: build/lib/opac/webapp/main/views.py:35 opac/webapp/main/views.py:35
+#: opac/webapp/main/views.py:35
 msgid "O número está indisponível por motivo de: "
 msgstr ""
 
-#: build/lib/opac/webapp/main/views.py:36 opac/webapp/main/views.py:36
+#: opac/webapp/main/views.py:36
 msgid "O artigo está indisponível por motivo de: "
 msgstr ""
 
-#: build/lib/opac/webapp/main/views.py:127 opac/webapp/main/views.py:127
+#: opac/webapp/main/views.py:127
 msgid "Código de idioma inválido"
 msgstr ""
 
-#: build/lib/opac/webapp/main/views.py:197 opac/webapp/main/views.py:197
+#: opac/webapp/main/views.py:197
 msgid "Últimos periódicos inseridos na coleção"
 msgstr ""
 
-#: build/lib/opac/webapp/main/views.py:198 opac/webapp/main/views.py:198
+#: opac/webapp/main/views.py:198
 #, python-format
 msgid "10 últimos periódicos inseridos na coleção %s"
 msgstr ""
 
-#: build/lib/opac/webapp/main/views.py:257 opac/webapp/main/views.py:257
+#: opac/webapp/main/views.py:257
 msgid "Página não encontrada"
 msgstr ""
 
-#: build/lib/opac/webapp/main/views.py:281
-#: build/lib/opac/webapp/main/views.py:371 opac/webapp/main/views.py:281
-#: opac/webapp/main/views.py:371
+#: opac/webapp/main/views.py:281 opac/webapp/main/views.py:371
 #, python-format
 msgid "Requsição inválida ao tentar acessar o artigo com pid: %s"
 msgstr ""
 
-#: build/lib/opac/webapp/main/views.py:289
-#: build/lib/opac/webapp/main/views.py:339
-#: build/lib/opac/webapp/main/views.py:383
-#: build/lib/opac/webapp/main/views.py:452
-#: build/lib/opac/webapp/main/views.py:500
-#: build/lib/opac/webapp/main/views.py:647
-#: build/lib/opac/webapp/main/views.py:664
-#: build/lib/opac/webapp/main/views.py:1127 opac/webapp/main/views.py:289
-#: opac/webapp/main/views.py:339 opac/webapp/main/views.py:383
-#: opac/webapp/main/views.py:452 opac/webapp/main/views.py:500
-#: opac/webapp/main/views.py:647 opac/webapp/main/views.py:664
-#: opac/webapp/main/views.py:1127
+#: opac/webapp/main/views.py:289 opac/webapp/main/views.py:339
+#: opac/webapp/main/views.py:383 opac/webapp/main/views.py:452
+#: opac/webapp/main/views.py:500 opac/webapp/main/views.py:647
+#: opac/webapp/main/views.py:664 opac/webapp/main/views.py:1127
 msgid "Periódico não encontrado"
 msgstr ""
 
-#: build/lib/opac/webapp/main/views.py:301
-#: build/lib/opac/webapp/main/views.py:714
-#: build/lib/opac/webapp/main/views.py:773
-#: build/lib/opac/webapp/main/views.py:1136 opac/webapp/main/views.py:301
-#: opac/webapp/main/views.py:714 opac/webapp/main/views.py:773
-#: opac/webapp/main/views.py:1136
+#: opac/webapp/main/views.py:301 opac/webapp/main/views.py:714
+#: opac/webapp/main/views.py:773 opac/webapp/main/views.py:1136
 msgid "Número não encontrado"
 msgstr ""
 
-#: build/lib/opac/webapp/main/views.py:319
-#: build/lib/opac/webapp/main/views.py:354
-#: build/lib/opac/webapp/main/views.py:825
-#: build/lib/opac/webapp/main/views.py:910
-#: build/lib/opac/webapp/main/views.py:1060 opac/webapp/main/views.py:319
-#: opac/webapp/main/views.py:354 opac/webapp/main/views.py:825
-#: opac/webapp/main/views.py:910 opac/webapp/main/views.py:1060
+#: opac/webapp/main/views.py:319 opac/webapp/main/views.py:354
+#: opac/webapp/main/views.py:825 opac/webapp/main/views.py:910
+#: opac/webapp/main/views.py:1060
 msgid "Artigo não encontrado"
 msgstr ""
 
-#: build/lib/opac/webapp/main/views.py:476 opac/webapp/main/views.py:476
+#: opac/webapp/main/views.py:476
 msgid "Artigo sem título"
 msgstr ""
 
-#: build/lib/opac/webapp/main/views.py:548
-#: build/lib/opac/webapp/main/views.py:565 opac/webapp/main/views.py:548
-#: opac/webapp/main/views.py:565
+#: opac/webapp/main/views.py:548 opac/webapp/main/views.py:565
 msgid "Requisição inválida. Deve ser por ajax"
 msgstr ""
 
-#: build/lib/opac/webapp/main/views.py:581 opac/webapp/main/views.py:581
+#: opac/webapp/main/views.py:581
 msgid ""
 "Parámetro \"filter\" é inválido, deve ser \"areas\", \"wos\" ou "
 "\"publisher\"."
 msgstr ""
 
-#: build/lib/opac/webapp/main/views.py:590 opac/webapp/main/views.py:590
+#: opac/webapp/main/views.py:590
 msgid "Parámetro \"extension\" é inválido, deve ser \"csv\" ou \"xls\"."
 msgstr ""
 
-#: build/lib/opac/webapp/main/views.py:592 opac/webapp/main/views.py:592
+#: opac/webapp/main/views.py:592
 msgid ""
 "Parámetro \"list_type\" é inválido, deve ser: \"alpha\", \"areas\", "
 "\"wos\" ou \"publisher\"."
 msgstr ""
 
-#: build/lib/opac/webapp/main/views.py:613 opac/webapp/main/views.py:613
+#: opac/webapp/main/views.py:613
 msgid "Requisição inválida, deve ser ajax."
 msgstr ""
 
-#: build/lib/opac/webapp/main/views.py:622 opac/webapp/main/views.py:622
+#: opac/webapp/main/views.py:622
 msgid "Periódico não permite envio de email."
 msgstr ""
 
-#: build/lib/opac/webapp/main/views.py:640 opac/webapp/main/views.py:640
+#: opac/webapp/main/views.py:640
 msgid "Requisição inválida, captcha inválido."
 msgstr ""
 
-#: build/lib/opac/webapp/main/views.py:901
-#: build/lib/opac/webapp/main/views.py:1055 opac/webapp/main/views.py:901
-#: opac/webapp/main/views.py:1055
+#: opac/webapp/main/views.py:901 opac/webapp/main/views.py:1055
 msgid "Issue não encontrado"
 msgstr ""
 
-#: build/lib/opac/webapp/main/views.py:943
-#: build/lib/opac/webapp/main/views.py:949
-#: build/lib/opac/webapp/main/views.py:1092
-#: build/lib/opac/webapp/main/views.py:1100
-#: build/lib/opac/webapp/main/views.py:1102 opac/webapp/main/views.py:943
-#: opac/webapp/main/views.py:949 opac/webapp/main/views.py:1092
-#: opac/webapp/main/views.py:1100 opac/webapp/main/views.py:1102
+#: opac/webapp/main/views.py:943 opac/webapp/main/views.py:949
+#: opac/webapp/main/views.py:1092 opac/webapp/main/views.py:1100
+#: opac/webapp/main/views.py:1102
 msgid "PDF do Artigo não encontrado"
 msgstr ""
 
-#: build/lib/opac/webapp/main/views.py:954 opac/webapp/main/views.py:954
+#: opac/webapp/main/views.py:954
 msgid "HTML do Artigo não encontrado ou indisponível"
 msgstr ""
 
-#: build/lib/opac/webapp/main/views.py:1001 opac/webapp/main/views.py:1001
+#: opac/webapp/main/views.py:1001
 msgid "Parâmetros insuficientes para obter o EPDF do artigo"
 msgstr ""
 
-#: build/lib/opac/webapp/main/views.py:1022 opac/webapp/main/views.py:1022
+#: opac/webapp/main/views.py:1022
 msgid "Recruso não encontrado"
 msgstr ""
 
-#: build/lib/opac/webapp/main/views.py:1041 opac/webapp/main/views.py:1041
+#: opac/webapp/main/views.py:1041
 msgid "Recurso do Artigo não encontrado. Caminho inválido!"
 msgstr ""
 
-#: build/lib/opac/webapp/main/views.py:1154 opac/webapp/main/views.py:1154
+#: opac/webapp/main/views.py:1154
 msgid "PDF do artigo não foi encontrado"
 msgstr ""
 
-#: build/lib/opac/webapp/main/views.py:1169
-#: build/lib/opac/webapp/main/views.py:1200 opac/webapp/main/views.py:1169
-#: opac/webapp/main/views.py:1200
+#: opac/webapp/main/views.py:1169 opac/webapp/main/views.py:1200
 msgid "Requisição inválida."
 msgstr ""
 
-#: build/lib/opac/webapp/templates/admin/index.html:7
 #: opac/webapp/templates/admin/index.html:7
 msgid "da coleção"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/admin/index.html:12
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu.html:31
 #: opac/webapp/templates/admin/index.html:12
 #: opac/webapp/templates/collection/includes/levelMenu.html:31
 msgid "Periódicos"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/admin/index.html:15
-#: build/lib/opac/webapp/templates/admin/index.html:22
-#: build/lib/opac/webapp/templates/admin/index.html:35
-#: build/lib/opac/webapp/templates/admin/index.html:42
-#: build/lib/opac/webapp/templates/admin/index.html:55
-#: build/lib/opac/webapp/templates/admin/index.html:62
 #: opac/webapp/templates/admin/index.html:15
 #: opac/webapp/templates/admin/index.html:22
 #: opac/webapp/templates/admin/index.html:35
@@ -1255,12 +1068,6 @@ msgstr ""
 msgid "Publicados"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/admin/index.html:16
-#: build/lib/opac/webapp/templates/admin/index.html:36
-#: build/lib/opac/webapp/templates/admin/index.html:56
-#: build/lib/opac/webapp/templates/admin/index.html:75
-#: build/lib/opac/webapp/templates/admin/index.html:85
-#: build/lib/opac/webapp/templates/admin/index.html:95
 #: opac/webapp/templates/admin/index.html:16
 #: opac/webapp/templates/admin/index.html:36
 #: opac/webapp/templates/admin/index.html:56
@@ -1270,78 +1077,58 @@ msgstr ""
 msgid "Total"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/admin/index.html:32
 #: opac/webapp/templates/admin/index.html:32
 msgid "Fascícluos"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/admin/index.html:52
 #: opac/webapp/templates/admin/index.html:52
 msgid "Artigos"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/admin/index.html:72
 #: opac/webapp/templates/admin/index.html:72
 msgid "News"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/admin/index.html:82
 #: opac/webapp/templates/admin/index.html:82
 msgid "Sponsors"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/admin/index.html:92
 #: opac/webapp/templates/admin/index.html:92
 msgid "Press Releases"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/admin/auth/reset.html:9
-#: build/lib/opac/webapp/templates/admin/auth/reset_with_token.html:9
-#: build/lib/opac/webapp/templates/admin/opac_base.html:13
 #: opac/webapp/templates/admin/auth/reset.html:9
 #: opac/webapp/templates/admin/auth/reset_with_token.html:9
 #: opac/webapp/templates/admin/opac_base.html:13
 msgid "Recuperar a senha"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/admin/opac_base.html:14
 #: opac/webapp/templates/admin/opac_base.html:14
 msgid "Terminar sessão"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/admin/auth/login.html:11
-#: build/lib/opac/webapp/templates/admin/auth/login.html:20
-#: build/lib/opac/webapp/templates/admin/opac_base.html:18
 #: opac/webapp/templates/admin/auth/login.html:11
 #: opac/webapp/templates/admin/auth/login.html:20
 #: opac/webapp/templates/admin/opac_base.html:18
 msgid "Iniciar sessão"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/admin/audit_log/fields_data_table.html:4
 #: opac/webapp/templates/admin/audit_log/fields_data_table.html:4
 msgid "Campo: "
 msgstr ""
 
-#: build/lib/opac/webapp/templates/admin/audit_log/fields_data_table.html:5
 #: opac/webapp/templates/admin/audit_log/fields_data_table.html:5
 msgid "Valor anterior: "
 msgstr ""
 
-#: build/lib/opac/webapp/templates/admin/audit_log/fields_data_table.html:6
 #: opac/webapp/templates/admin/audit_log/fields_data_table.html:6
 msgid "Valor novo: "
 msgstr ""
 
-#: build/lib/opac/webapp/templates/admin/auth/login.html:13
 #: opac/webapp/templates/admin/auth/login.html:13
 msgid "Você já iniciou sessão!"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/admin/auth/login.html:24
-#: build/lib/opac/webapp/templates/admin/auth/reset.html:13
-#: build/lib/opac/webapp/templates/admin/auth/reset_with_token.html:13
-#: build/lib/opac/webapp/templates/includes/error_form.html:60
 #: opac/webapp/templates/admin/auth/login.html:24
 #: opac/webapp/templates/admin/auth/reset.html:13
 #: opac/webapp/templates/admin/auth/reset_with_token.html:13
@@ -1349,17 +1136,14 @@ msgstr ""
 msgid "Enviar"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/admin/auth/login.html:28
 #: opac/webapp/templates/admin/auth/login.html:28
 msgid "Esqueci a senha?"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/admin/auth/unconfirm_email.html:7
 #: opac/webapp/templates/admin/auth/unconfirm_email.html:7
 msgid "Email não confirmado!"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/admin/auth/unconfirm_email.html:9
 #: opac/webapp/templates/admin/auth/unconfirm_email.html:9
 msgid ""
 "Você <strong>deve</strong> confirmar seu email.<br>\n"
@@ -1367,7 +1151,6 @@ msgid ""
 "administrador.</strong>"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/admin/pages/edit.html:7
 #: opac/webapp/templates/admin/pages/edit.html:7
 msgid ""
 "<strong>Atenção:</strong> ao selecionar um <strong>periódico</strong> "
@@ -1376,11 +1159,6 @@ msgid ""
 "<em>Sobre o SciELO</em>. "
 msgstr ""
 
-#: build/lib/opac/webapp/templates/article/includes/alternative_header.html:7
-#: build/lib/opac/webapp/templates/collection/includes/header.html:7
-#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:7
-#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:7
-#: build/lib/opac/webapp/templates/journal/includes/header.html:8
 #: opac/webapp/templates/article/includes/alternative_header.html:7
 #: opac/webapp/templates/collection/includes/header.html:7
 #: opac/webapp/templates/issue/includes/alternative_header.html:7
@@ -1389,10 +1167,6 @@ msgstr ""
 msgid "Abrir menu"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/article/includes/alternative_header.html:9
-#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:9
-#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:9
-#: build/lib/opac/webapp/templates/journal/includes/header.html:10
 #: opac/webapp/templates/article/includes/alternative_header.html:9
 #: opac/webapp/templates/issue/includes/alternative_header.html:9
 #: opac/webapp/templates/journal/includes/alternative_header.html:9
@@ -1400,11 +1174,6 @@ msgstr ""
 msgid "Ir para a homepage da coleção: "
 msgstr ""
 
-#: build/lib/opac/webapp/templates/article/includes/alternative_header.html:42
-#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:7
-#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:121
-#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:117
-#: build/lib/opac/webapp/templates/journal/includes/header.html:118
 #: opac/webapp/templates/article/includes/alternative_header.html:42
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:7
 #: opac/webapp/templates/issue/includes/alternative_header.html:121
@@ -1413,11 +1182,6 @@ msgstr ""
 msgid "Submissão de manuscritos"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/article/includes/alternative_header.html:48
-#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:16
-#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:127
-#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:123
-#: build/lib/opac/webapp/templates/journal/includes/header.html:124
 #: opac/webapp/templates/article/includes/alternative_header.html:48
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:16
 #: opac/webapp/templates/issue/includes/alternative_header.html:127
@@ -1426,11 +1190,6 @@ msgstr ""
 msgid "Sobre o periódico"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/article/includes/alternative_header.html:53
-#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:10
-#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:132
-#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:128
-#: build/lib/opac/webapp/templates/journal/includes/header.html:129
 #: opac/webapp/templates/article/includes/alternative_header.html:53
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:10
 #: opac/webapp/templates/issue/includes/alternative_header.html:132
@@ -1439,11 +1198,6 @@ msgstr ""
 msgid "Corpo Editorial"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/article/includes/alternative_header.html:58
-#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:13
-#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:137
-#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:133
-#: build/lib/opac/webapp/templates/journal/includes/header.html:134
 #: opac/webapp/templates/article/includes/alternative_header.html:58
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:13
 #: opac/webapp/templates/issue/includes/alternative_header.html:137
@@ -1452,11 +1206,6 @@ msgstr ""
 msgid "Instruções aos autores"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/article/includes/alternative_header.html:63
-#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:19
-#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:142
-#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:138
-#: build/lib/opac/webapp/templates/journal/includes/header.html:140
 #: opac/webapp/templates/article/includes/alternative_header.html:63
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:19
 #: opac/webapp/templates/issue/includes/alternative_header.html:142
@@ -1465,81 +1214,56 @@ msgstr ""
 msgid "Contato"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:2
-#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:60
 #: opac/webapp/templates/article/includes/floating_menu.html:2
 #: opac/webapp/templates/article/includes/floating_menu.html:60
 msgid "Ir para o topo"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:6
-#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:65
 #: opac/webapp/templates/article/includes/floating_menu.html:6
 #: opac/webapp/templates/article/includes/floating_menu.html:65
 msgid "PDFs"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:26
-#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:77
 #: opac/webapp/templates/article/includes/floating_menu.html:26
 #: opac/webapp/templates/article/includes/floating_menu.html:77
 msgid "Figuras e tabelas"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:32
-#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:83
 #: opac/webapp/templates/article/includes/floating_menu.html:32
 #: opac/webapp/templates/article/includes/floating_menu.html:83
 msgid "Versões e traduções"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:37
-#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:88
 #: opac/webapp/templates/article/includes/floating_menu.html:37
 #: opac/webapp/templates/article/includes/floating_menu.html:88
 msgid "Como citar este artigo"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:42
-#: build/lib/opac/webapp/templates/article/includes/modal/related_article.html:9
 #: opac/webapp/templates/article/includes/floating_menu.html:42
 #: opac/webapp/templates/article/includes/modal/related_article.html:9
 msgid "Artigos relacionados"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:93
 #: opac/webapp/templates/article/includes/floating_menu.html:93
 msgid "Artigos e similares"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:9
 #: opac/webapp/templates/article/includes/levelMenu.html:9
 msgid "home do periodico"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:17
-#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:70
-#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:123
 #: opac/webapp/templates/article/includes/levelMenu.html:17
 #: opac/webapp/templates/article/includes/levelMenu.html:70
 #: opac/webapp/templates/article/includes/levelMenu.html:123
 msgid "sumário"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:30
-#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:75
-#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:71
 #: opac/webapp/templates/article/includes/levelMenu.html:30
 #: opac/webapp/templates/issue/includes/alternative_header.html:75
 #: opac/webapp/templates/journal/includes/alternative_header.html:71
 msgid "anterior"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:35
-#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:88
-#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:141
-#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:82
-#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:78
 #: opac/webapp/templates/article/includes/levelMenu.html:35
 #: opac/webapp/templates/article/includes/levelMenu.html:88
 #: opac/webapp/templates/article/includes/levelMenu.html:141
@@ -1548,15 +1272,10 @@ msgstr ""
 msgid "atual"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:48
 #: opac/webapp/templates/article/includes/levelMenu.html:48
 msgid "seguinte"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:193
-#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:219
-#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:264
-#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:290
 #: opac/webapp/templates/article/includes/levelMenu.html:193
 #: opac/webapp/templates/article/includes/levelMenu.html:219
 #: opac/webapp/templates/article/includes/levelMenu.html:264
@@ -1564,10 +1283,6 @@ msgstr ""
 msgid "Download PDF (Espanhol)"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:195
-#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:221
-#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:266
-#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:292
 #: opac/webapp/templates/article/includes/levelMenu.html:195
 #: opac/webapp/templates/article/includes/levelMenu.html:221
 #: opac/webapp/templates/article/includes/levelMenu.html:266
@@ -1575,10 +1290,6 @@ msgstr ""
 msgid "Download PDF (Inglês)"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:197
-#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:223
-#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:268
-#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:294
 #: opac/webapp/templates/article/includes/levelMenu.html:197
 #: opac/webapp/templates/article/includes/levelMenu.html:223
 #: opac/webapp/templates/article/includes/levelMenu.html:268
@@ -1586,13 +1297,6 @@ msgstr ""
 msgid "Download PDF (Português)"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:310
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu.html:38
-#: build/lib/opac/webapp/templates/collection/includes/list_journals_section_title.html:14
-#: build/lib/opac/webapp/templates/issue/grid.html:14
-#: build/lib/opac/webapp/templates/issue/toc.html:13
-#: build/lib/opac/webapp/templates/journal/about.html:16
-#: build/lib/opac/webapp/templates/journal/detail.html:11
 #: opac/webapp/templates/article/includes/levelMenu.html:310
 #: opac/webapp/templates/collection/includes/levelMenu.html:38
 #: opac/webapp/templates/collection/includes/list_journals_section_title.html:14
@@ -1603,11 +1307,6 @@ msgstr ""
 msgid "Compartilhe"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:311
-#: build/lib/opac/webapp/templates/collection/includes/list_journals_section_title.html:16
-#: build/lib/opac/webapp/templates/issue/toc.html:14
-#: build/lib/opac/webapp/templates/journal/about.html:17
-#: build/lib/opac/webapp/templates/journal/detail.html:12
 #: opac/webapp/templates/article/includes/levelMenu.html:311
 #: opac/webapp/templates/collection/includes/list_journals_section_title.html:16
 #: opac/webapp/templates/issue/toc.html:14
@@ -1616,11 +1315,6 @@ msgstr ""
 msgid "Enviar link por e-mail"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:314
-#: build/lib/opac/webapp/templates/collection/includes/list_journals_section_title.html:19
-#: build/lib/opac/webapp/templates/issue/toc.html:15
-#: build/lib/opac/webapp/templates/journal/about.html:18
-#: build/lib/opac/webapp/templates/journal/detail.html:13
 #: opac/webapp/templates/article/includes/levelMenu.html:314
 #: opac/webapp/templates/collection/includes/list_journals_section_title.html:19
 #: opac/webapp/templates/issue/toc.html:15
@@ -1629,11 +1323,6 @@ msgstr ""
 msgid "Compartilhar no Facebook"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:317
-#: build/lib/opac/webapp/templates/collection/includes/list_journals_section_title.html:22
-#: build/lib/opac/webapp/templates/issue/toc.html:16
-#: build/lib/opac/webapp/templates/journal/about.html:19
-#: build/lib/opac/webapp/templates/journal/detail.html:14
 #: opac/webapp/templates/article/includes/levelMenu.html:317
 #: opac/webapp/templates/collection/includes/list_journals_section_title.html:22
 #: opac/webapp/templates/issue/toc.html:16
@@ -1642,18 +1331,6 @@ msgstr ""
 msgid "Compartilhar no Twitter"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:320
-#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:325
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu.html:46
-#: build/lib/opac/webapp/templates/collection/includes/list_journals_section_title.html:25
-#: build/lib/opac/webapp/templates/collection/includes/list_journals_section_title.html:30
-#: build/lib/opac/webapp/templates/issue/grid.html:20
-#: build/lib/opac/webapp/templates/issue/toc.html:17
-#: build/lib/opac/webapp/templates/issue/toc.html:19
-#: build/lib/opac/webapp/templates/journal/about.html:20
-#: build/lib/opac/webapp/templates/journal/about.html:22
-#: build/lib/opac/webapp/templates/journal/detail.html:15
-#: build/lib/opac/webapp/templates/journal/detail.html:17
 #: opac/webapp/templates/article/includes/levelMenu.html:320
 #: opac/webapp/templates/article/includes/levelMenu.html:325
 #: opac/webapp/templates/collection/includes/levelMenu.html:46
@@ -1669,24 +1346,16 @@ msgstr ""
 msgid "Outras redes sociais"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/article/includes/recent_articles_row.html:6
-#: build/lib/opac/webapp/templates/issue/toc.html:149
 #: opac/webapp/templates/article/includes/recent_articles_row.html:6
 #: opac/webapp/templates/issue/toc.html:149
 msgid "Documento sem título"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/article/includes/recent_articles_row.html:13
-#: build/lib/opac/webapp/templates/news/includes/journal_news_row.html:14
 #: opac/webapp/templates/article/includes/recent_articles_row.html:13
 #: opac/webapp/templates/news/includes/journal_news_row.html:14
 msgid "Continue lendo"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/article/includes/modal/download.html:6
-#: build/lib/opac/webapp/templates/article/includes/modal/related_article.html:7
-#: build/lib/opac/webapp/templates/email/email_form.html:7
-#: build/lib/opac/webapp/templates/includes/metric_modal.html:6
 #: opac/webapp/templates/article/includes/modal/download.html:6
 #: opac/webapp/templates/article/includes/modal/related_article.html:7
 #: opac/webapp/templates/email/email_form.html:7
@@ -1694,791 +1363,625 @@ msgstr ""
 msgid "Fechar"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/article/includes/modal/download.html:8
 #: opac/webapp/templates/article/includes/modal/download.html:8
 msgid "Versão para download de PDF"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/article/includes/modal/translate_version.html:6
 #: opac/webapp/templates/article/includes/modal/translate_version.html:6
 msgid "Versões e tradução automática"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/article/includes/modal/translate_version.html:11
 #: opac/webapp/templates/article/includes/modal/translate_version.html:11
 msgid "Versão original do texto"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/about.html:23
-#: build/lib/opac/webapp/templates/collection/pages.html:21
 #: opac/webapp/templates/collection/about.html:23
-#: opac/webapp/templates/collection/pages.html:21
 #, python-format
 msgid " %(page)s "
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/about.html:38
-#: build/lib/opac/webapp/templates/collection/pages.html:36
 #: opac/webapp/templates/collection/about.html:38
-#: opac/webapp/templates/collection/pages.html:36
 msgid " Conteúdo não cadastrado "
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/index.html:17
 #: opac/webapp/templates/collection/index.html:17
 msgid "em números | Métricas"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/index.html:27
 #: opac/webapp/templates/collection/index.html:27
 msgid "períodicos"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:31
-#: build/lib/opac/webapp/templates/collection/index.html:31
-#: build/lib/opac/webapp/templates/collection/list_feed_content.html:7
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:31
 #: opac/webapp/templates/collection/index.html:31
 #: opac/webapp/templates/collection/list_feed_content.html:7
 msgid "números"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/index.html:35
-#: build/lib/opac/webapp/templates/issue/grid.html:68
 #: opac/webapp/templates/collection/index.html:35
 #: opac/webapp/templates/issue/grid.html:68
 msgid "artigos"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/index.html:39
 #: opac/webapp/templates/collection/index.html:39
 msgid "referências"
 msgstr "referencias"
 
-#: build/lib/opac/webapp/templates/collection/index.html:45
 #: opac/webapp/templates/collection/index.html:45
 msgid "Downloads"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/index.html:48
 #: opac/webapp/templates/collection/index.html:48
 msgid "Citações"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/index.html:51
 #: opac/webapp/templates/collection/index.html:51
 msgid "Outros indicadores"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/index.html:62
-#: build/lib/opac/webapp/templates/collection/list_journal.html:3
 #: opac/webapp/templates/collection/index.html:62
 #: opac/webapp/templates/collection/list_journal.html:3
 msgid "Lista de periódicos"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/index.html:66
-#: build/lib/opac/webapp/templates/collection/list_journal.html:21
 #: opac/webapp/templates/collection/index.html:66
 #: opac/webapp/templates/collection/list_journal.html:21
 msgid "Alfabética"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/index.html:69
-#: build/lib/opac/webapp/templates/collection/list_journal.html:24
 #: opac/webapp/templates/collection/index.html:69
 #: opac/webapp/templates/collection/list_journal.html:24
 msgid "Temática"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/index.html:77
 #: opac/webapp/templates/collection/index.html:77
 msgid "Busca por periódicos"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/index.html:105
 #: opac/webapp/templates/collection/index.html:105
 msgid "Números <span>mais recentes</span>"
 msgstr "Números <span>más recientes</span>"
 
-#: build/lib/opac/webapp/templates/collection/index.html:149
 #: opac/webapp/templates/collection/index.html:149
 msgid "em perspectiva"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/list_feed_content.html:1
 #: opac/webapp/templates/collection/list_feed_content.html:1
 msgid "Último número"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/list_feed_content.html:4
 #: opac/webapp/templates/collection/list_feed_content.html:4
 msgid "Nº"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/list_feed_content.html:6
 #: opac/webapp/templates/collection/list_feed_content.html:6
 msgid "descontinuado"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/list_feed_content.html:7
 #: opac/webapp/templates/collection/list_feed_content.html:7
 msgid "de"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu.html:11
-#: build/lib/opac/webapp/templates/collection/list_journal.html:16
 #: opac/webapp/templates/collection/includes/levelMenu.html:11
 #: opac/webapp/templates/collection/list_journal.html:16
 msgid "Home"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_grouper_table_container.html:14
-#: build/lib/opac/webapp/templates/collection/list_journal.html:52
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_grouper_table_container.html:14
 #: opac/webapp/templates/collection/list_journal.html:52
 msgid "download da lista"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_grouper_table_container.html:15
-#: build/lib/opac/webapp/templates/collection/list_journal.html:53
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_grouper_table_container.html:15
 #: opac/webapp/templates/collection/list_journal.html:53
 msgid "Lista em arquivo para Excel"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_grouper_table_container.html:18
-#: build/lib/opac/webapp/templates/collection/list_journal.html:56
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_grouper_table_container.html:18
 #: opac/webapp/templates/collection/list_journal.html:56
 msgid "Lista em arquivo CSV"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/list_journal.html:80
-#: build/lib/opac/webapp/templates/collection/list_journal.html:84
 #: opac/webapp/templates/collection/list_journal.html:80
 #: opac/webapp/templates/collection/list_journal.html:84
 msgid "Grandes áreas do conhecimento"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/list_journal.html:85
 #: opac/webapp/templates/collection/list_journal.html:85
 msgid "Áreas temáticas do Web of Science"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/list_journal.html:222
 #: opac/webapp/templates/collection/list_journal.html:222
 msgid "grandes áreas"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/list_journal.html:236
 #: opac/webapp/templates/collection/list_journal.html:236
 msgid "áreas WOS"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/list_journal.html:248
 #: opac/webapp/templates/collection/list_journal.html:248
 msgid "Editoras"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/list_journal.html:249
 #: opac/webapp/templates/collection/list_journal.html:249
 msgid "editoras"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:7
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:7
 msgid "Sobre o"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:19
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:62
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:19
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:62
 msgid "Entre uma ou mais palavras"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:24
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:67
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:24
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:67
 msgid "Todos os índices"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:26
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:69
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:26
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:69
 msgid "Autor"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:38
-#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:95
-#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:91
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:38
 #: opac/webapp/templates/issue/includes/alternative_header.html:95
 #: opac/webapp/templates/journal/includes/alternative_header.html:91
 msgid "Buscar"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:44
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:44
 msgid "Adicionar outro campo"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:49
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:49
 msgid "Apagar campo"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:63
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:63
 msgid "Limpar expressão"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:92
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:92
 msgid "Sem resultados"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:96
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:96
 msgid "Não foram encontrados documentos para sua pesquisa"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/includes/list_journals_search_input.html:5
 #: opac/webapp/templates/collection/includes/list_journals_search_input.html:5
 msgid "Todos"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/includes/list_journals_search_input.html:9
 #: opac/webapp/templates/collection/includes/list_journals_search_input.html:9
 msgid "Periódicos ativos"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/includes/list_journals_search_input.html:13
 #: opac/webapp/templates/collection/includes/list_journals_search_input.html:13
 msgid "Periódicos descontinuados"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/includes/list_journals_search_input.html:24
 #: opac/webapp/templates/collection/includes/list_journals_search_input.html:24
 msgid "Digite uma ou mais palavras para filtrar a lista"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/includes/nav.html:22
-#: build/lib/opac/webapp/templates/collection/includes/nav.html:64
 #: opac/webapp/templates/collection/includes/nav.html:22
 #: opac/webapp/templates/collection/includes/nav.html:64
 msgid "Busca"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/includes/nav.html:32
 #: opac/webapp/templates/collection/includes/nav.html:32
 msgid "Sobre:"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/includes/nav.html:44
 #: opac/webapp/templates/collection/includes/nav.html:44
 msgid "SciELO.org - Rede SciELO"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/includes/nav.html:95
 #: opac/webapp/templates/collection/includes/nav.html:95
 msgid "Blog SciELO em Perspectiva"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_empty.html:3
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_empty.html:3
 msgid "Nenhum periódico encontrado."
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_error.html:3
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_error.html:3
 msgid "Ocorreu um erro obtendo a lista de periódicos."
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_grouper_table_container.html:10
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_grouper_table_container.html:10
 msgid "periódicos"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:3
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:3
 msgid "Homepage"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:25
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:25
 msgid "Título do periódico"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:29
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:29
 msgid "Grade de número"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:36
-#: build/lib/opac/webapp/templates/journal/detail.html:89
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:36
 #: opac/webapp/templates/journal/detail.html:89
 msgid "Número mais recente"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:37
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:37
 msgid "Último"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:45
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:45
 msgid "Continua como "
 msgstr ""
 
-#: build/lib/opac/webapp/templates/email/email_form.html:10
 #: opac/webapp/templates/email/email_form.html:10
 msgid "Enviar página por e-mail"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/email/email_form.html:18
-#: build/lib/opac/webapp/templates/includes/error_form.html:26
-#: build/lib/opac/webapp/templates/journal/includes/contact_form.html:20
 #: opac/webapp/templates/email/email_form.html:18
 #: opac/webapp/templates/includes/error_form.html:26
 #: opac/webapp/templates/journal/includes/contact_form.html:20
 msgid "Seu e-mail"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/email/email_form.html:23
 #: opac/webapp/templates/email/email_form.html:23
 msgid "Para"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/email/email_form.html:27
 #: opac/webapp/templates/email/email_form.html:27
 msgid "Utilize ; (ponto e vírgula) para inserir mais emails."
 msgstr ""
 
-#: build/lib/opac/webapp/templates/email/email_form.html:36
 #: opac/webapp/templates/email/email_form.html:36
 msgid "Alterar assunto e comentários"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/email/email_form.html:41
 #: opac/webapp/templates/email/email_form.html:41
 msgid "Assunto"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/email/email_form.html:45
 #: opac/webapp/templates/email/email_form.html:45
 msgid "Comentário"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/email/email_form.html:49
 #: opac/webapp/templates/email/email_form.html:49
 msgid "Remover remetente, assunto e comentários"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/email/email_form.html:75
 #: opac/webapp/templates/email/email_form.html:75
 msgid "Email enviado com sucesso."
 msgstr ""
 
-#: build/lib/opac/webapp/templates/email/email_form.html:76
-#: build/lib/opac/webapp/templates/includes/error_form.html:86
-#: build/lib/opac/webapp/templates/journal/includes/contact_form.html:77
 #: opac/webapp/templates/email/email_form.html:76
 #: opac/webapp/templates/includes/error_form.html:86
 #: opac/webapp/templates/journal/includes/contact_form.html:77
 msgid "Erro ao tentar enviar e-mail, por favor tente mais tarde."
 msgstr ""
 
-#: build/lib/opac/webapp/templates/errors/400.html:7
 #: opac/webapp/templates/errors/400.html:7
 msgid "Ação inválida"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/errors/403.html:7
 #: opac/webapp/templates/errors/403.html:7
 msgid "Acesso não autorizado!"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/errors/404.html:7
 #: opac/webapp/templates/errors/404.html:7
 msgid ""
 "A URL solicitada não foi encontrada no servidor. Se você digitou a URL "
 "manualmente, por favor verifique e tente novamente."
 msgstr ""
 
-#: build/lib/opac/webapp/templates/errors/500.html:5
 #: opac/webapp/templates/errors/500.html:5
 msgid ""
 "Erro interno do servidor. Tente novamente mais tarde. Nossos engenheiros "
 "foram notificados."
 msgstr ""
 
-#: build/lib/opac/webapp/templates/errors/500.html:9
 #: opac/webapp/templates/errors/500.html:9
 msgid "Id. do erro"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/errors/base.html:24
 #: opac/webapp/templates/errors/base.html:24
 msgid "Erro"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/errors/base.html:27
 #: opac/webapp/templates/errors/base.html:27
 msgid "Qualquer dúvida, por favor entre em contato com o administrador"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/includes/error_form.html:5
 #: opac/webapp/templates/includes/error_form.html:5
 msgid " Reportar erro "
 msgstr ""
 
-#: build/lib/opac/webapp/templates/includes/error_form.html:20
-#: build/lib/opac/webapp/templates/journal/includes/contact_form.html:14
 #: opac/webapp/templates/includes/error_form.html:20
 #: opac/webapp/templates/journal/includes/contact_form.html:14
 msgid "Seu Nome"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/includes/error_form.html:21
 #: opac/webapp/templates/includes/error_form.html:21
 msgid "Digite seu Nome"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/includes/error_form.html:32
 #: opac/webapp/templates/includes/error_form.html:32
 msgid "Erro referente"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/includes/error_form.html:35
 #: opac/webapp/templates/includes/error_form.html:35
 msgid "ao conteúdo"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/includes/error_form.html:39
 #: opac/webapp/templates/includes/error_form.html:39
 msgid "à aplicação"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/includes/error_form.html:46
 #: opac/webapp/templates/includes/error_form.html:46
 msgid "Descrição do erro"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/includes/error_form.html:47
 #: opac/webapp/templates/includes/error_form.html:47
 msgid "Digite sua mensagem"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/includes/error_form.html:49
 #: opac/webapp/templates/includes/error_form.html:49
 msgid "Obs.: Link e título da página são enviados automaticamente"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/includes/error_form.html:85
 #: opac/webapp/templates/includes/error_form.html:85
 msgid "Email de erro enviado com sucesso."
 msgstr ""
 
-#: build/lib/opac/webapp/templates/includes/footer.html:36
 #: opac/webapp/templates/includes/footer.html:36
 msgid "Open Access"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/includes/footer.html:38
 #: opac/webapp/templates/includes/footer.html:38
 msgid "Leia"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/includes/footer.html:38
 #: opac/webapp/templates/includes/footer.html:38
 msgid "a Declaração de Acesso Aberto"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/issue/grid.html:4
 #: opac/webapp/templates/issue/grid.html:4
 msgid "Fascículos"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/issue/grid.html:33
 #: opac/webapp/templates/issue/grid.html:33
 msgid "Todos os números"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/issue/grid.html:79
 #: opac/webapp/templates/issue/grid.html:79
 msgid "supl."
 msgstr ""
 
-#: build/lib/opac/webapp/templates/issue/grid.html:98
 #: opac/webapp/templates/issue/grid.html:98
 msgid "Nenhum número encontrado para esse periódico"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/issue/grid.html:101
 #: opac/webapp/templates/issue/grid.html:101
 msgid "Histórico deste periódico na coleção"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/issue/grid.html:105
 #: opac/webapp/templates/issue/grid.html:105
 msgid " admitido na coleção da SciELO"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/issue/toc.html:10
-#: build/lib/opac/webapp/templates/journal/detail.html:8
 #: opac/webapp/templates/issue/toc.html:10
 #: opac/webapp/templates/journal/detail.html:8
 msgid "Imprimir"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/issue/toc.html:41
 #: opac/webapp/templates/issue/toc.html:41
 msgid "Editor científico"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/issue/toc.html:45
 #: opac/webapp/templates/issue/toc.html:45
 msgid "Editores associados"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/issue/toc.html:52
 #: opac/webapp/templates/issue/toc.html:52
 msgid "Veja toda a equipe editorial"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/issue/toc.html:63
 #: opac/webapp/templates/issue/toc.html:63
 msgid "Expandir/recolher conteúdo"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/issue/toc.html:72
-#: build/lib/opac/webapp/templates/journal/detail.html:96
 #: opac/webapp/templates/issue/toc.html:72
 #: opac/webapp/templates/journal/detail.html:96
 msgid "Sumário"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/issue/toc.html:79
 #: opac/webapp/templates/issue/toc.html:79
 msgid "Ordenar publicações por"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/issue/toc.html:82
 #: opac/webapp/templates/issue/toc.html:82
 msgid "Ordem do fascículo"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/issue/toc.html:83
 #: opac/webapp/templates/issue/toc.html:83
 msgid "Mais novos primeiro"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/issue/toc.html:84
 #: opac/webapp/templates/issue/toc.html:84
 msgid "Mais antigos primeiro"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/issue/toc.html:102
-#: build/lib/opac/webapp/templates/issue/toc.html:104
 #: opac/webapp/templates/issue/toc.html:102
 #: opac/webapp/templates/issue/toc.html:104
 msgid "Todas as seções"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/issue/toc.html:187
-#: opac/webapp/templates/issue/toc.html:187
+#: opac/webapp/templates/issue/toc.html:182
 msgid "Texto"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/issue/toc.html:214
-#: opac/webapp/templates/issue/toc.html:214
+#: opac/webapp/templates/issue/toc.html:195
+msgid "PDF"
+msgstr ""
+
+#: opac/webapp/templates/issue/toc.html:210
+msgid "ePDF"
+msgstr ""
+
+#: opac/webapp/templates/issue/toc.html:232
 msgid "Resumo em"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:31
-#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:31
 #: opac/webapp/templates/issue/includes/alternative_header.html:31
 #: opac/webapp/templates/journal/includes/alternative_header.html:31
 msgid "Número atual"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:51
-#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:47
 #: opac/webapp/templates/issue/includes/alternative_header.html:51
 #: opac/webapp/templates/journal/includes/alternative_header.html:47
 msgid "Homepage do periódico"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:62
-#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:58
 #: opac/webapp/templates/issue/includes/alternative_header.html:62
 #: opac/webapp/templates/journal/includes/alternative_header.html:58
 msgid "Números"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:68
-#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:64
-#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:90
 #: opac/webapp/templates/issue/includes/alternative_header.html:68
 #: opac/webapp/templates/journal/includes/alternative_header.html:64
 #: opac/webapp/templates/journal/includes/levelMenu.html:90
 msgid "todos"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:89
-#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:85
 #: opac/webapp/templates/issue/includes/alternative_header.html:89
 #: opac/webapp/templates/journal/includes/alternative_header.html:85
 msgid "próximo"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/journal/about.html:39
 #: opac/webapp/templates/journal/about.html:39
 msgid "Conteúdo não cadastrado"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/journal/about.html:55
-#: build/lib/opac/webapp/templates/journal/includes/contact_footer.html:48
 #: opac/webapp/templates/journal/about.html:55
 #: opac/webapp/templates/journal/includes/contact_footer.html:48
 msgid "Siga este periódico nas redes sociais"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/journal/detail.html:32
+#: opac/webapp/templates/journal/detail.html:9
+#: opac/webapp/templates/journal/includes/contact_footer.html:53
+msgid "RSS do número mais recente do periódico"
+msgstr ""
+
 #: opac/webapp/templates/journal/detail.html:32
 msgid "Nossa Missão"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/journal/detail.html:34
 #: opac/webapp/templates/journal/detail.html:34
 msgid "Periódico sem missão cadastrada"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/journal/detail.html:42
 #: opac/webapp/templates/journal/detail.html:42
 msgid "Métricas deste periódico"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/journal/detail.html:52
 #: opac/webapp/templates/journal/detail.html:52
 msgid "Índice h5"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/journal/detail.html:54
-#: build/lib/opac/webapp/templates/journal/detail.html:66
 #: opac/webapp/templates/journal/detail.html:54
 #: opac/webapp/templates/journal/detail.html:66
 msgid "ano"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/journal/detail.html:58
-#: build/lib/opac/webapp/templates/journal/detail.html:70
 #: opac/webapp/templates/journal/detail.html:58
 #: opac/webapp/templates/journal/detail.html:70
 msgid "Não possui"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/journal/detail.html:63
 #: opac/webapp/templates/journal/detail.html:63
 msgid "Mediana h5"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/journal/detail.html:86
 #: opac/webapp/templates/journal/detail.html:86
 msgid "Capa do número mais recente"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/journal/detail.html:138
-#: opac/webapp/templates/journal/detail.html:138
+#: opac/webapp/templates/journal/detail.html:117
+#: opac/webapp/templates/journal/detail.html:119
+msgid "RSS dos Press Releases mais recentes desse periódico"
+msgstr ""
+
+#: opac/webapp/templates/journal/detail.html:145
 msgid "Artigos mais recentes"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/journal/includes/contact_footer.html:57
 #: opac/webapp/templates/journal/includes/contact_footer.html:57
 msgid "Acompanhe os números deste periódico no seu leitor de RSS"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/journal/includes/contact_form.html:26
 #: opac/webapp/templates/journal/includes/contact_form.html:26
 msgid "Mensagem"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/journal/includes/contact_form.html:76
 #: opac/webapp/templates/journal/includes/contact_form.html:76
 msgid "Email enviado para "
 msgstr ""
 
-#: build/lib/opac/webapp/templates/journal/includes/contact_form.html:76
 #: opac/webapp/templates/journal/includes/contact_form.html:76
 msgid "com sucesso."
 msgstr ""
 
-#: build/lib/opac/webapp/templates/journal/includes/header.html:42
 #: opac/webapp/templates/journal/includes/header.html:42
 msgid "Publicação de:"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/journal/includes/header.html:47
 #: opac/webapp/templates/journal/includes/header.html:47
 msgid "Área:"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/journal/includes/header.html:51
 #: opac/webapp/templates/journal/includes/header.html:51
 msgid "Multidisciplinar"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/journal/includes/header.html:60
 #: opac/webapp/templates/journal/includes/header.html:60
 msgid "Versão impressa ISSN:"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/journal/includes/header.html:67
 #: opac/webapp/templates/journal/includes/header.html:67
 msgid "Versão on-line ISSN:"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/journal/includes/header.html:76
 #: opac/webapp/templates/journal/includes/header.html:76
 msgid "Novo título:"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/journal/includes/header.html:93
 #: opac/webapp/templates/journal/includes/header.html:93
 msgid "Título anterior:"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/journal/includes/header.html:148
 #: opac/webapp/templates/journal/includes/header.html:148
 msgid "Siga-nos"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:10
 #: opac/webapp/templates/journal/includes/levelMenu.html:10
 msgid "home do periódico"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:19
 #: opac/webapp/templates/journal/includes/levelMenu.html:19
 msgid "todos os números"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:25
-#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:29
 #: opac/webapp/templates/journal/includes/levelMenu.html:25
 #: opac/webapp/templates/journal/includes/levelMenu.html:29
 msgid "número anterior"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:36
-#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:40
-#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:107
-#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:111
 #: opac/webapp/templates/journal/includes/levelMenu.html:36
 #: opac/webapp/templates/journal/includes/levelMenu.html:40
 #: opac/webapp/templates/journal/includes/levelMenu.html:107
@@ -2486,24 +1989,16 @@ msgstr ""
 msgid "número atual"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:47
-#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:51
 #: opac/webapp/templates/journal/includes/levelMenu.html:47
 #: opac/webapp/templates/journal/includes/levelMenu.html:51
 msgid "número seguinte"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:59
-#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:130
 #: opac/webapp/templates/journal/includes/levelMenu.html:59
 #: opac/webapp/templates/journal/includes/levelMenu.html:130
 msgid "buscar"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:65
-#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:69
-#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:136
-#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:140
 #: opac/webapp/templates/journal/includes/levelMenu.html:65
 #: opac/webapp/templates/journal/includes/levelMenu.html:69
 #: opac/webapp/templates/journal/includes/levelMenu.html:136
@@ -2511,27 +2006,22 @@ msgstr ""
 msgid "métricas"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/macros/issue.html:5
 #: opac/webapp/templates/macros/issue.html:5
 msgid " número especial "
 msgstr ""
 
-#: build/lib/opac/webapp/templates/macros/issue.html:10
 #: opac/webapp/templates/macros/issue.html:10
 msgid "número especial"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/news/includes/collection_news_row.html:16
 #: opac/webapp/templates/news/includes/collection_news_row.html:16
 msgid "continue lendo"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/news/includes/issue_last_row.html:15
 #: opac/webapp/templates/news/includes/issue_last_row.html:15
 msgid "Suplemento"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/news/includes/issue_last_row.html:20
 #: opac/webapp/templates/news/includes/issue_last_row.html:20
 msgid "Ver"
 msgstr ""

--- a/opac/webapp/translations/messages.pot
+++ b/opac/webapp/translations/messages.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-05-09 17:02-0300\n"
+"POT-Creation-Date: 2019-05-31 21:18+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,30 +17,13 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.6.0\n"
 
-#: build/lib/opac/tests/test_admin_custom_filters.py:100
-#: build/lib/opac/tests/test_admin_custom_filters.py:114
-#: build/lib/opac/tests/test_admin_custom_filters.py:129
-#: build/lib/opac/tests/test_admin_custom_filters.py:144
-#: build/lib/opac/tests/test_admin_custom_filters.py:158
-#: build/lib/opac/webapp/__init__.py:119
-#: build/lib/opac/webapp/admin/views.py:533
-#: build/lib/opac/webapp/admin/views.py:610
-#: build/lib/opac/webapp/admin/views.py:680
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:28
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:71
-#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_grouper_table_row.html:15
-#: build/lib/opac/webapp/templates/collection/list_journal.html:49
-#: build/lib/opac/webapp/templates/collection/list_journal.html:221
-#: build/lib/opac/webapp/templates/collection/list_journal.html:235
-#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:116
-#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:112
 #: opac/tests/test_admin_custom_filters.py:100
 #: opac/tests/test_admin_custom_filters.py:114
 #: opac/tests/test_admin_custom_filters.py:129
 #: opac/tests/test_admin_custom_filters.py:144
 #: opac/tests/test_admin_custom_filters.py:158 opac/webapp/__init__.py:119
-#: opac/webapp/admin/views.py:533 opac/webapp/admin/views.py:610
-#: opac/webapp/admin/views.py:680
+#: opac/webapp/admin/views.py:534 opac/webapp/admin/views.py:611
+#: opac/webapp/admin/views.py:681
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:28
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:71
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_grouper_table_row.html:15
@@ -52,38 +35,21 @@ msgstr ""
 msgid "Periódico"
 msgstr ""
 
-#: build/lib/opac/tests/test_interface_menu.py:51
 #: opac/tests/test_interface_menu.py:51
 msgid "NOME DA COLEÇÃO!!"
 msgstr ""
 
-#: build/lib/opac/tests/test_interface_menu.py:53
-#: build/lib/opac/tests/test_interface_menu.py:75
-#: build/lib/opac/webapp/templates/collection/includes/nav.html:12
-#: build/lib/opac/webapp/templates/collection/includes/nav.html:54
 #: opac/tests/test_interface_menu.py:53 opac/tests/test_interface_menu.py:75
 #: opac/webapp/templates/collection/includes/nav.html:12
 #: opac/webapp/templates/collection/includes/nav.html:54
 msgid "Lista alfabética de periódicos"
 msgstr ""
 
-#: build/lib/opac/tests/test_interface_menu.py:55
-#: build/lib/opac/webapp/templates/collection/includes/nav.html:17
 #: opac/tests/test_interface_menu.py:55
 #: opac/webapp/templates/collection/includes/nav.html:17
 msgid "Lista temática de periódicos"
 msgstr ""
 
-#: build/lib/opac/tests/test_interface_menu.py:61
-#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:11
-#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:70
-#: build/lib/opac/webapp/templates/collection/includes/nav.html:27
-#: build/lib/opac/webapp/templates/collection/includes/nav.html:69
-#: build/lib/opac/webapp/templates/includes/metric_modal.html:7
-#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:101
-#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:105
-#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:97
-#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:101
 #: opac/tests/test_interface_menu.py:61
 #: opac/webapp/templates/article/includes/floating_menu.html:11
 #: opac/webapp/templates/article/includes/floating_menu.html:70
@@ -97,383 +63,332 @@ msgstr ""
 msgid "Métricas"
 msgstr ""
 
-#: build/lib/opac/tests/test_interface_menu.py:63
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu.html:12
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu.html:29
 #: opac/tests/test_interface_menu.py:63
 #: opac/webapp/templates/collection/includes/levelMenu.html:12
 #: opac/webapp/templates/collection/includes/levelMenu.html:29
 msgid "Sobre o SciELO"
 msgstr ""
 
-#: build/lib/opac/tests/test_interface_menu.py:65
-#: build/lib/opac/tests/test_interface_menu.py:99
-#: build/lib/opac/webapp/templates/collection/includes/nav.html:37
-#: build/lib/opac/webapp/templates/collection/includes/nav.html:84
 #: opac/tests/test_interface_menu.py:65 opac/tests/test_interface_menu.py:99
 #: opac/webapp/templates/collection/includes/nav.html:37
 #: opac/webapp/templates/collection/includes/nav.html:84
 msgid "Contatos"
 msgstr ""
 
-#: build/lib/opac/tests/test_interface_menu.py:67
 #: opac/tests/test_interface_menu.py:67
 msgid "Rede SciELO"
 msgstr ""
 
-#: build/lib/opac/tests/test_interface_menu.py:71
-#: build/lib/opac/webapp/templates/collection/includes/nav.html:49
 #: opac/tests/test_interface_menu.py:71
 #: opac/webapp/templates/collection/includes/nav.html:49
 msgid "Coleções nacionais e temáticas"
 msgstr ""
 
-#: build/lib/opac/tests/test_interface_menu.py:79
-#: build/lib/opac/webapp/templates/collection/includes/nav.html:59
 #: opac/tests/test_interface_menu.py:79
 #: opac/webapp/templates/collection/includes/nav.html:59
 msgid "Lista de periódicos por assunto"
 msgstr ""
 
-#: build/lib/opac/tests/test_interface_menu.py:91
-#: build/lib/opac/webapp/templates/collection/includes/nav.html:74
 #: opac/tests/test_interface_menu.py:91
 #: opac/webapp/templates/collection/includes/nav.html:74
 msgid "Acesso OAI e RSS"
 msgstr ""
 
-#: build/lib/opac/tests/test_interface_menu.py:95
-#: build/lib/opac/webapp/templates/collection/includes/nav.html:79
 #: opac/tests/test_interface_menu.py:95
 #: opac/webapp/templates/collection/includes/nav.html:79
 msgid "Sobre a Rede SciELO"
 msgstr ""
 
-#: build/lib/opac/tests/test_main_errors.py:8 opac/tests/test_main_errors.py:8
+#: opac/tests/test_main_errors.py:8
 msgid "Mensagem de erro explicativo para o usuário"
 msgstr ""
 
-#: build/lib/opac/webapp/__init__.py:118 build/lib/opac/webapp/__init__.py:119
-#: build/lib/opac/webapp/__init__.py:120 build/lib/opac/webapp/__init__.py:121
-#: build/lib/opac/webapp/__init__.py:122 build/lib/opac/webapp/__init__.py:123
 #: opac/webapp/__init__.py:118 opac/webapp/__init__.py:119
 #: opac/webapp/__init__.py:120 opac/webapp/__init__.py:121
 #: opac/webapp/__init__.py:122 opac/webapp/__init__.py:123
 msgid "Catálogo"
 msgstr ""
 
-#: build/lib/opac/webapp/__init__.py:118
-#: build/lib/opac/webapp/admin/views.py:452 opac/webapp/__init__.py:118
-#: opac/webapp/admin/views.py:452
+#: opac/webapp/__init__.py:118 opac/webapp/admin/views.py:453
 msgid "Coleção"
 msgstr ""
 
-#: build/lib/opac/webapp/__init__.py:120
-#: build/lib/opac/webapp/admin/views.py:537
-#: build/lib/opac/webapp/admin/views.py:609
-#: build/lib/opac/webapp/templates/issue/grid.html:41
-#: build/lib/opac/webapp/templates/news/includes/issue_last_row.html:11
-#: opac/webapp/__init__.py:120 opac/webapp/admin/views.py:537
-#: opac/webapp/admin/views.py:609 opac/webapp/templates/issue/grid.html:41
+#: opac/webapp/__init__.py:120 opac/webapp/admin/views.py:538
+#: opac/webapp/admin/views.py:610 opac/webapp/templates/issue/grid.html:41
 #: opac/webapp/templates/news/includes/issue_last_row.html:11
 msgid "Número"
 msgstr ""
 
-#: build/lib/opac/webapp/__init__.py:121 opac/webapp/__init__.py:121
+#: opac/webapp/__init__.py:121
 msgid "Artigo"
 msgstr ""
 
-#: build/lib/opac/webapp/__init__.py:122
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:27
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:70
 #: opac/webapp/__init__.py:122
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:27
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:70
 msgid "Financiador"
 msgstr ""
 
-#: build/lib/opac/webapp/__init__.py:123 opac/webapp/__init__.py:123
+#: opac/webapp/__init__.py:123
 msgid "Press Release"
 msgstr ""
 
-#: build/lib/opac/webapp/__init__.py:124
-#: build/lib/opac/webapp/templates/journal/detail.html:160
-#: opac/webapp/__init__.py:124 opac/webapp/templates/journal/detail.html:160
+#: opac/webapp/__init__.py:124 opac/webapp/templates/journal/detail.html:167
 msgid "Notícias"
 msgstr ""
 
-#: build/lib/opac/webapp/__init__.py:125 build/lib/opac/webapp/__init__.py:126
 #: opac/webapp/__init__.py:125 opac/webapp/__init__.py:126
 msgid "Ativos"
 msgstr ""
 
-#: build/lib/opac/webapp/__init__.py:127 opac/webapp/__init__.py:127
+#: opac/webapp/__init__.py:127
 msgid "Páginas"
 msgstr ""
 
-#: build/lib/opac/webapp/__init__.py:128 build/lib/opac/webapp/__init__.py:129
 #: opac/webapp/__init__.py:128 opac/webapp/__init__.py:129
 msgid "Gestão"
 msgstr ""
 
-#: build/lib/opac/webapp/__init__.py:128 opac/webapp/__init__.py:128
+#: opac/webapp/__init__.py:128
 msgid "Auditoria: Páginas"
 msgstr ""
 
-#: build/lib/opac/webapp/__init__.py:129
-#: build/lib/opac/webapp/admin/views.py:896 opac/webapp/__init__.py:129
-#: opac/webapp/admin/views.py:896
+#: opac/webapp/__init__.py:129 opac/webapp/admin/views.py:897
 msgid "Usuário"
 msgstr ""
 
-#: build/lib/opac/webapp/choices.py:7 opac/webapp/choices.py:7
+#: opac/webapp/choices.py:7
 msgid "Conteúdo temporariamente indisponível"
 msgstr ""
 
-#: build/lib/opac/webapp/choices.py:11 build/lib/opac/webapp/choices.py:23
-#: build/lib/opac/webapp/templates/article/includes/modal/download.html:26
 #: opac/webapp/choices.py:11 opac/webapp/choices.py:23
 #: opac/webapp/templates/article/includes/modal/download.html:26
 msgid "Português"
 msgstr ""
 
-#: build/lib/opac/webapp/choices.py:12 build/lib/opac/webapp/choices.py:24
-#: build/lib/opac/webapp/templates/article/includes/modal/download.html:24
 #: opac/webapp/choices.py:12 opac/webapp/choices.py:24
 #: opac/webapp/templates/article/includes/modal/download.html:24
 msgid "Inglês"
 msgstr ""
 
-#: build/lib/opac/webapp/choices.py:13 build/lib/opac/webapp/choices.py:25
-#: build/lib/opac/webapp/templates/article/includes/modal/download.html:22
 #: opac/webapp/choices.py:13 opac/webapp/choices.py:25
 #: opac/webapp/templates/article/includes/modal/download.html:22
 msgid "Espanhol"
 msgstr ""
 
-#: build/lib/opac/webapp/choices.py:26 opac/webapp/choices.py:26
+#: opac/webapp/choices.py:26
 msgid "Albanês"
 msgstr ""
 
-#: build/lib/opac/webapp/choices.py:27 build/lib/opac/webapp/choices.py:33
 #: opac/webapp/choices.py:27 opac/webapp/choices.py:33
 msgid "Chinês"
 msgstr ""
 
-#: build/lib/opac/webapp/choices.py:28 opac/webapp/choices.py:28
+#: opac/webapp/choices.py:28
 msgid "Romeno"
 msgstr ""
 
-#: build/lib/opac/webapp/choices.py:29 opac/webapp/choices.py:29
+#: opac/webapp/choices.py:29
 msgid "Francês"
 msgstr ""
 
-#: build/lib/opac/webapp/choices.py:30 opac/webapp/choices.py:30
+#: opac/webapp/choices.py:30
 msgid "Italiano"
 msgstr ""
 
-#: build/lib/opac/webapp/choices.py:31 opac/webapp/choices.py:31
+#: opac/webapp/choices.py:31
 msgid "Russo"
 msgstr ""
 
-#: build/lib/opac/webapp/choices.py:32 opac/webapp/choices.py:32
+#: opac/webapp/choices.py:32
 msgid "Árabe"
 msgstr ""
 
-#: build/lib/opac/webapp/choices.py:37 opac/webapp/choices.py:37
+#: opac/webapp/choices.py:37
 msgid "corrente"
 msgstr ""
 
-#: build/lib/opac/webapp/choices.py:38 opac/webapp/choices.py:38
+#: opac/webapp/choices.py:38
 msgid "terminado"
 msgstr ""
 
-#: build/lib/opac/webapp/choices.py:39 opac/webapp/choices.py:39
+#: opac/webapp/choices.py:39
 msgid "indexação interrompida"
 msgstr ""
 
-#: build/lib/opac/webapp/choices.py:40 opac/webapp/choices.py:40
+#: opac/webapp/choices.py:40
 msgid "indexação interrompida pelo Comitê"
 msgstr ""
 
-#: build/lib/opac/webapp/choices.py:41 opac/webapp/choices.py:41
+#: opac/webapp/choices.py:41
 msgid "publicação finalizada"
 msgstr ""
 
-#: build/lib/opac/webapp/choices.py:45 opac/webapp/choices.py:45
+#: opac/webapp/choices.py:45
 msgid "Ciências Agrárias"
 msgstr ""
 
-#: build/lib/opac/webapp/choices.py:46 opac/webapp/choices.py:46
+#: opac/webapp/choices.py:46
 msgid "Ciências Sociais Aplicadas"
 msgstr ""
 
-#: build/lib/opac/webapp/choices.py:47 opac/webapp/choices.py:47
+#: opac/webapp/choices.py:47
 msgid "Ciências Biológicas"
 msgstr ""
 
-#: build/lib/opac/webapp/choices.py:48 opac/webapp/choices.py:48
+#: opac/webapp/choices.py:48
 msgid "Engenharias"
 msgstr ""
 
-#: build/lib/opac/webapp/choices.py:49 opac/webapp/choices.py:49
+#: opac/webapp/choices.py:49
 msgid "Ciências Exatas e da Terra"
 msgstr ""
 
-#: build/lib/opac/webapp/choices.py:50 opac/webapp/choices.py:50
+#: opac/webapp/choices.py:50
 msgid "Ciências da Saúde"
 msgstr ""
 
-#: build/lib/opac/webapp/choices.py:51 opac/webapp/choices.py:51
+#: opac/webapp/choices.py:51
 msgid "Ciências Humanas"
 msgstr ""
 
-#: build/lib/opac/webapp/choices.py:52 build/lib/opac/webapp/choices.py:53
 #: opac/webapp/choices.py:52 opac/webapp/choices.py:53
 msgid "Lingüística, Letras e Artes"
 msgstr ""
 
-#: build/lib/opac/webapp/controllers.py:353 opac/webapp/controllers.py:353
+#: opac/webapp/controllers.py:353
 msgid "Lista Alfabética"
 msgstr ""
 
-#: build/lib/opac/webapp/controllers.py:357 opac/webapp/controllers.py:357
+#: opac/webapp/controllers.py:357
 msgid "Lista Temática"
 msgstr ""
 
-#: build/lib/opac/webapp/controllers.py:361 opac/webapp/controllers.py:361
+#: opac/webapp/controllers.py:361
 msgid "Lista Web of Science"
 msgstr ""
 
-#: build/lib/opac/webapp/controllers.py:365 opac/webapp/controllers.py:365
+#: opac/webapp/controllers.py:365
 msgid "Lista by Institution"
 msgstr ""
 
-#: build/lib/opac/webapp/controllers.py:424 opac/webapp/controllers.py:424
+#: opac/webapp/controllers.py:424
 msgid "Obrigatório um jid."
 msgstr ""
 
-#: build/lib/opac/webapp/controllers.py:440 opac/webapp/controllers.py:440
+#: opac/webapp/controllers.py:440
 msgid "Obrigatório um acronym."
 msgstr ""
 
-#: build/lib/opac/webapp/controllers.py:456 opac/webapp/controllers.py:456
+#: opac/webapp/controllers.py:456
 msgid "Obrigatório um url_seg."
 msgstr ""
 
-#: build/lib/opac/webapp/controllers.py:472 opac/webapp/controllers.py:472
+#: opac/webapp/controllers.py:472
 msgid "Obrigatório um issn."
 msgstr ""
 
-#: build/lib/opac/webapp/controllers.py:487 opac/webapp/controllers.py:487
+#: opac/webapp/controllers.py:487
 msgid "Obrigatório um title."
 msgstr ""
 
-#: build/lib/opac/webapp/controllers.py:525
-#: build/lib/opac/webapp/controllers.py:669
-#: build/lib/opac/webapp/controllers.py:830 opac/webapp/controllers.py:525
-#: opac/webapp/controllers.py:669 opac/webapp/controllers.py:830
+#: opac/webapp/controllers.py:525 opac/webapp/controllers.py:669
+#: opac/webapp/controllers.py:830
 msgid "Obrigatório uma lista de ids."
 msgstr ""
 
-#: build/lib/opac/webapp/controllers.py:631
-#: build/lib/opac/webapp/controllers.py:851 opac/webapp/controllers.py:631
-#: opac/webapp/controllers.py:851
+#: opac/webapp/controllers.py:631 opac/webapp/controllers.py:851
 msgid "Obrigatório um iid."
 msgstr ""
 
-#: build/lib/opac/webapp/controllers.py:688 opac/webapp/controllers.py:688
+#: opac/webapp/controllers.py:688
 msgid "Obrigatório um jacron e issue_label."
 msgstr ""
 
-#: build/lib/opac/webapp/controllers.py:701 opac/webapp/controllers.py:701
+#: opac/webapp/controllers.py:701
 msgid "Obrigatório um PID."
 msgstr ""
 
-#: build/lib/opac/webapp/controllers.py:717 opac/webapp/controllers.py:717
+#: opac/webapp/controllers.py:717
 msgid "Obrigatório um url_seg e url_seg_issue."
 msgstr ""
 
-#: build/lib/opac/webapp/controllers.py:724 opac/webapp/controllers.py:724
+#: opac/webapp/controllers.py:724
 msgid "Obrigatório um assets_code."
 msgstr ""
 
-#: build/lib/opac/webapp/controllers.py:727 opac/webapp/controllers.py:727
+#: opac/webapp/controllers.py:727
 msgid "Obrigatório um journal."
 msgstr ""
 
-#: build/lib/opac/webapp/controllers.py:743 opac/webapp/controllers.py:743
+#: opac/webapp/controllers.py:743
 msgid "Obrigatório um aid."
 msgstr ""
 
-#: build/lib/opac/webapp/controllers.py:757 opac/webapp/controllers.py:757
+#: opac/webapp/controllers.py:757
 msgid "Obrigatório um url_seg_article."
 msgstr ""
 
-#: build/lib/opac/webapp/controllers.py:772 opac/webapp/controllers.py:772
+#: opac/webapp/controllers.py:772
 msgid "Obrigatório um iid and url_seg_article."
 msgstr ""
 
-#: build/lib/opac/webapp/controllers.py:788 opac/webapp/controllers.py:788
+#: opac/webapp/controllers.py:788
 msgid "Obrigatório um jid, url_seg_issue and url_seg_article."
 msgstr ""
 
-#: build/lib/opac/webapp/controllers.py:889 opac/webapp/controllers.py:889
+#: opac/webapp/controllers.py:889
 msgid "Obrigatório um pid."
 msgstr ""
 
-#: build/lib/opac/webapp/controllers.py:902 opac/webapp/controllers.py:902
+#: opac/webapp/controllers.py:902
 msgid "Obrigatório um aop_pid."
 msgstr ""
 
-#: build/lib/opac/webapp/controllers.py:913 opac/webapp/controllers.py:913
+#: opac/webapp/controllers.py:913
 msgid "Parámetro obrigatório: issue_iid."
 msgstr ""
 
-#: build/lib/opac/webapp/controllers.py:961 opac/webapp/controllers.py:961
+#: opac/webapp/controllers.py:961
 msgid "Parâmetro email deve ser uma string"
 msgstr ""
 
-#: build/lib/opac/webapp/controllers.py:972 opac/webapp/controllers.py:972
+#: opac/webapp/controllers.py:972
 msgid "Parâmetro email deve ser uma inteiro"
 msgstr ""
 
-#: build/lib/opac/webapp/controllers.py:984
-#: build/lib/opac/webapp/controllers.py:998 opac/webapp/controllers.py:984
-#: opac/webapp/controllers.py:998
+#: opac/webapp/controllers.py:984 opac/webapp/controllers.py:998
 #, python-format
 msgid "Usuário deve ser do tipo %s"
 msgstr ""
 
-#: build/lib/opac/webapp/controllers.py:1054 opac/webapp/controllers.py:1054
+#: opac/webapp/controllers.py:1054
 msgid "Compartilhamento de link SciELO"
 msgstr ""
 
-#: build/lib/opac/webapp/controllers.py:1055 opac/webapp/controllers.py:1055
+#: opac/webapp/controllers.py:1055
 #, python-format
 msgid "O usuário %s compartilha este link: %s, da SciELO"
 msgstr ""
 
-#: build/lib/opac/webapp/controllers.py:1063
-#: build/lib/opac/webapp/controllers.py:1099
-#: build/lib/opac/webapp/controllers.py:1121 opac/webapp/controllers.py:1063
-#: opac/webapp/controllers.py:1099 opac/webapp/controllers.py:1121
+#: opac/webapp/controllers.py:1063 opac/webapp/controllers.py:1099
+#: opac/webapp/controllers.py:1121
 msgid "Mensagem enviada!"
 msgstr ""
 
-#: build/lib/opac/webapp/controllers.py:1080 opac/webapp/controllers.py:1080
+#: opac/webapp/controllers.py:1080
 msgid "[Erro] Erro informado pelo usuário no site SciELO"
 msgstr ""
 
-#: build/lib/opac/webapp/controllers.py:1083 opac/webapp/controllers.py:1083
+#: opac/webapp/controllers.py:1083
 msgid "aplicação"
 msgstr ""
 
-#: build/lib/opac/webapp/controllers.py:1085 opac/webapp/controllers.py:1085
+#: opac/webapp/controllers.py:1085
 msgid "conteúdo"
 msgstr ""
 
-#: build/lib/opac/webapp/controllers.py:1090 opac/webapp/controllers.py:1090
+#: opac/webapp/controllers.py:1090
 #, python-format
 msgid ""
 "O usuário <b>%s</b> com e-mail: <b>%s</b>, informa que existe um erro na "
@@ -481,463 +396,412 @@ msgid ""
 " %s"
 msgstr ""
 
-#: build/lib/opac/webapp/controllers.py:1111 opac/webapp/controllers.py:1111
+#: opac/webapp/controllers.py:1111
 msgid "Contato de usuário via site SciELO"
 msgstr ""
 
-#: build/lib/opac/webapp/controllers.py:1113 opac/webapp/controllers.py:1113
+#: opac/webapp/controllers.py:1113
 #, python-format
 msgid "O usuário %s, com e-mail: %s, entra em contato com a seguinte mensagem:"
 msgstr ""
 
-#: build/lib/opac/webapp/controllers.py:1145 opac/webapp/controllers.py:1145
+#: opac/webapp/controllers.py:1145
 msgid "Obrigatório um slug_name."
 msgstr ""
 
-#: build/lib/opac/webapp/forms.py:29 opac/webapp/forms.py:29
+#: opac/webapp/forms.py:29
 msgid "Endereço de e-mail inválido."
 msgstr ""
 
-#: build/lib/opac/webapp/admin/forms.py:9
-#: build/lib/opac/webapp/admin/forms.py:21 opac/webapp/admin/forms.py:9
-#: opac/webapp/admin/forms.py:21
+#: opac/webapp/admin/forms.py:9 opac/webapp/admin/forms.py:21
 msgid "Email"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/forms.py:10
-#: build/lib/opac/webapp/admin/forms.py:25 opac/webapp/admin/forms.py:10
-#: opac/webapp/admin/forms.py:25
+#: opac/webapp/admin/forms.py:10 opac/webapp/admin/forms.py:25
 msgid "Senha"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/forms.py:15 opac/webapp/admin/forms.py:15
+#: opac/webapp/admin/forms.py:15
 msgid "Usuário inválido"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/forms.py:17 opac/webapp/admin/forms.py:17
+#: opac/webapp/admin/forms.py:17
 msgid "Senha inválida"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:28 opac/webapp/admin/views.py:28
+#: opac/webapp/admin/views.py:28
 msgid "Tem certeza que quer publicar os itens selecionados?"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:29 opac/webapp/admin/views.py:29
+#: opac/webapp/admin/views.py:29
 msgid "Tem certeza que quer despublicar os itens selecionados?"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:30 opac/webapp/admin/views.py:30
+#: opac/webapp/admin/views.py:30
 msgid "Tem certeza que quer reconstruir os artigos selecionados?"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:31 opac/webapp/admin/views.py:31
+#: opac/webapp/admin/views.py:31
 msgid ""
 "Tem certeza que quer enviar email de confirmação aos usuários "
 "selecionados?"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:91
-#: build/lib/opac/webapp/admin/views.py:104 opac/webapp/admin/views.py:91
-#: opac/webapp/admin/views.py:104
+#: opac/webapp/admin/views.py:91 opac/webapp/admin/views.py:104
 msgid "Usuário não encontrado"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:94 opac/webapp/admin/views.py:94
+#: opac/webapp/admin/views.py:94
 #, python-format
 msgid "Email: %(email)s confirmado com sucesso!"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:110 opac/webapp/admin/views.py:110
+#: opac/webapp/admin/views.py:110
 #, python-format
 msgid "Enviamos as instruções para recuperar a senha para: %(email)s"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:113 opac/webapp/admin/views.py:113
+#: opac/webapp/admin/views.py:113
 #, python-format
 msgid ""
 "Ocorreu um erro no envio das instruções por email para: %(email)s. Erro: "
 "%(error)s"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:139 opac/webapp/admin/views.py:139
+#: opac/webapp/admin/views.py:139
 msgid "Nova senha salva com sucesso!!"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:167
-#: build/lib/opac/webapp/admin/views.py:186 opac/webapp/admin/views.py:167
-#: opac/webapp/admin/views.py:186
+#: opac/webapp/admin/views.py:167 opac/webapp/admin/views.py:186
 #, python-format
 msgid "Enviamos o email de confirmação para: %(email)s"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:170 opac/webapp/admin/views.py:170
+#: opac/webapp/admin/views.py:170
 #, python-format
 msgid ""
 "Ocorreu um erro no envio do email de confirmação para: %(email)s "
 "%(error_msg)s"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:177 opac/webapp/admin/views.py:177
+#: opac/webapp/admin/views.py:177
 msgid "Enviar email de confirmação"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:189 opac/webapp/admin/views.py:189
+#: opac/webapp/admin/views.py:189
 #, python-format
 msgid "Ocorreu um erro no envio do email de confirmação para: %(email)s"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:193 opac/webapp/admin/views.py:193
+#: opac/webapp/admin/views.py:193
 #, python-format
 msgid "%(count)s usuários foram notificados com sucesso!"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:196 opac/webapp/admin/views.py:196
+#: opac/webapp/admin/views.py:196
 #, python-format
 msgid "Ocorreu um erro no envio do emails de confirmação. Erro: %(ex)s"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:231
-#: build/lib/opac/webapp/admin/views.py:265
-#: build/lib/opac/webapp/admin/views.py:363
-#: build/lib/opac/webapp/admin/views.py:393
-#: build/lib/opac/webapp/admin/views.py:677 opac/webapp/admin/views.py:231
-#: opac/webapp/admin/views.py:265 opac/webapp/admin/views.py:363
-#: opac/webapp/admin/views.py:393 opac/webapp/admin/views.py:677
+#: opac/webapp/admin/views.py:231 opac/webapp/admin/views.py:265
+#: opac/webapp/admin/views.py:363 opac/webapp/admin/views.py:393
+#: opac/webapp/admin/views.py:678
 msgid "Nome"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:232
-#: build/lib/opac/webapp/admin/views.py:267 opac/webapp/admin/views.py:232
-#: opac/webapp/admin/views.py:267
+#: opac/webapp/admin/views.py:232 opac/webapp/admin/views.py:267
 msgid "Link"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:233
-#: build/lib/opac/webapp/admin/views.py:268
-#: build/lib/opac/webapp/admin/views.py:678 opac/webapp/admin/views.py:233
-#: opac/webapp/admin/views.py:268 opac/webapp/admin/views.py:678
+#: opac/webapp/admin/views.py:233 opac/webapp/admin/views.py:268
+#: opac/webapp/admin/views.py:679
 msgid "Idioma"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:266 opac/webapp/admin/views.py:266
+#: opac/webapp/admin/views.py:266
 msgid "Previsualização"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:362
-#: build/lib/opac/webapp/admin/views.py:547
-#: build/lib/opac/webapp/admin/views.py:627 opac/webapp/admin/views.py:362
-#: opac/webapp/admin/views.py:547 opac/webapp/admin/views.py:627
+#: opac/webapp/admin/views.py:362 opac/webapp/admin/views.py:548
+#: opac/webapp/admin/views.py:628
 msgid "Ordem"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:364 opac/webapp/admin/views.py:364
+#: opac/webapp/admin/views.py:364
 msgid "URL"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:365 opac/webapp/admin/views.py:365
+#: opac/webapp/admin/views.py:365
 msgid "URL da logomarca"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:375 opac/webapp/admin/views.py:375
+#: opac/webapp/admin/views.py:375
 msgid "Financiador com Ordem ou Nome já cadastrado!"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:394 opac/webapp/admin/views.py:394
+#: opac/webapp/admin/views.py:394
 msgid "Acerca de"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:395
-#: build/lib/opac/webapp/admin/views.py:462 opac/webapp/admin/views.py:395
-#: opac/webapp/admin/views.py:462
+#: opac/webapp/admin/views.py:395 opac/webapp/admin/views.py:463
 msgid "Acrônimo"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:396 opac/webapp/admin/views.py:396
+#: opac/webapp/admin/views.py:396
 msgid "Endereço principal"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:397 opac/webapp/admin/views.py:397
+#: opac/webapp/admin/views.py:397
 msgid "Endereço secundário"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:398 opac/webapp/admin/views.py:398
+#: opac/webapp/admin/views.py:398
 msgid "Logo da Home (PT)"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:399 opac/webapp/admin/views.py:399
+#: opac/webapp/admin/views.py:399
 msgid "Logo da Home (EN)"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:400 opac/webapp/admin/views.py:400
+#: opac/webapp/admin/views.py:400
 msgid "Logo da Home (ES)"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:401 opac/webapp/admin/views.py:401
+#: opac/webapp/admin/views.py:401
 msgid "Logo do cabeçalho (PT)"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:402 opac/webapp/admin/views.py:402
+#: opac/webapp/admin/views.py:402
 msgid "Logo do cabeçalho (EN)"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:403 opac/webapp/admin/views.py:403
+#: opac/webapp/admin/views.py:403
 msgid "Logo do cabeçalho (ES)"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:404 opac/webapp/admin/views.py:404
+#: opac/webapp/admin/views.py:404
 msgid "Logo do menu (PT)"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:405
-#: build/lib/opac/webapp/admin/views.py:406 opac/webapp/admin/views.py:405
-#: opac/webapp/admin/views.py:406
+#: opac/webapp/admin/views.py:405 opac/webapp/admin/views.py:406
 msgid "Logo do menu (ES)"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:407 opac/webapp/admin/views.py:407
+#: opac/webapp/admin/views.py:407
 msgid "Logo do menu (drop)"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:408 opac/webapp/admin/views.py:408
+#: opac/webapp/admin/views.py:408
 msgid "Logo do rodapé"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:451 opac/webapp/admin/views.py:451
+#: opac/webapp/admin/views.py:452
 msgid "Id Periódico"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:453 opac/webapp/admin/views.py:453
+#: opac/webapp/admin/views.py:454
 msgid "Linha do tempo"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:454 opac/webapp/admin/views.py:454
+#: opac/webapp/admin/views.py:455
 msgid "Categorias de assunto"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:455 opac/webapp/admin/views.py:455
+#: opac/webapp/admin/views.py:456
 msgid "Áreas de estudo"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:456 opac/webapp/admin/views.py:456
+#: opac/webapp/admin/views.py:457
 msgid "Redes sociais"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:457
-#: build/lib/opac/webapp/admin/views.py:611
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:30
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:73
-#: opac/webapp/admin/views.py:457 opac/webapp/admin/views.py:611
+#: opac/webapp/admin/views.py:458 opac/webapp/admin/views.py:612
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:30
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:73
 msgid "Título"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:458 opac/webapp/admin/views.py:458
+#: opac/webapp/admin/views.py:459
 msgid "Título ISO"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:459 opac/webapp/admin/views.py:459
+#: opac/webapp/admin/views.py:460
 msgid "Título curto"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:460
-#: build/lib/opac/webapp/admin/views.py:538
-#: build/lib/opac/webapp/admin/views.py:614 opac/webapp/admin/views.py:460
-#: opac/webapp/admin/views.py:538 opac/webapp/admin/views.py:614
+#: opac/webapp/admin/views.py:461 opac/webapp/admin/views.py:539
+#: opac/webapp/admin/views.py:615
 msgid "Criado"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:461
-#: build/lib/opac/webapp/admin/views.py:539
-#: build/lib/opac/webapp/admin/views.py:615 opac/webapp/admin/views.py:461
-#: opac/webapp/admin/views.py:539 opac/webapp/admin/views.py:615
+#: opac/webapp/admin/views.py:462 opac/webapp/admin/views.py:540
+#: opac/webapp/admin/views.py:616
 msgid "Atualizado"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:463 opac/webapp/admin/views.py:463
+#: opac/webapp/admin/views.py:464
 msgid "ISSN SciELO"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:464 opac/webapp/admin/views.py:464
+#: opac/webapp/admin/views.py:465
 msgid "ISSN impresso"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:465 opac/webapp/admin/views.py:465
+#: opac/webapp/admin/views.py:466
 msgid "ISSN eletrônico"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:466 opac/webapp/admin/views.py:466
+#: opac/webapp/admin/views.py:467
 msgid "Descritores de assunto"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:467 opac/webapp/admin/views.py:467
+#: opac/webapp/admin/views.py:468
 msgid "Url da submissão online"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:468 opac/webapp/admin/views.py:468
+#: opac/webapp/admin/views.py:469
 msgid "Url do capa"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:469 opac/webapp/admin/views.py:469
+#: opac/webapp/admin/views.py:470
 msgid "Url do logotipo"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:470 opac/webapp/admin/views.py:470
+#: opac/webapp/admin/views.py:471
 msgid "Outros títulos"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:471 opac/webapp/admin/views.py:471
+#: opac/webapp/admin/views.py:472
 msgid "Nome da editora"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:472 opac/webapp/admin/views.py:472
+#: opac/webapp/admin/views.py:473
 msgid "País da editora"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:473 opac/webapp/admin/views.py:473
+#: opac/webapp/admin/views.py:474
 msgid "Estado da editora"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:474 opac/webapp/admin/views.py:474
+#: opac/webapp/admin/views.py:475
 msgid "Cidade da editora"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:475 opac/webapp/admin/views.py:475
+#: opac/webapp/admin/views.py:476
 msgid "Endereço da editora"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:476 opac/webapp/admin/views.py:476
+#: opac/webapp/admin/views.py:477
 msgid "Telefone da editora"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:477 opac/webapp/admin/views.py:477
+#: opac/webapp/admin/views.py:478
 msgid "Missão"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:478 opac/webapp/admin/views.py:478
+#: opac/webapp/admin/views.py:479
 msgid "No índice"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:479 opac/webapp/admin/views.py:479
+#: opac/webapp/admin/views.py:480
 msgid "Patrocinadores"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:480 opac/webapp/admin/views.py:480
+#: opac/webapp/admin/views.py:481
 msgid "Ref periódico anterior"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:481 opac/webapp/admin/views.py:481
+#: opac/webapp/admin/views.py:482
 msgid "Situação atual"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:482 opac/webapp/admin/views.py:482
+#: opac/webapp/admin/views.py:483
 msgid "Total de números"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:483
-#: build/lib/opac/webapp/admin/views.py:548
-#: build/lib/opac/webapp/admin/views.py:618 opac/webapp/admin/views.py:483
-#: opac/webapp/admin/views.py:548 opac/webapp/admin/views.py:618
+#: opac/webapp/admin/views.py:484 opac/webapp/admin/views.py:549
+#: opac/webapp/admin/views.py:619
 msgid "Publicado?"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:484
-#: build/lib/opac/webapp/admin/views.py:549
-#: build/lib/opac/webapp/admin/views.py:619 opac/webapp/admin/views.py:484
-#: opac/webapp/admin/views.py:549 opac/webapp/admin/views.py:619
+#: opac/webapp/admin/views.py:485 opac/webapp/admin/views.py:550
+#: opac/webapp/admin/views.py:620
 msgid "Motivo de despublicação"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:485
-#: build/lib/opac/webapp/admin/views.py:551
-#: build/lib/opac/webapp/admin/views.py:620 opac/webapp/admin/views.py:485
-#: opac/webapp/admin/views.py:551 opac/webapp/admin/views.py:620
+#: opac/webapp/admin/views.py:486 opac/webapp/admin/views.py:552
+#: opac/webapp/admin/views.py:621
 msgid "Segmento de URL"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:488
-#: build/lib/opac/webapp/admin/views.py:554
-#: build/lib/opac/webapp/admin/views.py:633 opac/webapp/admin/views.py:488
-#: opac/webapp/admin/views.py:554 opac/webapp/admin/views.py:633
+#: opac/webapp/admin/views.py:489 opac/webapp/admin/views.py:555
+#: opac/webapp/admin/views.py:634
 msgid "Publicar"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:493 opac/webapp/admin/views.py:493
+#: opac/webapp/admin/views.py:494
 msgid "Periódico(s) publicado(s) com sucesso!!"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:495 opac/webapp/admin/views.py:495
+#: opac/webapp/admin/views.py:496
 msgid "Ocorreu um erro tentando publicar o(s) periódico(s)!!"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:501 opac/webapp/admin/views.py:501
+#: opac/webapp/admin/views.py:502
 msgid "Periódico(s) despublicado com sucesso!!"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:504 opac/webapp/admin/views.py:504
+#: opac/webapp/admin/views.py:505
 #, python-format
 msgid "Ocorreu um erro tentando despublicar o(s) periódico(s)!!. Erro: %(ex)s"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:508
-#: build/lib/opac/webapp/admin/views.py:576
-#: build/lib/opac/webapp/admin/views.py:656 opac/webapp/admin/views.py:508
-#: opac/webapp/admin/views.py:576 opac/webapp/admin/views.py:656
+#: opac/webapp/admin/views.py:509 opac/webapp/admin/views.py:577
+#: opac/webapp/admin/views.py:657
 #, python-format
 msgid "Despublicar por %s"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:532 opac/webapp/admin/views.py:532
+#: opac/webapp/admin/views.py:533
 msgid "Id Número"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:534
-#: build/lib/opac/webapp/admin/views.py:624 opac/webapp/admin/views.py:534
-#: opac/webapp/admin/views.py:624
+#: opac/webapp/admin/views.py:535 opac/webapp/admin/views.py:625
 msgid "Seções"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:535 opac/webapp/admin/views.py:535
+#: opac/webapp/admin/views.py:536
 msgid "Url da capa"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:536
-#: build/lib/opac/webapp/templates/collection/list_feed_content.html:3
-#: build/lib/opac/webapp/templates/issue/grid.html:40
-#: build/lib/opac/webapp/templates/news/includes/issue_last_row.html:7
-#: opac/webapp/admin/views.py:536
+#: opac/webapp/admin/views.py:537
 #: opac/webapp/templates/collection/list_feed_content.html:3
 #: opac/webapp/templates/issue/grid.html:40
 #: opac/webapp/templates/news/includes/issue_last_row.html:7
 msgid "Volume"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:540 opac/webapp/admin/views.py:540
+#: opac/webapp/admin/views.py:541
 msgid "Tipo"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:541 opac/webapp/admin/views.py:541
+#: opac/webapp/admin/views.py:542
 msgid "Texto do suplemento"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:542 opac/webapp/admin/views.py:542
+#: opac/webapp/admin/views.py:543
 msgid "Texto do especial"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:543 opac/webapp/admin/views.py:543
+#: opac/webapp/admin/views.py:544
 msgid "Mês inicial"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:544 opac/webapp/admin/views.py:544
+#: opac/webapp/admin/views.py:545
 msgid "Mês final"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:545
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:25
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:68
-#: build/lib/opac/webapp/templates/issue/grid.html:39
-#: build/lib/opac/webapp/templates/news/includes/issue_last_row.html:5
-#: opac/webapp/admin/views.py:545
+#: opac/webapp/admin/views.py:546
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:25
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:68
 #: opac/webapp/templates/issue/grid.html:39
@@ -945,305 +809,254 @@ msgstr ""
 msgid "Ano"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:546 opac/webapp/admin/views.py:546
+#: opac/webapp/admin/views.py:547
 msgid "Etiqueta"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:550
-#: build/lib/opac/webapp/admin/views.py:621 opac/webapp/admin/views.py:550
-#: opac/webapp/admin/views.py:621
+#: opac/webapp/admin/views.py:551 opac/webapp/admin/views.py:622
 msgid "PID"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:559 opac/webapp/admin/views.py:559
+#: opac/webapp/admin/views.py:560
 msgid "Número(s) publicado(s) com sucesso!!"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:562
-#: build/lib/opac/webapp/admin/views.py:642 opac/webapp/admin/views.py:562
-#: opac/webapp/admin/views.py:642
+#: opac/webapp/admin/views.py:563 opac/webapp/admin/views.py:643
 #, python-format
 msgid "Ocorreu um erro tentando publicar o(s) número(s)!!. Erro: %(ex)s"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:569 opac/webapp/admin/views.py:569
+#: opac/webapp/admin/views.py:570
 msgid "Número(s) despublicado(s) com sucesso!!"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:572
-#: build/lib/opac/webapp/admin/views.py:652 opac/webapp/admin/views.py:572
-#: opac/webapp/admin/views.py:652
+#: opac/webapp/admin/views.py:573 opac/webapp/admin/views.py:653
 #, python-format
 msgid "Ocorreu um erro tentando despublicar o(s) número(s)!!. Erro: %(ex)s"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:608 opac/webapp/admin/views.py:608
+#: opac/webapp/admin/views.py:609
 msgid "Id Artigo"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:612 opac/webapp/admin/views.py:612
+#: opac/webapp/admin/views.py:613
 msgid "Seção"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:613 opac/webapp/admin/views.py:613
+#: opac/webapp/admin/views.py:614
 msgid "É Ahead of Print?"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:616 opac/webapp/admin/views.py:616
+#: opac/webapp/admin/views.py:617
 msgid "HTML's"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:617 opac/webapp/admin/views.py:617
+#: opac/webapp/admin/views.py:618
 msgid "Chave de domínio"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:622 opac/webapp/admin/views.py:622
+#: opac/webapp/admin/views.py:623
 msgid "Idioma original"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:623 opac/webapp/admin/views.py:623
+#: opac/webapp/admin/views.py:624
 msgid "Idiomas das traduções"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:625 opac/webapp/admin/views.py:625
+#: opac/webapp/admin/views.py:626
 msgid "Autores"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:626
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:29
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:72
-#: build/lib/opac/webapp/templates/issue/toc.html:176
-#: opac/webapp/admin/views.py:626
+#: opac/webapp/admin/views.py:627
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:29
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:72
-#: opac/webapp/templates/issue/toc.html:176
+#: opac/webapp/templates/issue/toc.html:169
 msgid "Resumo"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:628 opac/webapp/admin/views.py:628
+#: opac/webapp/admin/views.py:629
 msgid "DOI"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:629 opac/webapp/admin/views.py:629
+#: opac/webapp/admin/views.py:630
 msgid "Idiomas"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:630 opac/webapp/admin/views.py:630
+#: opac/webapp/admin/views.py:631
 msgid "Idiomas dos resumos"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:638 opac/webapp/admin/views.py:638
+#: opac/webapp/admin/views.py:639
 msgid "Artigo(s) publicado com sucesso!!"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:649 opac/webapp/admin/views.py:649
+#: opac/webapp/admin/views.py:650
 msgid "Artigo(s) despublicado com sucesso!!"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:679 opac/webapp/admin/views.py:679
+#: opac/webapp/admin/views.py:680
 msgid "Conteúdo"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:681
-#: build/lib/opac/webapp/admin/views.py:901 opac/webapp/admin/views.py:681
-#: opac/webapp/admin/views.py:901
+#: opac/webapp/admin/views.py:682 opac/webapp/admin/views.py:902
 msgid "Descrição"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:682
-#: build/lib/opac/webapp/admin/views.py:898 opac/webapp/admin/views.py:682
-#: opac/webapp/admin/views.py:898
+#: opac/webapp/admin/views.py:683 opac/webapp/admin/views.py:899
 msgid "Data de Criação"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:683 opac/webapp/admin/views.py:683
+#: opac/webapp/admin/views.py:684
 msgid "Data de Atualização"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:897 opac/webapp/admin/views.py:897
+#: opac/webapp/admin/views.py:898
 msgid "Ação"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:899 opac/webapp/admin/views.py:899
+#: opac/webapp/admin/views.py:900
 msgid "Modelo Auditado"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:900 opac/webapp/admin/views.py:900
+#: opac/webapp/admin/views.py:901
 msgid "Id Auditado"
 msgstr ""
 
-#: build/lib/opac/webapp/admin/views.py:902 opac/webapp/admin/views.py:902
+#: opac/webapp/admin/views.py:903
 msgid "Dados dos campos"
 msgstr ""
 
-#: build/lib/opac/webapp/main/views.py:34 opac/webapp/main/views.py:34
+#: opac/webapp/main/views.py:34
 msgid "O periódico está indisponível por motivo de: "
 msgstr ""
 
-#: build/lib/opac/webapp/main/views.py:35 opac/webapp/main/views.py:35
+#: opac/webapp/main/views.py:35
 msgid "O número está indisponível por motivo de: "
 msgstr ""
 
-#: build/lib/opac/webapp/main/views.py:36 opac/webapp/main/views.py:36
+#: opac/webapp/main/views.py:36
 msgid "O artigo está indisponível por motivo de: "
 msgstr ""
 
-#: build/lib/opac/webapp/main/views.py:127 opac/webapp/main/views.py:127
+#: opac/webapp/main/views.py:127
 msgid "Código de idioma inválido"
 msgstr ""
 
-#: build/lib/opac/webapp/main/views.py:197 opac/webapp/main/views.py:197
+#: opac/webapp/main/views.py:197
 msgid "Últimos periódicos inseridos na coleção"
 msgstr ""
 
-#: build/lib/opac/webapp/main/views.py:198 opac/webapp/main/views.py:198
+#: opac/webapp/main/views.py:198
 #, python-format
 msgid "10 últimos periódicos inseridos na coleção %s"
 msgstr ""
 
-#: build/lib/opac/webapp/main/views.py:257 opac/webapp/main/views.py:257
+#: opac/webapp/main/views.py:257
 msgid "Página não encontrada"
 msgstr ""
 
-#: build/lib/opac/webapp/main/views.py:281
-#: build/lib/opac/webapp/main/views.py:371 opac/webapp/main/views.py:281
-#: opac/webapp/main/views.py:371
+#: opac/webapp/main/views.py:281 opac/webapp/main/views.py:371
 #, python-format
 msgid "Requsição inválida ao tentar acessar o artigo com pid: %s"
 msgstr ""
 
-#: build/lib/opac/webapp/main/views.py:289
-#: build/lib/opac/webapp/main/views.py:339
-#: build/lib/opac/webapp/main/views.py:383
-#: build/lib/opac/webapp/main/views.py:452
-#: build/lib/opac/webapp/main/views.py:500
-#: build/lib/opac/webapp/main/views.py:647
-#: build/lib/opac/webapp/main/views.py:664
-#: build/lib/opac/webapp/main/views.py:1127 opac/webapp/main/views.py:289
-#: opac/webapp/main/views.py:339 opac/webapp/main/views.py:383
-#: opac/webapp/main/views.py:452 opac/webapp/main/views.py:500
-#: opac/webapp/main/views.py:647 opac/webapp/main/views.py:664
-#: opac/webapp/main/views.py:1127
+#: opac/webapp/main/views.py:289 opac/webapp/main/views.py:339
+#: opac/webapp/main/views.py:383 opac/webapp/main/views.py:452
+#: opac/webapp/main/views.py:500 opac/webapp/main/views.py:647
+#: opac/webapp/main/views.py:664 opac/webapp/main/views.py:1127
 msgid "Periódico não encontrado"
 msgstr ""
 
-#: build/lib/opac/webapp/main/views.py:301
-#: build/lib/opac/webapp/main/views.py:714
-#: build/lib/opac/webapp/main/views.py:773
-#: build/lib/opac/webapp/main/views.py:1136 opac/webapp/main/views.py:301
-#: opac/webapp/main/views.py:714 opac/webapp/main/views.py:773
-#: opac/webapp/main/views.py:1136
+#: opac/webapp/main/views.py:301 opac/webapp/main/views.py:714
+#: opac/webapp/main/views.py:773 opac/webapp/main/views.py:1136
 msgid "Número não encontrado"
 msgstr ""
 
-#: build/lib/opac/webapp/main/views.py:319
-#: build/lib/opac/webapp/main/views.py:354
-#: build/lib/opac/webapp/main/views.py:825
-#: build/lib/opac/webapp/main/views.py:910
-#: build/lib/opac/webapp/main/views.py:1060 opac/webapp/main/views.py:319
-#: opac/webapp/main/views.py:354 opac/webapp/main/views.py:825
-#: opac/webapp/main/views.py:910 opac/webapp/main/views.py:1060
+#: opac/webapp/main/views.py:319 opac/webapp/main/views.py:354
+#: opac/webapp/main/views.py:825 opac/webapp/main/views.py:910
+#: opac/webapp/main/views.py:1060
 msgid "Artigo não encontrado"
 msgstr ""
 
-#: build/lib/opac/webapp/main/views.py:476 opac/webapp/main/views.py:476
+#: opac/webapp/main/views.py:476
 msgid "Artigo sem título"
 msgstr ""
 
-#: build/lib/opac/webapp/main/views.py:548
-#: build/lib/opac/webapp/main/views.py:565 opac/webapp/main/views.py:548
-#: opac/webapp/main/views.py:565
+#: opac/webapp/main/views.py:548 opac/webapp/main/views.py:565
 msgid "Requisição inválida. Deve ser por ajax"
 msgstr ""
 
-#: build/lib/opac/webapp/main/views.py:581 opac/webapp/main/views.py:581
+#: opac/webapp/main/views.py:581
 msgid ""
 "Parámetro \"filter\" é inválido, deve ser \"areas\", \"wos\" ou "
 "\"publisher\"."
 msgstr ""
 
-#: build/lib/opac/webapp/main/views.py:590 opac/webapp/main/views.py:590
+#: opac/webapp/main/views.py:590
 msgid "Parámetro \"extension\" é inválido, deve ser \"csv\" ou \"xls\"."
 msgstr ""
 
-#: build/lib/opac/webapp/main/views.py:592 opac/webapp/main/views.py:592
+#: opac/webapp/main/views.py:592
 msgid ""
 "Parámetro \"list_type\" é inválido, deve ser: \"alpha\", \"areas\", "
 "\"wos\" ou \"publisher\"."
 msgstr ""
 
-#: build/lib/opac/webapp/main/views.py:613 opac/webapp/main/views.py:613
+#: opac/webapp/main/views.py:613
 msgid "Requisição inválida, deve ser ajax."
 msgstr ""
 
-#: build/lib/opac/webapp/main/views.py:622 opac/webapp/main/views.py:622
+#: opac/webapp/main/views.py:622
 msgid "Periódico não permite envio de email."
 msgstr ""
 
-#: build/lib/opac/webapp/main/views.py:640 opac/webapp/main/views.py:640
+#: opac/webapp/main/views.py:640
 msgid "Requisição inválida, captcha inválido."
 msgstr ""
 
-#: build/lib/opac/webapp/main/views.py:901
-#: build/lib/opac/webapp/main/views.py:1055 opac/webapp/main/views.py:901
-#: opac/webapp/main/views.py:1055
+#: opac/webapp/main/views.py:901 opac/webapp/main/views.py:1055
 msgid "Issue não encontrado"
 msgstr ""
 
-#: build/lib/opac/webapp/main/views.py:943
-#: build/lib/opac/webapp/main/views.py:949
-#: build/lib/opac/webapp/main/views.py:1092
-#: build/lib/opac/webapp/main/views.py:1100
-#: build/lib/opac/webapp/main/views.py:1102 opac/webapp/main/views.py:943
-#: opac/webapp/main/views.py:949 opac/webapp/main/views.py:1092
-#: opac/webapp/main/views.py:1100 opac/webapp/main/views.py:1102
+#: opac/webapp/main/views.py:943 opac/webapp/main/views.py:949
+#: opac/webapp/main/views.py:1092 opac/webapp/main/views.py:1100
+#: opac/webapp/main/views.py:1102
 msgid "PDF do Artigo não encontrado"
 msgstr ""
 
-#: build/lib/opac/webapp/main/views.py:954 opac/webapp/main/views.py:954
+#: opac/webapp/main/views.py:954
 msgid "HTML do Artigo não encontrado ou indisponível"
 msgstr ""
 
-#: build/lib/opac/webapp/main/views.py:1001 opac/webapp/main/views.py:1001
+#: opac/webapp/main/views.py:1001
 msgid "Parâmetros insuficientes para obter o EPDF do artigo"
 msgstr ""
 
-#: build/lib/opac/webapp/main/views.py:1022 opac/webapp/main/views.py:1022
+#: opac/webapp/main/views.py:1022
 msgid "Recruso não encontrado"
 msgstr ""
 
-#: build/lib/opac/webapp/main/views.py:1041 opac/webapp/main/views.py:1041
+#: opac/webapp/main/views.py:1041
 msgid "Recurso do Artigo não encontrado. Caminho inválido!"
 msgstr ""
 
-#: build/lib/opac/webapp/main/views.py:1154 opac/webapp/main/views.py:1154
+#: opac/webapp/main/views.py:1154
 msgid "PDF do artigo não foi encontrado"
 msgstr ""
 
-#: build/lib/opac/webapp/main/views.py:1169
-#: build/lib/opac/webapp/main/views.py:1200 opac/webapp/main/views.py:1169
-#: opac/webapp/main/views.py:1200
+#: opac/webapp/main/views.py:1169 opac/webapp/main/views.py:1200
 msgid "Requisição inválida."
 msgstr ""
 
-#: build/lib/opac/webapp/templates/admin/index.html:7
 #: opac/webapp/templates/admin/index.html:7
 msgid "da coleção"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/admin/index.html:12
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu.html:31
 #: opac/webapp/templates/admin/index.html:12
 #: opac/webapp/templates/collection/includes/levelMenu.html:31
 msgid "Periódicos"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/admin/index.html:15
-#: build/lib/opac/webapp/templates/admin/index.html:22
-#: build/lib/opac/webapp/templates/admin/index.html:35
-#: build/lib/opac/webapp/templates/admin/index.html:42
-#: build/lib/opac/webapp/templates/admin/index.html:55
-#: build/lib/opac/webapp/templates/admin/index.html:62
 #: opac/webapp/templates/admin/index.html:15
 #: opac/webapp/templates/admin/index.html:22
 #: opac/webapp/templates/admin/index.html:35
@@ -1253,12 +1066,6 @@ msgstr ""
 msgid "Publicados"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/admin/index.html:16
-#: build/lib/opac/webapp/templates/admin/index.html:36
-#: build/lib/opac/webapp/templates/admin/index.html:56
-#: build/lib/opac/webapp/templates/admin/index.html:75
-#: build/lib/opac/webapp/templates/admin/index.html:85
-#: build/lib/opac/webapp/templates/admin/index.html:95
 #: opac/webapp/templates/admin/index.html:16
 #: opac/webapp/templates/admin/index.html:36
 #: opac/webapp/templates/admin/index.html:56
@@ -1268,78 +1075,58 @@ msgstr ""
 msgid "Total"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/admin/index.html:32
 #: opac/webapp/templates/admin/index.html:32
 msgid "Fascícluos"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/admin/index.html:52
 #: opac/webapp/templates/admin/index.html:52
 msgid "Artigos"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/admin/index.html:72
 #: opac/webapp/templates/admin/index.html:72
 msgid "News"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/admin/index.html:82
 #: opac/webapp/templates/admin/index.html:82
 msgid "Sponsors"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/admin/index.html:92
 #: opac/webapp/templates/admin/index.html:92
 msgid "Press Releases"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/admin/auth/reset.html:9
-#: build/lib/opac/webapp/templates/admin/auth/reset_with_token.html:9
-#: build/lib/opac/webapp/templates/admin/opac_base.html:13
 #: opac/webapp/templates/admin/auth/reset.html:9
 #: opac/webapp/templates/admin/auth/reset_with_token.html:9
 #: opac/webapp/templates/admin/opac_base.html:13
 msgid "Recuperar a senha"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/admin/opac_base.html:14
 #: opac/webapp/templates/admin/opac_base.html:14
 msgid "Terminar sessão"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/admin/auth/login.html:11
-#: build/lib/opac/webapp/templates/admin/auth/login.html:20
-#: build/lib/opac/webapp/templates/admin/opac_base.html:18
 #: opac/webapp/templates/admin/auth/login.html:11
 #: opac/webapp/templates/admin/auth/login.html:20
 #: opac/webapp/templates/admin/opac_base.html:18
 msgid "Iniciar sessão"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/admin/audit_log/fields_data_table.html:4
 #: opac/webapp/templates/admin/audit_log/fields_data_table.html:4
 msgid "Campo: "
 msgstr ""
 
-#: build/lib/opac/webapp/templates/admin/audit_log/fields_data_table.html:5
 #: opac/webapp/templates/admin/audit_log/fields_data_table.html:5
 msgid "Valor anterior: "
 msgstr ""
 
-#: build/lib/opac/webapp/templates/admin/audit_log/fields_data_table.html:6
 #: opac/webapp/templates/admin/audit_log/fields_data_table.html:6
 msgid "Valor novo: "
 msgstr ""
 
-#: build/lib/opac/webapp/templates/admin/auth/login.html:13
 #: opac/webapp/templates/admin/auth/login.html:13
 msgid "Você já iniciou sessão!"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/admin/auth/login.html:24
-#: build/lib/opac/webapp/templates/admin/auth/reset.html:13
-#: build/lib/opac/webapp/templates/admin/auth/reset_with_token.html:13
-#: build/lib/opac/webapp/templates/includes/error_form.html:60
 #: opac/webapp/templates/admin/auth/login.html:24
 #: opac/webapp/templates/admin/auth/reset.html:13
 #: opac/webapp/templates/admin/auth/reset_with_token.html:13
@@ -1347,17 +1134,14 @@ msgstr ""
 msgid "Enviar"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/admin/auth/login.html:28
 #: opac/webapp/templates/admin/auth/login.html:28
 msgid "Esqueci a senha?"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/admin/auth/unconfirm_email.html:7
 #: opac/webapp/templates/admin/auth/unconfirm_email.html:7
 msgid "Email não confirmado!"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/admin/auth/unconfirm_email.html:9
 #: opac/webapp/templates/admin/auth/unconfirm_email.html:9
 msgid ""
 "Você <strong>deve</strong> confirmar seu email.<br>\n"
@@ -1365,7 +1149,6 @@ msgid ""
 "administrador.</strong>"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/admin/pages/edit.html:7
 #: opac/webapp/templates/admin/pages/edit.html:7
 msgid ""
 "<strong>Atenção:</strong> ao selecionar um <strong>periódico</strong> "
@@ -1374,11 +1157,6 @@ msgid ""
 "<em>Sobre o SciELO</em>. "
 msgstr ""
 
-#: build/lib/opac/webapp/templates/article/includes/alternative_header.html:7
-#: build/lib/opac/webapp/templates/collection/includes/header.html:7
-#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:7
-#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:7
-#: build/lib/opac/webapp/templates/journal/includes/header.html:8
 #: opac/webapp/templates/article/includes/alternative_header.html:7
 #: opac/webapp/templates/collection/includes/header.html:7
 #: opac/webapp/templates/issue/includes/alternative_header.html:7
@@ -1387,10 +1165,6 @@ msgstr ""
 msgid "Abrir menu"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/article/includes/alternative_header.html:9
-#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:9
-#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:9
-#: build/lib/opac/webapp/templates/journal/includes/header.html:10
 #: opac/webapp/templates/article/includes/alternative_header.html:9
 #: opac/webapp/templates/issue/includes/alternative_header.html:9
 #: opac/webapp/templates/journal/includes/alternative_header.html:9
@@ -1398,11 +1172,6 @@ msgstr ""
 msgid "Ir para a homepage da coleção: "
 msgstr ""
 
-#: build/lib/opac/webapp/templates/article/includes/alternative_header.html:42
-#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:7
-#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:121
-#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:117
-#: build/lib/opac/webapp/templates/journal/includes/header.html:118
 #: opac/webapp/templates/article/includes/alternative_header.html:42
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:7
 #: opac/webapp/templates/issue/includes/alternative_header.html:121
@@ -1411,11 +1180,6 @@ msgstr ""
 msgid "Submissão de manuscritos"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/article/includes/alternative_header.html:48
-#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:16
-#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:127
-#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:123
-#: build/lib/opac/webapp/templates/journal/includes/header.html:124
 #: opac/webapp/templates/article/includes/alternative_header.html:48
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:16
 #: opac/webapp/templates/issue/includes/alternative_header.html:127
@@ -1424,11 +1188,6 @@ msgstr ""
 msgid "Sobre o periódico"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/article/includes/alternative_header.html:53
-#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:10
-#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:132
-#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:128
-#: build/lib/opac/webapp/templates/journal/includes/header.html:129
 #: opac/webapp/templates/article/includes/alternative_header.html:53
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:10
 #: opac/webapp/templates/issue/includes/alternative_header.html:132
@@ -1437,11 +1196,6 @@ msgstr ""
 msgid "Corpo Editorial"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/article/includes/alternative_header.html:58
-#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:13
-#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:137
-#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:133
-#: build/lib/opac/webapp/templates/journal/includes/header.html:134
 #: opac/webapp/templates/article/includes/alternative_header.html:58
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:13
 #: opac/webapp/templates/issue/includes/alternative_header.html:137
@@ -1450,11 +1204,6 @@ msgstr ""
 msgid "Instruções aos autores"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/article/includes/alternative_header.html:63
-#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:19
-#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:142
-#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:138
-#: build/lib/opac/webapp/templates/journal/includes/header.html:140
 #: opac/webapp/templates/article/includes/alternative_header.html:63
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:19
 #: opac/webapp/templates/issue/includes/alternative_header.html:142
@@ -1463,81 +1212,56 @@ msgstr ""
 msgid "Contato"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:2
-#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:60
 #: opac/webapp/templates/article/includes/floating_menu.html:2
 #: opac/webapp/templates/article/includes/floating_menu.html:60
 msgid "Ir para o topo"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:6
-#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:65
 #: opac/webapp/templates/article/includes/floating_menu.html:6
 #: opac/webapp/templates/article/includes/floating_menu.html:65
 msgid "PDFs"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:26
-#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:77
 #: opac/webapp/templates/article/includes/floating_menu.html:26
 #: opac/webapp/templates/article/includes/floating_menu.html:77
 msgid "Figuras e tabelas"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:32
-#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:83
 #: opac/webapp/templates/article/includes/floating_menu.html:32
 #: opac/webapp/templates/article/includes/floating_menu.html:83
 msgid "Versões e traduções"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:37
-#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:88
 #: opac/webapp/templates/article/includes/floating_menu.html:37
 #: opac/webapp/templates/article/includes/floating_menu.html:88
 msgid "Como citar este artigo"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:42
-#: build/lib/opac/webapp/templates/article/includes/modal/related_article.html:9
 #: opac/webapp/templates/article/includes/floating_menu.html:42
 #: opac/webapp/templates/article/includes/modal/related_article.html:9
 msgid "Artigos relacionados"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/article/includes/floating_menu.html:93
 #: opac/webapp/templates/article/includes/floating_menu.html:93
 msgid "Artigos e similares"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:9
 #: opac/webapp/templates/article/includes/levelMenu.html:9
 msgid "home do periodico"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:17
-#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:70
-#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:123
 #: opac/webapp/templates/article/includes/levelMenu.html:17
 #: opac/webapp/templates/article/includes/levelMenu.html:70
 #: opac/webapp/templates/article/includes/levelMenu.html:123
 msgid "sumário"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:30
-#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:75
-#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:71
 #: opac/webapp/templates/article/includes/levelMenu.html:30
 #: opac/webapp/templates/issue/includes/alternative_header.html:75
 #: opac/webapp/templates/journal/includes/alternative_header.html:71
 msgid "anterior"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:35
-#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:88
-#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:141
-#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:82
-#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:78
 #: opac/webapp/templates/article/includes/levelMenu.html:35
 #: opac/webapp/templates/article/includes/levelMenu.html:88
 #: opac/webapp/templates/article/includes/levelMenu.html:141
@@ -1546,15 +1270,10 @@ msgstr ""
 msgid "atual"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:48
 #: opac/webapp/templates/article/includes/levelMenu.html:48
 msgid "seguinte"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:193
-#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:219
-#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:264
-#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:290
 #: opac/webapp/templates/article/includes/levelMenu.html:193
 #: opac/webapp/templates/article/includes/levelMenu.html:219
 #: opac/webapp/templates/article/includes/levelMenu.html:264
@@ -1562,10 +1281,6 @@ msgstr ""
 msgid "Download PDF (Espanhol)"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:195
-#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:221
-#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:266
-#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:292
 #: opac/webapp/templates/article/includes/levelMenu.html:195
 #: opac/webapp/templates/article/includes/levelMenu.html:221
 #: opac/webapp/templates/article/includes/levelMenu.html:266
@@ -1573,10 +1288,6 @@ msgstr ""
 msgid "Download PDF (Inglês)"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:197
-#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:223
-#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:268
-#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:294
 #: opac/webapp/templates/article/includes/levelMenu.html:197
 #: opac/webapp/templates/article/includes/levelMenu.html:223
 #: opac/webapp/templates/article/includes/levelMenu.html:268
@@ -1584,13 +1295,6 @@ msgstr ""
 msgid "Download PDF (Português)"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:310
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu.html:38
-#: build/lib/opac/webapp/templates/collection/includes/list_journals_section_title.html:14
-#: build/lib/opac/webapp/templates/issue/grid.html:14
-#: build/lib/opac/webapp/templates/issue/toc.html:13
-#: build/lib/opac/webapp/templates/journal/about.html:16
-#: build/lib/opac/webapp/templates/journal/detail.html:11
 #: opac/webapp/templates/article/includes/levelMenu.html:310
 #: opac/webapp/templates/collection/includes/levelMenu.html:38
 #: opac/webapp/templates/collection/includes/list_journals_section_title.html:14
@@ -1601,11 +1305,6 @@ msgstr ""
 msgid "Compartilhe"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:311
-#: build/lib/opac/webapp/templates/collection/includes/list_journals_section_title.html:16
-#: build/lib/opac/webapp/templates/issue/toc.html:14
-#: build/lib/opac/webapp/templates/journal/about.html:17
-#: build/lib/opac/webapp/templates/journal/detail.html:12
 #: opac/webapp/templates/article/includes/levelMenu.html:311
 #: opac/webapp/templates/collection/includes/list_journals_section_title.html:16
 #: opac/webapp/templates/issue/toc.html:14
@@ -1614,11 +1313,6 @@ msgstr ""
 msgid "Enviar link por e-mail"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:314
-#: build/lib/opac/webapp/templates/collection/includes/list_journals_section_title.html:19
-#: build/lib/opac/webapp/templates/issue/toc.html:15
-#: build/lib/opac/webapp/templates/journal/about.html:18
-#: build/lib/opac/webapp/templates/journal/detail.html:13
 #: opac/webapp/templates/article/includes/levelMenu.html:314
 #: opac/webapp/templates/collection/includes/list_journals_section_title.html:19
 #: opac/webapp/templates/issue/toc.html:15
@@ -1627,11 +1321,6 @@ msgstr ""
 msgid "Compartilhar no Facebook"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:317
-#: build/lib/opac/webapp/templates/collection/includes/list_journals_section_title.html:22
-#: build/lib/opac/webapp/templates/issue/toc.html:16
-#: build/lib/opac/webapp/templates/journal/about.html:19
-#: build/lib/opac/webapp/templates/journal/detail.html:14
 #: opac/webapp/templates/article/includes/levelMenu.html:317
 #: opac/webapp/templates/collection/includes/list_journals_section_title.html:22
 #: opac/webapp/templates/issue/toc.html:16
@@ -1640,18 +1329,6 @@ msgstr ""
 msgid "Compartilhar no Twitter"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:320
-#: build/lib/opac/webapp/templates/article/includes/levelMenu.html:325
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu.html:46
-#: build/lib/opac/webapp/templates/collection/includes/list_journals_section_title.html:25
-#: build/lib/opac/webapp/templates/collection/includes/list_journals_section_title.html:30
-#: build/lib/opac/webapp/templates/issue/grid.html:20
-#: build/lib/opac/webapp/templates/issue/toc.html:17
-#: build/lib/opac/webapp/templates/issue/toc.html:19
-#: build/lib/opac/webapp/templates/journal/about.html:20
-#: build/lib/opac/webapp/templates/journal/about.html:22
-#: build/lib/opac/webapp/templates/journal/detail.html:15
-#: build/lib/opac/webapp/templates/journal/detail.html:17
 #: opac/webapp/templates/article/includes/levelMenu.html:320
 #: opac/webapp/templates/article/includes/levelMenu.html:325
 #: opac/webapp/templates/collection/includes/levelMenu.html:46
@@ -1667,24 +1344,16 @@ msgstr ""
 msgid "Outras redes sociais"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/article/includes/recent_articles_row.html:6
-#: build/lib/opac/webapp/templates/issue/toc.html:149
 #: opac/webapp/templates/article/includes/recent_articles_row.html:6
 #: opac/webapp/templates/issue/toc.html:149
 msgid "Documento sem título"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/article/includes/recent_articles_row.html:13
-#: build/lib/opac/webapp/templates/news/includes/journal_news_row.html:14
 #: opac/webapp/templates/article/includes/recent_articles_row.html:13
 #: opac/webapp/templates/news/includes/journal_news_row.html:14
 msgid "Continue lendo"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/article/includes/modal/download.html:6
-#: build/lib/opac/webapp/templates/article/includes/modal/related_article.html:7
-#: build/lib/opac/webapp/templates/email/email_form.html:7
-#: build/lib/opac/webapp/templates/includes/metric_modal.html:6
 #: opac/webapp/templates/article/includes/modal/download.html:6
 #: opac/webapp/templates/article/includes/modal/related_article.html:7
 #: opac/webapp/templates/email/email_form.html:7
@@ -1692,791 +1361,625 @@ msgstr ""
 msgid "Fechar"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/article/includes/modal/download.html:8
 #: opac/webapp/templates/article/includes/modal/download.html:8
 msgid "Versão para download de PDF"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/article/includes/modal/translate_version.html:6
 #: opac/webapp/templates/article/includes/modal/translate_version.html:6
 msgid "Versões e tradução automática"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/article/includes/modal/translate_version.html:11
 #: opac/webapp/templates/article/includes/modal/translate_version.html:11
 msgid "Versão original do texto"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/about.html:23
-#: build/lib/opac/webapp/templates/collection/pages.html:21
 #: opac/webapp/templates/collection/about.html:23
-#: opac/webapp/templates/collection/pages.html:21
 #, python-format
 msgid " %(page)s "
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/about.html:38
-#: build/lib/opac/webapp/templates/collection/pages.html:36
 #: opac/webapp/templates/collection/about.html:38
-#: opac/webapp/templates/collection/pages.html:36
 msgid " Conteúdo não cadastrado "
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/index.html:17
 #: opac/webapp/templates/collection/index.html:17
 msgid "em números | Métricas"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/index.html:27
 #: opac/webapp/templates/collection/index.html:27
 msgid "períodicos"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:31
-#: build/lib/opac/webapp/templates/collection/index.html:31
-#: build/lib/opac/webapp/templates/collection/list_feed_content.html:7
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:31
 #: opac/webapp/templates/collection/index.html:31
 #: opac/webapp/templates/collection/list_feed_content.html:7
 msgid "números"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/index.html:35
-#: build/lib/opac/webapp/templates/issue/grid.html:68
 #: opac/webapp/templates/collection/index.html:35
 #: opac/webapp/templates/issue/grid.html:68
 msgid "artigos"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/index.html:39
 #: opac/webapp/templates/collection/index.html:39
 msgid "referências"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/index.html:45
 #: opac/webapp/templates/collection/index.html:45
 msgid "Downloads"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/index.html:48
 #: opac/webapp/templates/collection/index.html:48
 msgid "Citações"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/index.html:51
 #: opac/webapp/templates/collection/index.html:51
 msgid "Outros indicadores"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/index.html:62
-#: build/lib/opac/webapp/templates/collection/list_journal.html:3
 #: opac/webapp/templates/collection/index.html:62
 #: opac/webapp/templates/collection/list_journal.html:3
 msgid "Lista de periódicos"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/index.html:66
-#: build/lib/opac/webapp/templates/collection/list_journal.html:21
 #: opac/webapp/templates/collection/index.html:66
 #: opac/webapp/templates/collection/list_journal.html:21
 msgid "Alfabética"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/index.html:69
-#: build/lib/opac/webapp/templates/collection/list_journal.html:24
 #: opac/webapp/templates/collection/index.html:69
 #: opac/webapp/templates/collection/list_journal.html:24
 msgid "Temática"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/index.html:77
 #: opac/webapp/templates/collection/index.html:77
 msgid "Busca por periódicos"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/index.html:105
 #: opac/webapp/templates/collection/index.html:105
 msgid "Números <span>mais recentes</span>"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/index.html:149
 #: opac/webapp/templates/collection/index.html:149
 msgid "em perspectiva"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/list_feed_content.html:1
 #: opac/webapp/templates/collection/list_feed_content.html:1
 msgid "Último número"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/list_feed_content.html:4
 #: opac/webapp/templates/collection/list_feed_content.html:4
 msgid "Nº"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/list_feed_content.html:6
 #: opac/webapp/templates/collection/list_feed_content.html:6
 msgid "descontinuado"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/list_feed_content.html:7
 #: opac/webapp/templates/collection/list_feed_content.html:7
 msgid "de"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu.html:11
-#: build/lib/opac/webapp/templates/collection/list_journal.html:16
 #: opac/webapp/templates/collection/includes/levelMenu.html:11
 #: opac/webapp/templates/collection/list_journal.html:16
 msgid "Home"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_grouper_table_container.html:14
-#: build/lib/opac/webapp/templates/collection/list_journal.html:52
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_grouper_table_container.html:14
 #: opac/webapp/templates/collection/list_journal.html:52
 msgid "download da lista"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_grouper_table_container.html:15
-#: build/lib/opac/webapp/templates/collection/list_journal.html:53
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_grouper_table_container.html:15
 #: opac/webapp/templates/collection/list_journal.html:53
 msgid "Lista em arquivo para Excel"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_grouper_table_container.html:18
-#: build/lib/opac/webapp/templates/collection/list_journal.html:56
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_grouper_table_container.html:18
 #: opac/webapp/templates/collection/list_journal.html:56
 msgid "Lista em arquivo CSV"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/list_journal.html:80
-#: build/lib/opac/webapp/templates/collection/list_journal.html:84
 #: opac/webapp/templates/collection/list_journal.html:80
 #: opac/webapp/templates/collection/list_journal.html:84
 msgid "Grandes áreas do conhecimento"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/list_journal.html:85
 #: opac/webapp/templates/collection/list_journal.html:85
 msgid "Áreas temáticas do Web of Science"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/list_journal.html:222
 #: opac/webapp/templates/collection/list_journal.html:222
 msgid "grandes áreas"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/list_journal.html:236
 #: opac/webapp/templates/collection/list_journal.html:236
 msgid "áreas WOS"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/list_journal.html:248
 #: opac/webapp/templates/collection/list_journal.html:248
 msgid "Editoras"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/list_journal.html:249
 #: opac/webapp/templates/collection/list_journal.html:249
 msgid "editoras"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:7
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:7
 msgid "Sobre o"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:19
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:62
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:19
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:62
 msgid "Entre uma ou mais palavras"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:24
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:67
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:24
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:67
 msgid "Todos os índices"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:26
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:69
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:26
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:69
 msgid "Autor"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:38
-#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:95
-#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:91
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:38
 #: opac/webapp/templates/issue/includes/alternative_header.html:95
 #: opac/webapp/templates/journal/includes/alternative_header.html:91
 msgid "Buscar"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:44
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:44
 msgid "Adicionar outro campo"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:49
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:49
 msgid "Apagar campo"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:63
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:63
 msgid "Limpar expressão"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:92
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:92
 msgid "Sem resultados"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/includes/levelMenu_search.html:96
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:96
 msgid "Não foram encontrados documentos para sua pesquisa"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/includes/list_journals_search_input.html:5
 #: opac/webapp/templates/collection/includes/list_journals_search_input.html:5
 msgid "Todos"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/includes/list_journals_search_input.html:9
 #: opac/webapp/templates/collection/includes/list_journals_search_input.html:9
 msgid "Periódicos ativos"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/includes/list_journals_search_input.html:13
 #: opac/webapp/templates/collection/includes/list_journals_search_input.html:13
 msgid "Periódicos descontinuados"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/includes/list_journals_search_input.html:24
 #: opac/webapp/templates/collection/includes/list_journals_search_input.html:24
 msgid "Digite uma ou mais palavras para filtrar a lista"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/includes/nav.html:22
-#: build/lib/opac/webapp/templates/collection/includes/nav.html:64
 #: opac/webapp/templates/collection/includes/nav.html:22
 #: opac/webapp/templates/collection/includes/nav.html:64
 msgid "Busca"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/includes/nav.html:32
 #: opac/webapp/templates/collection/includes/nav.html:32
 msgid "Sobre:"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/includes/nav.html:44
 #: opac/webapp/templates/collection/includes/nav.html:44
 msgid "SciELO.org - Rede SciELO"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/includes/nav.html:95
 #: opac/webapp/templates/collection/includes/nav.html:95
 msgid "Blog SciELO em Perspectiva"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_empty.html:3
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_empty.html:3
 msgid "Nenhum periódico encontrado."
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_error.html:3
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_error.html:3
 msgid "Ocorreu um erro obtendo a lista de periódicos."
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_grouper_table_container.html:10
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_grouper_table_container.html:10
 msgid "periódicos"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:3
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:3
 msgid "Homepage"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:25
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:25
 msgid "Título do periódico"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:29
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:29
 msgid "Grade de número"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:36
-#: build/lib/opac/webapp/templates/journal/detail.html:89
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:36
 #: opac/webapp/templates/journal/detail.html:89
 msgid "Número mais recente"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:37
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:37
 msgid "Último"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:45
 #: opac/webapp/templates/collection/includes/tmpl_journal_list_row.html:45
 msgid "Continua como "
 msgstr ""
 
-#: build/lib/opac/webapp/templates/email/email_form.html:10
 #: opac/webapp/templates/email/email_form.html:10
 msgid "Enviar página por e-mail"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/email/email_form.html:18
-#: build/lib/opac/webapp/templates/includes/error_form.html:26
-#: build/lib/opac/webapp/templates/journal/includes/contact_form.html:20
 #: opac/webapp/templates/email/email_form.html:18
 #: opac/webapp/templates/includes/error_form.html:26
 #: opac/webapp/templates/journal/includes/contact_form.html:20
 msgid "Seu e-mail"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/email/email_form.html:23
 #: opac/webapp/templates/email/email_form.html:23
 msgid "Para"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/email/email_form.html:27
 #: opac/webapp/templates/email/email_form.html:27
 msgid "Utilize ; (ponto e vírgula) para inserir mais emails."
 msgstr ""
 
-#: build/lib/opac/webapp/templates/email/email_form.html:36
 #: opac/webapp/templates/email/email_form.html:36
 msgid "Alterar assunto e comentários"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/email/email_form.html:41
 #: opac/webapp/templates/email/email_form.html:41
 msgid "Assunto"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/email/email_form.html:45
 #: opac/webapp/templates/email/email_form.html:45
 msgid "Comentário"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/email/email_form.html:49
 #: opac/webapp/templates/email/email_form.html:49
 msgid "Remover remetente, assunto e comentários"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/email/email_form.html:75
 #: opac/webapp/templates/email/email_form.html:75
 msgid "Email enviado com sucesso."
 msgstr ""
 
-#: build/lib/opac/webapp/templates/email/email_form.html:76
-#: build/lib/opac/webapp/templates/includes/error_form.html:86
-#: build/lib/opac/webapp/templates/journal/includes/contact_form.html:77
 #: opac/webapp/templates/email/email_form.html:76
 #: opac/webapp/templates/includes/error_form.html:86
 #: opac/webapp/templates/journal/includes/contact_form.html:77
 msgid "Erro ao tentar enviar e-mail, por favor tente mais tarde."
 msgstr ""
 
-#: build/lib/opac/webapp/templates/errors/400.html:7
 #: opac/webapp/templates/errors/400.html:7
 msgid "Ação inválida"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/errors/403.html:7
 #: opac/webapp/templates/errors/403.html:7
 msgid "Acesso não autorizado!"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/errors/404.html:7
 #: opac/webapp/templates/errors/404.html:7
 msgid ""
 "A URL solicitada não foi encontrada no servidor. Se você digitou a URL "
 "manualmente, por favor verifique e tente novamente."
 msgstr ""
 
-#: build/lib/opac/webapp/templates/errors/500.html:5
 #: opac/webapp/templates/errors/500.html:5
 msgid ""
 "Erro interno do servidor. Tente novamente mais tarde. Nossos engenheiros "
 "foram notificados."
 msgstr ""
 
-#: build/lib/opac/webapp/templates/errors/500.html:9
 #: opac/webapp/templates/errors/500.html:9
 msgid "Id. do erro"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/errors/base.html:24
 #: opac/webapp/templates/errors/base.html:24
 msgid "Erro"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/errors/base.html:27
 #: opac/webapp/templates/errors/base.html:27
 msgid "Qualquer dúvida, por favor entre em contato com o administrador"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/includes/error_form.html:5
 #: opac/webapp/templates/includes/error_form.html:5
 msgid " Reportar erro "
 msgstr ""
 
-#: build/lib/opac/webapp/templates/includes/error_form.html:20
-#: build/lib/opac/webapp/templates/journal/includes/contact_form.html:14
 #: opac/webapp/templates/includes/error_form.html:20
 #: opac/webapp/templates/journal/includes/contact_form.html:14
 msgid "Seu Nome"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/includes/error_form.html:21
 #: opac/webapp/templates/includes/error_form.html:21
 msgid "Digite seu Nome"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/includes/error_form.html:32
 #: opac/webapp/templates/includes/error_form.html:32
 msgid "Erro referente"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/includes/error_form.html:35
 #: opac/webapp/templates/includes/error_form.html:35
 msgid "ao conteúdo"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/includes/error_form.html:39
 #: opac/webapp/templates/includes/error_form.html:39
 msgid "à aplicação"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/includes/error_form.html:46
 #: opac/webapp/templates/includes/error_form.html:46
 msgid "Descrição do erro"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/includes/error_form.html:47
 #: opac/webapp/templates/includes/error_form.html:47
 msgid "Digite sua mensagem"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/includes/error_form.html:49
 #: opac/webapp/templates/includes/error_form.html:49
 msgid "Obs.: Link e título da página são enviados automaticamente"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/includes/error_form.html:85
 #: opac/webapp/templates/includes/error_form.html:85
 msgid "Email de erro enviado com sucesso."
 msgstr ""
 
-#: build/lib/opac/webapp/templates/includes/footer.html:36
 #: opac/webapp/templates/includes/footer.html:36
 msgid "Open Access"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/includes/footer.html:38
 #: opac/webapp/templates/includes/footer.html:38
 msgid "Leia"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/includes/footer.html:38
 #: opac/webapp/templates/includes/footer.html:38
 msgid "a Declaração de Acesso Aberto"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/issue/grid.html:4
 #: opac/webapp/templates/issue/grid.html:4
 msgid "Fascículos"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/issue/grid.html:33
 #: opac/webapp/templates/issue/grid.html:33
 msgid "Todos os números"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/issue/grid.html:79
 #: opac/webapp/templates/issue/grid.html:79
 msgid "supl."
 msgstr ""
 
-#: build/lib/opac/webapp/templates/issue/grid.html:98
 #: opac/webapp/templates/issue/grid.html:98
 msgid "Nenhum número encontrado para esse periódico"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/issue/grid.html:101
 #: opac/webapp/templates/issue/grid.html:101
 msgid "Histórico deste periódico na coleção"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/issue/grid.html:105
 #: opac/webapp/templates/issue/grid.html:105
 msgid " admitido na coleção da SciELO"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/issue/toc.html:10
-#: build/lib/opac/webapp/templates/journal/detail.html:8
 #: opac/webapp/templates/issue/toc.html:10
 #: opac/webapp/templates/journal/detail.html:8
 msgid "Imprimir"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/issue/toc.html:41
 #: opac/webapp/templates/issue/toc.html:41
 msgid "Editor científico"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/issue/toc.html:45
 #: opac/webapp/templates/issue/toc.html:45
 msgid "Editores associados"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/issue/toc.html:52
 #: opac/webapp/templates/issue/toc.html:52
 msgid "Veja toda a equipe editorial"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/issue/toc.html:63
 #: opac/webapp/templates/issue/toc.html:63
 msgid "Expandir/recolher conteúdo"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/issue/toc.html:72
-#: build/lib/opac/webapp/templates/journal/detail.html:96
 #: opac/webapp/templates/issue/toc.html:72
 #: opac/webapp/templates/journal/detail.html:96
 msgid "Sumário"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/issue/toc.html:79
 #: opac/webapp/templates/issue/toc.html:79
 msgid "Ordenar publicações por"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/issue/toc.html:82
 #: opac/webapp/templates/issue/toc.html:82
 msgid "Ordem do fascículo"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/issue/toc.html:83
 #: opac/webapp/templates/issue/toc.html:83
 msgid "Mais novos primeiro"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/issue/toc.html:84
 #: opac/webapp/templates/issue/toc.html:84
 msgid "Mais antigos primeiro"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/issue/toc.html:102
-#: build/lib/opac/webapp/templates/issue/toc.html:104
 #: opac/webapp/templates/issue/toc.html:102
 #: opac/webapp/templates/issue/toc.html:104
 msgid "Todas as seções"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/issue/toc.html:187
-#: opac/webapp/templates/issue/toc.html:187
+#: opac/webapp/templates/issue/toc.html:182
 msgid "Texto"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/issue/toc.html:214
-#: opac/webapp/templates/issue/toc.html:214
+#: opac/webapp/templates/issue/toc.html:195
+msgid "PDF"
+msgstr ""
+
+#: opac/webapp/templates/issue/toc.html:210
+msgid "ePDF"
+msgstr ""
+
+#: opac/webapp/templates/issue/toc.html:232
 msgid "Resumo em"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:31
-#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:31
 #: opac/webapp/templates/issue/includes/alternative_header.html:31
 #: opac/webapp/templates/journal/includes/alternative_header.html:31
 msgid "Número atual"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:51
-#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:47
 #: opac/webapp/templates/issue/includes/alternative_header.html:51
 #: opac/webapp/templates/journal/includes/alternative_header.html:47
 msgid "Homepage do periódico"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:62
-#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:58
 #: opac/webapp/templates/issue/includes/alternative_header.html:62
 #: opac/webapp/templates/journal/includes/alternative_header.html:58
 msgid "Números"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:68
-#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:64
-#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:90
 #: opac/webapp/templates/issue/includes/alternative_header.html:68
 #: opac/webapp/templates/journal/includes/alternative_header.html:64
 #: opac/webapp/templates/journal/includes/levelMenu.html:90
 msgid "todos"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/issue/includes/alternative_header.html:89
-#: build/lib/opac/webapp/templates/journal/includes/alternative_header.html:85
 #: opac/webapp/templates/issue/includes/alternative_header.html:89
 #: opac/webapp/templates/journal/includes/alternative_header.html:85
 msgid "próximo"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/journal/about.html:39
 #: opac/webapp/templates/journal/about.html:39
 msgid "Conteúdo não cadastrado"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/journal/about.html:55
-#: build/lib/opac/webapp/templates/journal/includes/contact_footer.html:48
 #: opac/webapp/templates/journal/about.html:55
 #: opac/webapp/templates/journal/includes/contact_footer.html:48
 msgid "Siga este periódico nas redes sociais"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/journal/detail.html:32
+#: opac/webapp/templates/journal/detail.html:9
+#: opac/webapp/templates/journal/includes/contact_footer.html:53
+msgid "RSS do número mais recente do periódico"
+msgstr ""
+
 #: opac/webapp/templates/journal/detail.html:32
 msgid "Nossa Missão"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/journal/detail.html:34
 #: opac/webapp/templates/journal/detail.html:34
 msgid "Periódico sem missão cadastrada"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/journal/detail.html:42
 #: opac/webapp/templates/journal/detail.html:42
 msgid "Métricas deste periódico"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/journal/detail.html:52
 #: opac/webapp/templates/journal/detail.html:52
 msgid "Índice h5"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/journal/detail.html:54
-#: build/lib/opac/webapp/templates/journal/detail.html:66
 #: opac/webapp/templates/journal/detail.html:54
 #: opac/webapp/templates/journal/detail.html:66
 msgid "ano"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/journal/detail.html:58
-#: build/lib/opac/webapp/templates/journal/detail.html:70
 #: opac/webapp/templates/journal/detail.html:58
 #: opac/webapp/templates/journal/detail.html:70
 msgid "Não possui"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/journal/detail.html:63
 #: opac/webapp/templates/journal/detail.html:63
 msgid "Mediana h5"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/journal/detail.html:86
 #: opac/webapp/templates/journal/detail.html:86
 msgid "Capa do número mais recente"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/journal/detail.html:138
-#: opac/webapp/templates/journal/detail.html:138
+#: opac/webapp/templates/journal/detail.html:117
+#: opac/webapp/templates/journal/detail.html:119
+msgid "RSS dos Press Releases mais recentes desse periódico"
+msgstr ""
+
+#: opac/webapp/templates/journal/detail.html:145
 msgid "Artigos mais recentes"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/journal/includes/contact_footer.html:57
 #: opac/webapp/templates/journal/includes/contact_footer.html:57
 msgid "Acompanhe os números deste periódico no seu leitor de RSS"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/journal/includes/contact_form.html:26
 #: opac/webapp/templates/journal/includes/contact_form.html:26
 msgid "Mensagem"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/journal/includes/contact_form.html:76
 #: opac/webapp/templates/journal/includes/contact_form.html:76
 msgid "Email enviado para "
 msgstr ""
 
-#: build/lib/opac/webapp/templates/journal/includes/contact_form.html:76
 #: opac/webapp/templates/journal/includes/contact_form.html:76
 msgid "com sucesso."
 msgstr ""
 
-#: build/lib/opac/webapp/templates/journal/includes/header.html:42
 #: opac/webapp/templates/journal/includes/header.html:42
 msgid "Publicação de:"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/journal/includes/header.html:47
 #: opac/webapp/templates/journal/includes/header.html:47
 msgid "Área:"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/journal/includes/header.html:51
 #: opac/webapp/templates/journal/includes/header.html:51
 msgid "Multidisciplinar"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/journal/includes/header.html:60
 #: opac/webapp/templates/journal/includes/header.html:60
 msgid "Versão impressa ISSN:"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/journal/includes/header.html:67
 #: opac/webapp/templates/journal/includes/header.html:67
 msgid "Versão on-line ISSN:"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/journal/includes/header.html:76
 #: opac/webapp/templates/journal/includes/header.html:76
 msgid "Novo título:"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/journal/includes/header.html:93
 #: opac/webapp/templates/journal/includes/header.html:93
 msgid "Título anterior:"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/journal/includes/header.html:148
 #: opac/webapp/templates/journal/includes/header.html:148
 msgid "Siga-nos"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:10
 #: opac/webapp/templates/journal/includes/levelMenu.html:10
 msgid "home do periódico"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:19
 #: opac/webapp/templates/journal/includes/levelMenu.html:19
 msgid "todos os números"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:25
-#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:29
 #: opac/webapp/templates/journal/includes/levelMenu.html:25
 #: opac/webapp/templates/journal/includes/levelMenu.html:29
 msgid "número anterior"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:36
-#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:40
-#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:107
-#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:111
 #: opac/webapp/templates/journal/includes/levelMenu.html:36
 #: opac/webapp/templates/journal/includes/levelMenu.html:40
 #: opac/webapp/templates/journal/includes/levelMenu.html:107
@@ -2484,24 +1987,16 @@ msgstr ""
 msgid "número atual"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:47
-#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:51
 #: opac/webapp/templates/journal/includes/levelMenu.html:47
 #: opac/webapp/templates/journal/includes/levelMenu.html:51
 msgid "número seguinte"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:59
-#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:130
 #: opac/webapp/templates/journal/includes/levelMenu.html:59
 #: opac/webapp/templates/journal/includes/levelMenu.html:130
 msgid "buscar"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:65
-#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:69
-#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:136
-#: build/lib/opac/webapp/templates/journal/includes/levelMenu.html:140
 #: opac/webapp/templates/journal/includes/levelMenu.html:65
 #: opac/webapp/templates/journal/includes/levelMenu.html:69
 #: opac/webapp/templates/journal/includes/levelMenu.html:136
@@ -2509,27 +2004,22 @@ msgstr ""
 msgid "métricas"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/macros/issue.html:5
 #: opac/webapp/templates/macros/issue.html:5
 msgid " número especial "
 msgstr ""
 
-#: build/lib/opac/webapp/templates/macros/issue.html:10
 #: opac/webapp/templates/macros/issue.html:10
 msgid "número especial"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/news/includes/collection_news_row.html:16
 #: opac/webapp/templates/news/includes/collection_news_row.html:16
 msgid "continue lendo"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/news/includes/issue_last_row.html:15
 #: opac/webapp/templates/news/includes/issue_last_row.html:15
 msgid "Suplemento"
 msgstr ""
 
-#: build/lib/opac/webapp/templates/news/includes/issue_last_row.html:20
 #: opac/webapp/templates/news/includes/issue_last_row.html:20
 msgid "Ver"
 msgstr ""


### PR DESCRIPTION
#### O que esse PR faz?
Corrige os tooltips com uma legenda mais clara e fácil de entender

#### Onde a revisão poderia começar?
Acesse a home do periódico e posicione o mouse sobre os ícones de RSS existentes na tela.
Verifique que a mensagem está de acordo como solicitado pelo @alexxxmendonca 

#### Como este poderia ser testado manualmente?
Siga o passo anterior.

#### Algum cenário de contexto que queira dar?
Nem todos os periódicos contém pres-release.
O que usei para teste foi o /journal/icse/

### Screenshots
![Screen Shot 2019-05-31 at 6 32 05 PM](https://user-images.githubusercontent.com/22373640/58735911-70c76f80-83d2-11e9-8a76-aaf92f6a67cf.png)
![Screen Shot 2019-05-31 at 6 31 57 PM](https://user-images.githubusercontent.com/22373640/58735912-70c76f80-83d2-11e9-8381-80e36a22e748.png)
![Screen Shot 2019-05-31 at 6 31 48 PM](https://user-images.githubusercontent.com/22373640/58735914-70c76f80-83d2-11e9-9c3a-22e9982b9832.png)


#### Quais são tickets relevantes?
#1319 

### Referências
Utilizei o histórico de uma conversa minha com o @jamilatta e com a @patymori onde eles me explicaram como proceder para alterar os arquivos de tradução.

