### PR TITLE
Corrige url_segment de fascículo nas rotas do Issue Toc, Feed Toc, artigo e PDF

### DIFF
--- a/opac/webapp/main/views.py
+++ b/opac/webapp/main/views.py
@@ -694,7 +694,7 @@ def issue_grid(url_seg):
     return render_template("issue/grid.html", **context)
 
 
-@main.route('/toc/<string:url_seg>/<regex("\d{4}\.(\w+[-\.]?\w+[-\.]?)"):url_seg_issue>/')
+@main.route('/toc/<string:url_seg>/<string:url_seg_issue>/')
 @cache.cached(key_prefix=cache_key_with_lang_with_qs)
 def issue_toc(url_seg, url_seg_issue):
     # idioma da sessão
@@ -764,7 +764,7 @@ def issue_toc(url_seg, url_seg_issue):
     return render_template("issue/toc.html", **context)
 
 
-@main.route('/feed/<string:url_seg>/<regex("\d{4}\.(\w+[-\.]?\w+[-\.]?)"):url_seg_issue>/')
+@main.route('/feed/<string:url_seg>/<string:url_seg_issue>/')
 @cache.cached(key_prefix=cache_key_with_lang)
 def issue_feed(url_seg, url_seg_issue):
     issue = controllers.get_issue_by_url_seg(url_seg, url_seg_issue)
@@ -884,10 +884,10 @@ def normalize_ssm_url(url):
         return current_app.config["SSM_BASE_URI"] + url
 
 
-@main.route('/article/<string:url_seg>/<regex("\d{4}\.(\w+[-\.]?\w+[-\.]?)"):url_seg_issue>/<string:url_seg_article>/')
-@main.route('/article/<string:url_seg>/<regex("\d{4}\.(\w+[-\.]?\w+[-\.]?)"):url_seg_issue>/<string:url_seg_article>/<regex("(?:\w{2})"):lang_code>/')
-@main.route('/article/<string:url_seg>/<regex("\d{4}\.(\w+[-\.]?\w+[-\.]?)"):url_seg_issue>/<regex("(.*)"):url_seg_article>/')
-@main.route('/article/<string:url_seg>/<regex("\d{4}\.(\w+[-\.]?\w+[-\.]?)"):url_seg_issue>/<regex("(.*)"):url_seg_article>/<regex("(?:\w{2})"):lang_code>/')
+@main.route('/article/<string:url_seg>/<string:url_seg_issue>/<string:url_seg_article>/')
+@main.route('/article/<string:url_seg>/<string:url_seg_issue>/<string:url_seg_article>/<regex("(?:\w{2})"):lang_code>/')
+@main.route('/article/<string:url_seg>/<string:url_seg_issue>/<regex("(.*)"):url_seg_article>/')
+@main.route('/article/<string:url_seg>/<string:url_seg_issue>/<regex("(.*)"):url_seg_article>/<regex("(?:\w{2})"):lang_code>/')
 @cache.cached(key_prefix=cache_key_with_lang)
 def article_detail(url_seg, url_seg_issue, url_seg_article, lang_code=''):
     article_url = url_for('main.article_detail',
@@ -1043,10 +1043,10 @@ def article_ssm_content_raw():
         return get_content_from_ssm(resource_ssm_path)
 
 
-@main.route('/pdf/<string:url_seg>/<regex("\d{4}\.(\w+[-\.]?\w+[-\.]?)"):url_seg_issue>/<string:url_seg_article>')
-@main.route('/pdf/<string:url_seg>/<regex("\d{4}\.(\w+[-\.]?\w+[-\.]?)"):url_seg_issue>/<string:url_seg_article>/<regex("(?:\w{2})"):lang_code>')
-@main.route('/pdf/<string:url_seg>/<regex("\d{4}\.(\w+[-\.]?\w+[-\.]?)"):url_seg_issue>/<regex("(.*)"):url_seg_article>')
-@main.route('/pdf/<string:url_seg>/<regex("\d{4}\.(\w+[-\.]?\w+[-\.]?)"):url_seg_issue>/<regex("(.*)"):url_seg_article>/<regex("(?:\w{2})"):lang_code>')
+@main.route('/pdf/<string:url_seg>/<string:url_seg_issue>/<string:url_seg_article>')
+@main.route('/pdf/<string:url_seg>/<string:url_seg_issue>/<string:url_seg_article>/<regex("(?:\w{2})"):lang_code>')
+@main.route('/pdf/<string:url_seg>/<string:url_seg_issue>/<regex("(.*)"):url_seg_article>')
+@main.route('/pdf/<string:url_seg>/<string:url_seg_issue>/<regex("(.*)"):url_seg_article>/<regex("(?:\w{2})"):lang_code>')
 @cache.cached(key_prefix=cache_key_with_lang)
 def article_detail_pdf(url_seg, url_seg_issue, url_seg_article, lang_code=''):
     issue = controllers.get_issue_by_url_seg(url_seg, url_seg_issue)


### PR DESCRIPTION
#### O que esse PR faz?
Altera rota para as view functions de Issue TOC, Feed TOC, artigo e PDF. Elas estabeleciam um padrão para `url_seg_issue` através de uma regex que não atende todos os url_segments possíveis. Como este é um parâmetro utilizado para busca por documentos no MongoDB que tenham exatamente este `url_segment`, caso um dado não válido seja informado, a aplicação se comporta da forma esperada, retornando 404.

#### Onde a revisão poderia começar?
Em `opac/webapp/main/views.py`, L697.

#### Como este poderia ser testado manualmente?
1. Localize um fascículo que fuja ao casos comuns de `url_segment` `<ano de publicação>.v<volume numérico>n<número>`. Ex: em `/grid/mioc/`, ano 1955, volume 53, número 2-3-4.
2. Acesse o fascículo e ele deve retornar corretamente
3. Acesse o feed deste Issue TOC, clicando no ícone do RSS, e ele deve abrir corretamente
4. Acesse neste Issue TOC qualquer artigo e ele deve abrir corretamente
5. Acesse o PDF de qualquer artigo deste fascículo e ele deve abrir corretamente
6. Repita dos testes com outros fascículos que atendam ou não ao padrão mais encontrado

#### Algum cenário de contexto que queira dar?
No exemplo dado no teste, por conta da regex usada para extrair o url_segment do fascículo, não era possível localizar a rota.

### Screenshots
N/A

#### Quais são tickets relevantes?
#1342 

### Referências
Nenhuma.
