### PR TITLE
Lista alfabética estática para os crawlers

### DIFF
--- a/opac/webapp/controllers.py
+++ b/opac/webapp/controllers.py
@@ -235,7 +235,7 @@ def get_journal_json_data(journal, language='pt'):
         'is_active': journal.current_status == 'current',
         'issues_count': journal.issue_count,
         'next_title': journal.next_title,
-        'status_reason' : str(JOURNAL_STATUS.get(journal.current_status, journal.current_status))
+        'status_reason': str(JOURNAL_STATUS.get(journal.current_status,  journal.current_status))
     }
 
     if journal.last_issue:

--- a/opac/webapp/main/views.py
+++ b/opac/webapp/main/views.py
@@ -29,6 +29,8 @@ from webapp.config.lang_names import display_original_lang_name
 from lxml import etree
 from packtools import HTMLGenerator
 
+from user_agents import parse
+
 logger = logging.getLogger(__name__)
 
 JOURNAL_UNPUBLISH = _("O periódico está indisponível por motivo de: ")
@@ -185,7 +187,23 @@ def index():
 @main.route('/journals/')
 @cache.cached(key_prefix=cache_key_with_lang)
 def collection_list():
-    return render_template("collection/list_journal.html")
+    """
+        A lista de periódico é exibida para o browser com paginação infinita, "infinite scroll", porém isso é um problema para os crawlers!.
+
+        Os crawlers enxergam os link como ruas e a paginação infinita não exibi todas as ruas, o que impedi dos crawlers seguir "caminho" e realize as indexações das páginas, no nosso caso páginas de periódicos.
+
+        Para contornar esse problema, resolvemos avaliar se estamos sendo acessados por um browser ou por um crawler, para isso avaliamos o cabeçalho da requisição verificando o parâmetro "User-Agent" e no caso dos crawlers exibimos todos os links da página.
+    """
+
+    journals_list = None
+
+    user_agent = parse(request.headers.get("User-Agent"))
+
+    if user_agent.is_bot:
+        journals_list = [controllers.get_journal_json_data(journal) for journal in controllers.get_journals()]
+
+    return render_template("collection/list_journal.html",
+                           **{'journals_list': journals_list})
 
 
 @main.route('/journals/feed/')
@@ -551,8 +569,12 @@ def journals_search_alpha_ajax():
     query_filter = request.args.get('query_filter', '', type=str)
     page = request.args.get('page', 1, type=int)
     lang = get_lang_from_session()[:2].lower()
+
     response_data = controllers.get_alpha_list_from_paginated_journals(
-        title_query=query, query_filter=query_filter, page=page, lang=lang)
+                        title_query=query,
+                        query_filter=query_filter,
+                        page=page,
+                        lang=lang)
 
     return jsonify(response_data)
 

--- a/opac/webapp/templates/collection/includes/journal_list_row.html
+++ b/opac/webapp/templates/collection/includes/journal_list_row.html
@@ -1,0 +1,61 @@
+{% for journal in journals_list %}
+  <tr>
+    <td class="actions">
+      <a data-toggle="tooltip" href="{{ journal.links.detail }}" title="{% trans %}Homepage{% endtrans %}">
+        <span class="glyphBtn home"></span>
+      </a>
+      {% if journal.is_active  %}
+        <a data-toggle="tooltip" href="{{ journal.links.submission }}" title="{% trans %}Submissão de manuscritos{% endtrans %}" target="_blank">
+          <span class="glyphBtn submission"></span>
+        </a>
+        <a data-toggle="tooltip" href="{{ journal.links.editors }}" title="{% trans %}Corpo Editorial{% endtrans %}">
+          <span class="glyphBtn editorial"></span>
+        </a>
+        <a data-toggle="tooltip" href="{{ journal.links.instructions }}" title="{% trans %}Instruções aos autores{% endtrans %}">
+          <span class="glyphBtn authorInstructions"></span>
+        </a>
+        <a data-toggle="tooltip" href="{{ journal.links.about }}" title="{% trans %}Sobre o periódico{% endtrans %}">
+          <span class="glyphBtn about"></span>
+        </a>
+        <a data-toggle="tooltip" href="{{ journal.links.contact }}" title="{% trans %}Contato{% endtrans %}">
+          <span class="glyphBtn contact"></span>
+        </a>
+      {% endif %}
+    </td>
+    <td>
+      <a title="{% trans %}Título do periódico{% endtrans %}"
+         class="collectionLink {% if not journal.is_active %} disabled {% endif %}" href="{{ journal.links.detail }}">
+        <strong class="journalTitle">{{ journal.title }}</strong>,
+      </a>
+      <a title="{% trans %}Grade de número{% endtrans %}"
+         href="{{ journal.links.issue_grid }}">
+        <strong class="journalIssues">{{ journal.issues_count }} {% trans %}números{% endtrans %}</strong>,
+      </a>
+
+      {% if journal.last_issue %}
+        <a href="/{{ journal.last_issue.url_segment }}"
+          title="{% trans %}Número mais recente{% endtrans %}">
+          {% trans %}Último{% endtrans %}:
+          <span class="last-issue-legend">{{ journal.last_issue.legend }}</span>
+        </a>
+      {% endif %}
+
+      {% if journal.is_active %}
+        ({{ journal.status_reason }})
+          {% if journal.next_title %}
+          <span class="journalPreviousTitle">{% trans %}Continua como {% endtrans %}
+               {% if journal.url_next_journal %}
+                <a href="{{ journal.url_next_journal }}" class="NewCollectionLink">
+                    {{ journal.next_title }}
+                </a>
+              {% else %}
+                <span class="NewCollectionLink">
+                  {{ journal.next_title }}
+                </span>
+              {% endif %}
+          </span>
+          {% endif %}
+      {% endif %}
+    </td>
+  </tr>
+{% endfor %}

--- a/opac/webapp/templates/collection/list_journal.html
+++ b/opac/webapp/templates/collection/list_journal.html
@@ -62,6 +62,11 @@
                     </thead>
                     <tbody id="journals_table_body">
                       {# preenchido com a lista de periódicos com js #}
+
+                      {% if journals_list %}
+                          {% include 'collection/includes/journal_list_row.html' %}
+                      {% endif %}
+
                     </tbody>
                   </table>
                 </div>
@@ -362,7 +367,9 @@
               listThemeAreas();
               break;
           default:
-              listAlpha();
+              {% if not journals_list %}
+                listAlpha();
+              {% endif %}
       }
 
       // tab ativa
@@ -386,7 +393,7 @@
                 listThemeAreas();
                 break;
             default:
-                listAlpha()
+                listAlpha();
         }
         window.location.hash = target;
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,3 +33,6 @@ rq-scheduler-dashboard==0.0.2
 lxml==4.2.4
 Werkzeug==0.14.1
 packtools==2.5.1
+PyYAML==5.1.1
+ua-parser==0.8.0
+user-agents==2.0


### PR DESCRIPTION
#### O que esse PR faz?

A lista de periódico é exibida para o browser com paginação infinita, "infinite scroll", porém isso é um problema para os crawlers!.

Os crawlers enxergam os link como ruas e a paginação infinita não exibi todas as ruas, o que impedi dos crawlers seguir "caminho" e realize as indexações das páginas, no nosso caso páginas de periódicos.

Para contornar esse problema, resolvemos avaliar se estamos sendo acessados por um browser ou por um crawler, para isso avaliamos o cabeçalho da requisição verificando o parâmetro "User-Agent" e no caso dos crawlers exibimos todos os links da página.

#### Onde a revisão poderia começar?

- opac/webapp/controllers.py
- opac/webapp/main/views.py
- opac/webapp/templates/collection/list_journal.html
- requirements.txt
- opac/webapp/templates/collection/includes/journal_list_row.html

#### Como este poderia ser testado manualmente?

Adicionando um extensão no Chrome ou no Firefox que possibilite o uso de um cabeçalho: User-agent: googlebot, ou outro bot! 

No caso do chrome: 

<img width="688" alt="Screenshot 2019-06-27 16 12 29" src="https://user-images.githubusercontent.com/373745/60293808-637ca280-98f6-11e9-9ec5-baf571e3f5af.png">


#### Algum cenário de contexto que queira dar?

IMPORTANTE: esse ticket depende de definição estratégica que está sendo avaliada delo @gustavofonseca, portanto ficará marcado com bloquedo para que não seja incorporado no master! 

### Screenshots

Utilizando o User-agent do Google: 

![Screenshot 2019-06-27 16 16 49](https://user-images.githubusercontent.com/373745/60294179-2b299400-98f7-11e9-9dd2-6b668e2b10d7.png)


#### Quais são tickets relevantes?

https://github.com/scieloorg/opac/issues/1323

### Referências

https://brasil.uxdesign.cc/quando-usar-pagina%C3%A7%C3%A3o-e-quando-usar-scroll-infinito-8fbc18f32de4
https://www.seroundtable.com/google-index-rank-content-in-accordions-tabs-fully-26379.html
https://varn.co.uk/07/24/can-google-crawl-content-accordions-seo/
https://perishablepress.com/list-all-user-agents-top-search-engines/
https://www.keycdn.com/blog/web-crawlers
https://support.google.com/webmasters/answer/1061943?hl=pt-BR
https://hacks.mozilla.org/2013/09/user-agent-detection-history-and-checklist/
https://github.com/selwin/python-user-agents

