### PR TITLE
Altera seleção de periódico no cadastro de páginas secundárias

### DIFF
--- a/opac/webapp/admin/views.py
+++ b/opac/webapp/admin/views.py
@@ -697,14 +697,14 @@ class PagesAdminView(OpacBaseAdminView):
 
     form_overrides = dict(
         language=Select2Field,
-        journal=SelectField,
+        journal=Select2Field,
         content=CKEditorField
     )
 
     form_args = dict(
         language=dict(choices=choices.LANGUAGES_CHOICES),
         journal=dict(choices=[('', '------')] +
-                     [(journal.acronym, journal.title) for journal in controllers.get_journals()]),
+                     [(journal.acronym, journal.title) for journal in Journal.objects.all()]),
     )
 
     form_excluded_columns = ('created_at', 'updated_at')


### PR DESCRIPTION
#### O que esse PR faz?
Este PR tem o objetivo de listas todos os periódicos cadastrados na criação/edição das páginas secundárias, independente se o periódico está público ou não.
Também altera o campo de periódico para possibilitar a busca pelo nome, facilitando a seleção do periódico.

#### Onde a revisão poderia começar?
Em `opac/webapp/admin/views.py`, na view `PagesAdminView` 

#### Como este poderia ser testado manualmente?
- Acesse o admin do site o menu Pages
- Crie uma página secundária
- Vá ao campo de periódico e observe que o dropdown exibe uma caixa para digitação, que permite a busca do periódico
- Selecione um periódico, complete as demais informações e pressione Salvar
- A página deve ser cadastrada sem problemas para o periódico escolhido
- Verifique a existência de um periódico com campo `is_public` igual à `False`
- Repita os passos anteriores, selecionando um periódico com campo `is_public` igual à `False`
- A página deve ser cadastrada sem problemas para o periódico escolhido

#### Algum cenário de contexto que queira dar?
Nenhum.

### Screenshots
![Screen Shot 2019-09-23 at 15 50 16](https://user-images.githubusercontent.com/18053487/65453583-e3dd7180-de19-11e9-892a-619727f009bb.png)

#### Quais são tickets relevantes?
#1416 

### Referências
Nenhuma.
