### PR TITLE
Resolve URLs de PDFs quebrados

### DIFF
--- a/opac/webapp/controllers.py
+++ b/opac/webapp/controllers.py
@@ -7,6 +7,7 @@
     acessem diretamente a camada inferior de modelos.
 """
 
+import re
 import unicodecsv
 import io
 import xlsxwriter
@@ -683,7 +684,6 @@ def get_issue_by_journal_and_assets_code(assets_code, journal):
 
     if not journal:
         raise ValueError(__('Obrigatório um journal.'))
-
     return Issue.objects.filter(assets_code=assets_code, journal=journal).first()
 
 
@@ -812,6 +812,39 @@ def get_recent_articles_of_issue(issue_iid, is_public=True):
         raise ValueError(__('Parámetro obrigatório: issue_iid.'))
 
     return Article.objects.filter(issue=issue_iid, is_public=is_public).order_by('-order')
+
+
+def get_article_by_pdf_filename(journal_acron, issue_info, pdf_filename):
+    """
+    Retorna dados dos pdfs de um artigo
+    """
+    def get_valid_name(pdf_filename):
+        """
+        Por conta do SSM salvar os arquivos com "clean filename", é necessário
+        fazer a busca por ele. Na prática, o nome do arquivo tem os espaços no
+        início e fim removidos; outros espaços são substituídos por underscore; e
+        qualquer caracter que não for um alphanumérico unicode, traço, underscore ou
+        ponto será removido. Ex:
+        >>> get_valid_filename("john's portrait in 2004.jpg")
+        'johns_portrait_in_2004.jpg'
+        """
+        _filename = pdf_filename.strip().replace(' ', '_')
+        return re.sub(r'(?u)[^-\w.]', '', _filename)
+
+    if not journal_acron:
+        raise ValueError(__('Obrigatório o acrônimo do periódico.'))
+    if not issue_info:
+        raise ValueError(__('Obrigatório o campo issue_info.'))
+    if not pdf_filename:
+        raise ValueError(__('Obrigatório o nome do arquivo PDF.'))
+    pdf_path = "/".join([journal_acron, issue_info, get_valid_name(pdf_filename)])
+    article = Article.objects.only("pdfs").filter(
+        pdfs__url__endswith=pdf_path, is_public=True).first()
+    if article:
+        for pdf in article.pdfs:
+            if pdf["url"].endswith(pdf_path):
+                return pdf["url"]
+
 
 # -------- NEWS --------
 

--- a/opac/webapp/main/views.py
+++ b/opac/webapp/main/views.py
@@ -925,45 +925,13 @@ def article_detail_pdf(url_seg, url_seg_issue, url_seg_article, lang_code=''):
 @main.route('/pdf/<string:journal_acron>/<string:issue_info>/<string:pdf_filename>.pdf')
 @cache.cached(key_prefix=cache_key_with_lang_with_qs)
 def router_legacy_pdf(journal_acron, issue_info, pdf_filename):
-    language = session.get('lang', get_locale())
     pdf_filename = '%s.pdf' % pdf_filename
-
-    journal = controllers.get_journal_by_acron(journal_acron)
-
-    if not journal:
-        abort(404, _('Periódico não encontrado'))
-
-    if not journal.is_public:
-        abort(404, JOURNAL_UNPUBLISH + _(journal.unpublish_reason))
-
-    # procuramos o issue filtrando pelo campo: assets_code e o journal
-    issue = controllers.get_issue_by_journal_and_assets_code(assets_code=issue_info, journal=journal)
-
-    if not issue:
-        abort(404, _('Número não encontrado'))
-
-    if not issue.is_public:
-        abort(404, ISSUE_UNPUBLISH + _(issue.unpublish_reason))
-
-    pdf_lang = language
-
-    # procuramos entre os artigos, qual tem um pdf nesse idioma com esse filename
-    article_match = None
-    for article in controllers.get_articles_by_iid(iid=issue.iid):
-        if article.pdfs:
-            for pdf in article.pdfs:
-                if pdf['url'].endswith(pdf_filename):
-                    article_match = article
-                    pdf_lang = pdf['lang']
-                    break
-
-    if article_match is None:
+    pdf_url = controllers.get_article_by_pdf_filename(journal_acron, issue_info, pdf_filename)
+    if pdf_url is None:
         abort(404, _('PDF do artigo não foi encontrado'))
     else:
-        return article_detail_pdf(
-            url_seg=journal.url_segment,
-            url_seg_issue=issue.url_segment,
-            url_seg_article=article_match.url_segment, lang_code=pdf_lang)
+        pdf_url_parsed = urlparse(pdf_url)
+        return get_content_from_ssm(pdf_url_parsed.path)
 
 # ##################################Search#######################################
 


### PR DESCRIPTION
#### O que esse PR faz?
Esse PR leva para o ambiente do http://scielosp.org, o fix realizado no master da aplicação

Demais definições no PR #1328
>#### Onde a revisão poderia começar?
>Em `opac/webapp/controllers.py` L723.
>
>#### Como este poderia ser testado manualmente?
>1. Busque um fascículo que não possui o campo `assets_code`
>2. Acesse um PDF de um artigo deste fascículo pela URL legada. Ex: /pdf/csp/v28n5/03.pdf
>3. O PDF deve ser exibido.
>4. Execute os passos anteriores com fascículos que, além do `assets_code` nulo, tenham: `suppl_text` nulo, `suppl_text` igual à string vazia, `suppl_text` com qualquer valor
>
>#### Algum cenário de contexto que queira dar?
>Este erro foi apontado em Saúde Pública mas ocorre também na coleção Brasil
>

#### Quais são tickets relevantes?
#1291

### Referências
#1328