### PR TITLE
Remoçao do is_public no select das paginas secundarias do admin #1416

### DIFF
--- a/opac/webapp/admin/views.py
+++ b/opac/webapp/admin/views.py
@@ -704,7 +704,7 @@ class PagesAdminView(OpacBaseAdminView):
     form_args = dict(
         language=dict(choices=choices.LANGUAGES_CHOICES),
         journal=dict(choices=[('', '------')] +
-                     [(journal.acronym, journal.title) for journal in controllers.get_journals()]),
+                     [(journal.acronym, journal.title) for journal in controllers.get_journals(is_public=False)]),
     )
 
     form_excluded_columns = ('created_at', 'updated_at')

--- a/opac/webapp/controllers.py
+++ b/opac/webapp/controllers.py
@@ -163,13 +163,14 @@ def get_journals(title_query='', is_public=True, query_filter="", order_by="titl
             "current_status__ne": "current",
         }
 
+    if is_public:
+        filters["is_public"] = is_public
+
     if not title_query or title_query.strip() == "":
-        journals = Journal.objects(
-            is_public=is_public, **filters).order_by(order_by)
+        journals = Journal.objects(**filters).order_by(order_by)
     else:
         title_query_slug = slugify(title_query)
         journals = Journal.objects(
-            is_public=is_public,
             title_slug__icontains=title_query_slug,
             **filters).order_by(order_by)
 


### PR DESCRIPTION
#### O que esse PR faz?
Esse PR remove a necessidade dos periodicos estarem publicos para serem visualizados no select da criação das paginas secundarias do admin.

#### Onde a revisão poderia começar?
Comece pelo arquivo:
* `opac/webapp/controllers.py`
* `opac/webapp/admin/views.py`

#### Como este poderia ser testado manualmente?
Apos atualizar o ambiente, 
- acesse o `/admin` 
- verifique na lista um periodico _despublicado_, ou edite algum
- acesse as `paginas` e na tela de criação , verifique que no select de periodicos o periodico _despublicado_ ainda esta na lista

**PS:** tenha certeza que seu ambiente esta sem cache ativado, e em alguns casos apos a edição do periodico e necessario reiniciar o processo o servidor `wsgui`, para que a lista do select seja atualizada na mesma hora 

#### Algum cenário de contexto que queira dar?
Essa implementação é necessario pois a equipe de produção deve cadastrar as paginas secundarias antes do periodico esta publico com seus artigos e fasciculos, e sem essa modificação não  é possivel criar essas paginas

### Screenshots
N/A

#### Quais são tickets relevantes?
#1416 
