### PR TITLE
Altera o quadro de métricas para exibir números presentes no site

### DIFF
--- a/opac/tests/test_controller.py
+++ b/opac/tests/test_controller.py
@@ -1289,6 +1289,62 @@ class FunctionsInControllerTestCase(BaseTestCase):
         controller_col = controllers.get_current_collection()
         self.assertEqual(collection, controller_col)
 
+    def test_get_current_collection_get_public_and_current_journals_numbers(self):
+        collection = utils.makeOneCollection({
+            "metrics" : {
+                "total_journal" : 10,
+                "total_issue" : 2000,
+                "total_article" : 30000,
+                "total_citation" : 400000
+            },
+        })
+        utils.makeAnyJournal(
+            items=20, attrib={'is_public': True, 'current_status': 'current'}
+        )
+        utils.makeOneJournal({'is_public': False, 'current_status': 'current'})
+        utils.makeOneJournal({'is_public': False, 'current_status': 'current'})
+        utils.makeOneJournal({'is_public': False, 'current_status': 'current'})
+        utils.makeOneJournal({'current_status': 'deceased'})
+        utils.makeOneJournal({'current_status': 'deceased'})
+        utils.makeOneJournal({'current_status': 'deceased'})
+        utils.makeOneJournal({'current_status': 'suspended'})
+        controller_col = controllers.get_current_collection()
+        self.assertEqual(controller_col.metrics.total_journal, 20)
+
+    def test_get_current_collection_get_public_issues_numbers(self):
+        collection = utils.makeOneCollection({
+            "metrics" : {
+                "total_journal" : 10,
+                "total_issue" : 2000,
+                "total_article" : 30000,
+                "total_citation" : 400000
+            },
+        })
+        utils.makeAnyIssue(items=50, attrib={'is_public': True})
+        utils.makeOneIssue({'is_public': False})
+        utils.makeOneIssue({'is_public': False})
+        utils.makeOneIssue({'is_public': False})
+        utils.makeOneIssue({'is_public': False})
+        controller_col = controllers.get_current_collection()
+        self.assertEqual(controller_col.metrics.total_issue, 50)
+
+    def test_get_current_collection_get_public_articles_numbers(self):
+        collection = utils.makeOneCollection({
+            "metrics" : {
+                "total_journal" : 10,
+                "total_issue" : 2000,
+                "total_article" : 30000,
+                "total_citation" : 400000
+            },
+        })
+        utils.makeAnyArticle(items=101, attrib={'is_public': True})
+        utils.makeOneArticle({'is_public': False})
+        utils.makeOneArticle({'is_public': False})
+        utils.makeOneArticle({'is_public': False})
+        utils.makeOneArticle({'is_public': False})
+        controller_col = controllers.get_current_collection()
+        self.assertEqual(controller_col.metrics.total_article, 101)
+
     def test_count_elements_by_type_and_visibility_type_journal(self):
         """
         Testando a função count_elements_by_type_and_visibility() com 20

--- a/opac/webapp/controllers.py
+++ b/opac/webapp/controllers.py
@@ -53,10 +53,22 @@ HIGHLIGHTED_TYPES = (
 def get_current_collection():
     """
     Retorna o objeto coleção filtrando pela coleção cadastrada no arquivo de
-    configuração ``OPAC_COLLECTION``.
+    configuração ``OPAC_COLLECTION`` e atualiza com os dados da coleção já no site.
+    Isso se mantém ainda para coletar as citações que não são possíveis extrair dos
+    dados já presentes no site.
     """
     current_collection_acronym = current_app.config['OPAC_COLLECTION']
     collection = Collection.objects.get(acronym=current_collection_acronym)
+    number_of_journals = Journal.objects.filter(
+        is_public=True, current_status="current").count()
+    if number_of_journals > 0:
+        collection.metrics.total_journal = number_of_journals
+    number_of_issues = Issue.objects.filter(is_public=True).count()
+    if number_of_issues > 0:
+        collection.metrics.total_issue = number_of_issues
+    number_of_articles = Article.objects.filter(is_public=True).count()
+    if number_of_articles > 0:
+        collection.metrics.total_article = number_of_articles
     return collection
 
 


### PR DESCRIPTION
#### O que esse PR faz?
Altera o site para exibir os números de periódicos, fascículos e artigos reais da coleção, que estão de fato presentes na base de dados do site.

#### Onde a revisão poderia começar?
Pelos testes em `opac/tests/test_controller.py`

#### Como este poderia ser testado manualmente?
1. Acesse a página inicial do site
2. Verifique os números da coleção, que devem ser:
  * Números de periódicos publicados e com status "current"
  * Números de fascículos publicados
  * Números de artigos publicados

#### Algum cenário de contexto que queira dar?
Os números exibidos atualmente são os registrados no Publication Stats, que não refletem o real da base de dados do site e dependem do processamento dos dados para o site.

### Screenshots
N/A.

#### Quais são tickets relevantes?
#1331.

### Referências
Nenhuma.
