### PR TITLE
Retira geração automática de tags no Docker Hub via TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,13 +19,5 @@ script:
 - make travis_compose_make_test
 - make travis_run_audit
 
-after_success:
-- if [ "$TRAVIS_BRANCH" == "master" ] && [ "$TRAVIS_EVENT_TYPE" == "push" ]; then
-  docker login -u="$DOCKER_USER" -p="$DOCKER_PASS";
-  make release_docker_build;
-  make release_docker_tag;
-  make release_docker_push;
-  fi
-
 notifications:
   slack: scielo:6YcYDMh1STDOQT8H7umVuD0R


### PR DESCRIPTION
#### O que esse PR faz?
Retira geração automática de tags no Docker Hub via TravisCI. Elas serão configuradas no próprio Docker Hub, somente quando um novo release for criado no Github.

#### Onde a revisão poderia começar?
Em `.travis.yml`

#### Como este poderia ser testado manualmente?
É necessário verificar após o ciclo do TravisCI que não houve disparo para gerar o Docker Hub gerar nova tag.

#### Algum cenário de contexto que queira dar?
N/A

### Screenshots
N/A

#### Quais são tickets relevantes?
#1345 

### Referências
Nenhuma.
