### PR TITLE
Adicionar a capacidade de ligar e desligar a reescrita da URL para HTMLs

### DIFF
--- a/opac/webapp/config/default.py
+++ b/opac/webapp/config/default.py
@@ -106,6 +106,7 @@ import os
         - OPAC_SSM_DOMAIN: Dominio/FQDN do conexão com SSM. Ex: 'homolog.ssm.scielo.org - (default: 'ssm.scielo.org')
         - OPAC_SSM_PORT: Porta de conexão com o SSM. Ex. '8000'. (default: '80')
         - OPAC_SSM_MEDIA_PATH: Path da pasta media do assests no SSM. Ex. '/media/assets/' -  (default: '/media/assets/')
+        - OPAC_SSM_ASSET_REWRITE: Realiza um proxy da URL do SSM para que o SSM não esteja disponível para acesso externo. Variável boleana: 'False' (default: 'True')
 
       - Cookie de Sessão: (http://flask.pocoo.org/docs/0.12/config/#builtin-configuration-values)
         - OPAC_SERVER_NAME: Nome:IP do servidor - (default: None)
@@ -409,6 +410,7 @@ SSM_SCHEME = os.environ.get('OPAC_SSM_SCHEME', 'https')
 SSM_DOMAIN = os.environ.get('OPAC_SSM_DOMAIN', 'homolog.ssm.scielo.org')
 SSM_PORT = os.environ.get('OPAC_SSM_PORT', '443')
 SSM_MEDIA_PATH = os.environ.get('OPAC_SSM_MEDIA_PATH', '/media/assets/')
+SSM_ASSET_REWRITE = os.environ.get('OPAC_SSM_ASSET_REWRITE', 'True') == 'True'
 
 # SSM_BASE_URI ex: 'https://homolog.ssm.scielo.org:80/'
 SSM_BASE_URI = "{scheme}://{domain}:{port}".format(

--- a/opac/webapp/config/default.py
+++ b/opac/webapp/config/default.py
@@ -106,7 +106,7 @@ import os
         - OPAC_SSM_DOMAIN: Dominio/FQDN do conexão com SSM. Ex: 'homolog.ssm.scielo.org - (default: 'ssm.scielo.org')
         - OPAC_SSM_PORT: Porta de conexão com o SSM. Ex. '8000'. (default: '80')
         - OPAC_SSM_MEDIA_PATH: Path da pasta media do assests no SSM. Ex. '/media/assets/' -  (default: '/media/assets/')
-        - OPAC_SSM_ASSET_REWRITE: Realiza um proxy da URL do SSM para que o SSM não esteja disponível para acesso externo. Variável boleana: 'False' (default: 'True')
+        - OPAC_SSM_URL_REWRITE: Realiza um proxy da URL do SSM para que o SSM não esteja disponível para acesso externo. Variável boleana: 'False' (default: 'True')
 
       - Cookie de Sessão: (http://flask.pocoo.org/docs/0.12/config/#builtin-configuration-values)
         - OPAC_SERVER_NAME: Nome:IP do servidor - (default: None)
@@ -410,7 +410,7 @@ SSM_SCHEME = os.environ.get('OPAC_SSM_SCHEME', 'https')
 SSM_DOMAIN = os.environ.get('OPAC_SSM_DOMAIN', 'homolog.ssm.scielo.org')
 SSM_PORT = os.environ.get('OPAC_SSM_PORT', '443')
 SSM_MEDIA_PATH = os.environ.get('OPAC_SSM_MEDIA_PATH', '/media/assets/')
-SSM_ASSET_REWRITE = os.environ.get('OPAC_SSM_ASSET_REWRITE', 'True') == 'True'
+SSM_URL_REWRITE = os.environ.get('OPAC_SSM_URL_REWRITE', 'True') == 'True'
 
 # SSM_BASE_URI ex: 'https://homolog.ssm.scielo.org:80/'
 SSM_BASE_URI = "{scheme}://{domain}:{port}".format(

--- a/opac/webapp/main/views.py
+++ b/opac/webapp/main/views.py
@@ -886,7 +886,8 @@ def article_detail_pid(pid):
 
 
 def render_html_from_xml(article, lang):
-    result = fetch_data(normalize_ssm_url(article.xml))
+    result = fetch_data(maybe_normalize_ssm_url(article.xml,
+                                                current_app.config["SSM_URL_REWRITE"]))
 
     xml = etree.parse(BytesIO(result))
 
@@ -909,7 +910,8 @@ def render_html_from_html(article, lang):
     except IndexError:
         raise ValueError('Artigo não encontrado') from None
 
-    result = fetch_data(normalize_ssm_url(html_url))
+    result = fetch_data(maybe_normalize_ssm_url(html_url,
+                                                current_app.config["SSM_URL_REWRITE"]))
 
     html = result.decode('utf8')
 
@@ -931,9 +933,9 @@ def render_html(article, lang):
 
 # TODO: Remover assim que o valor Article.xml estiver consistente na base de
 # dados
-def normalize_ssm_url(url):
+def maybe_normalize_ssm_url(url, normalized_url=False):
 
-    if not current_app.config["SSM_ASSET_REWRITE"]:
+    if not normalized_url:
         return url
 
     if url.startswith("http"):

--- a/opac/webapp/main/views.py
+++ b/opac/webapp/main/views.py
@@ -932,6 +932,10 @@ def render_html(article, lang):
 # TODO: Remover assim que o valor Article.xml estiver consistente na base de
 # dados
 def normalize_ssm_url(url):
+
+    if not current_app.config["SSM_ASSET_REWRITE"]:
+        return url
+
     if url.startswith("http"):
         parsed_url = urlparse(url)
         return current_app.config["SSM_BASE_URI"] + parsed_url.path


### PR DESCRIPTION
#### O que esse PR faz?

Adiciona no arquivo de configuração uma opção para realizar ou não a tradução das URLs dos ativos.

#### Onde a revisão poderia começar?

É possível verificar as mudanças nos seguinte módulos: 

opac/webapp/config/default.py
opac/webapp/main/views.py

#### Como este poderia ser testado manualmente?

Executando a aplicação com: python manager.py runserver e adicionando uma variável de ambiente OPAC_SSM_ASSET_REWRITE com o valor "False"

**IMPORTANTE:** É importante garantir que na base de dados de artigo contenha URL para os HTMLs acessíveis para que não seja realizado o "proxy" para o Data Store.

#### Algum cenário de contexto que queira dar?

Essa atividade garante que a inclusão dos dados a partir do Escalonador seja feita sem que tenhamos que realizar ajuste no código.

#### Quais são tickets relevantes?

https://github.com/scieloorg/opac/issues/1441


