### PR TITLE
Fixa ordem de carregamento para o MathJax e Dimensions

### DIFF
--- a/opac/webapp/config/default.py
+++ b/opac/webapp/config/default.py
@@ -481,7 +481,7 @@ MAILING_CRON_STRING = os.environ.get(
 DEFAULT_SCHEDULER_TIMEOUT = int(
     os.environ.get('OPAC_DEFAULT_SCHEDULER_TIMEOUT', 1000))
 
-DEFAULT_MATHJAX_CDN_URL = "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/latest.js?config=TeX-AMS-MML_SVG"
+DEFAULT_MATHJAX_CDN_URL = "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-AMS-MML_SVG"
 MATHJAX_CDN_URL = os.environ.get('OPAC_MATHJAX_CDN_URL', DEFAULT_MATHJAX_CDN_URL)
 
 

--- a/opac/webapp/templates/article/base.html
+++ b/opac/webapp/templates/article/base.html
@@ -15,10 +15,6 @@
 
 {% block extra_css %}
   <link rel="stylesheet" href="{{ url_for('static', filename='css/scielo-article.css') }}" type="text/css" async/>
-  {% if config.MATHJAX_CDN_URL %}
-    {# recomendação da doc do mathjax: "(It can also go in the <body> if necessary, but the head is to be preferred.)" #}
-    <script type="text/javascript" async src="{{ config.MATHJAX_CDN_URL }}"></script>
-  {% endif %}
 {% endblock %}
 
 {% block content %}
@@ -43,7 +39,6 @@
 
 {% block extra_js %}
   <script type="text/javascript" src="{{ url_for('static', filename='js/scielo-article-min.js') }}"></script>
-  <script type="text/javascript" src="//badge.dimensions.ai/badge.js" charset="utf-8" async></script>
   <script type="text/javascript" src="//cdn.plu.mx/widget-popup.js"></script>
 
   {% if config.USE_ALTMETRIC %}
@@ -53,6 +48,23 @@
   {% if config.USE_SCIENCEOPEN %}
     <script id="9cf9cf8f-3a99-fe86-4013-f630edbf80ac" src="https://www.scienceopen.com/script/badge2.js" async defer></script>
       <script type="text/javascript" src="{{ url_for('static', filename='js/scienceopen.js') }}"></script>
+  {% endif %}
+
+  {% if config.MATHJAX_CDN_URL %}
+    <script sync src="{{ config.MATHJAX_CDN_URL }}" charset="utf-8"></script>
+
+    <script>
+      var insertScript = function(url, callback, parentNode) {
+        var scriptNode = document.createElement("script");
+        scriptNode.src = url;
+        scriptNode.onload = callback;
+        parentNode.appendChild(scriptNode)
+      }
+      var headNode = document.getElementsByTagName("head")[0];
+      setTimeout(MathJax.Callback([insertScript, "//badge.dimensions.ai/badge.js", console.log, headNode]), 1500);
+    </script>
+  {% else %}
+    <script type="text/javascript" src="//badge.dimensions.ai/badge.js" charset="utf-8" async></script>
   {% endif %}
 
 {% endblock %}


### PR DESCRIPTION
#### O que esse PR faz?
Este pull request fixa a ordem de carregamento para as bibliotecas MathJax e Dimesions. Anteriormente as duas bibliotecas eram carregadas de forma assíncrona e na ocasião onde a Dimensions era carregada `antes` do MathJax nós tinham um problema na renderização de equações com saída em SVG.

Durante a execução desta task pude detalhar outros pontos de abordagem e metodologias para reprodução do problema no comentário https://github.com/scieloorg/opac/issues/1381#issuecomment-534748255;

#### Onde a revisão poderia começar?
- `opac/webapp/templates/article/base.html` L `56`

#### Como este poderia ser testado manualmente?

Pode-se testar este PR com os passos exibidos na issue https://github.com/scieloorg/opac/issues/1381 e no comentário https://github.com/scieloorg/opac/issues/1381#issuecomment-534748255;

#### Algum cenário de contexto que queira dar?
Uma outra abordagem para solucionar o problema consistia em atualizar a versão do MathJax para 3.0 porém a biblioteca foi totalmente reescrita e está em estado de WIP não estável.

### Screenshots
N/A

#### Quais são tickets relevantes?
#1381 

### Referências
N/A

