### PR TITLE
Simplifica a exibição dos links no TOC

### DIFF
--- a/opac/webapp/templates/issue/toc.html
+++ b/opac/webapp/templates/issue/toc.html
@@ -167,12 +167,10 @@
                             {% if article.abstract_languages|length > 0 %}
                             <li>
                               {% trans %}Resumo{% endtrans %}:
-                              {% for lang in article.languages %}
-                                {% if lang in article.abstract_languages %}
-                                    <a class="collapseAbstractBlock" href="#" data-id="{{article.id}}_{{lang}}" data-toggle="tooltip" data-placement="bottom" title="{{lang|trans_alpha2}}">
-                                      {{ lang }}
-                                    </a>
-                                {% endif %}
+                              {% for lang in article.abstract_languages|sort %}
+                                <a class="collapseAbstractBlock" href="#" data-id="{{article.id}}_{{lang}}" data-toggle="tooltip" data-placement="bottom" title="{{lang|trans_alpha2}}">
+                                  {{ lang }}
+                                </a>
                               {% endfor %}
                             </li>
                             {% endif %}
@@ -226,7 +224,7 @@
                         </ul>
 
                         {# Adicionar divs com os resumos #}
-                        {% for lang in article.languages|reverse %}
+                        {% for lang in article.abstract_languages|sort|reverse %}
                           <div class="collapseAbstractContent" id="{{article.id}}_{{lang}}" data-toggle="tooltip" data-placement="bottom" title="{{lang|trans_alpha2}}">
                             {% if article.get_abstract_by_lang(lang) %}
                               <p><strong>{% trans %}Resumo em{% endtrans %} {{ lang|trans_alpha2 }}:</strong></p>

--- a/opac/webapp/templates/issue/toc.html
+++ b/opac/webapp/templates/issue/toc.html
@@ -132,17 +132,6 @@
                 <ul class="articles">
                   {% for article in articles %}
 
-                    {# Item comentado se caso precisarmos reverter
-                     {% if article.section %}
-                      <a name="{{ article.section|upper }}"></a>
-                      <h1>
-                        <a href="{{ url_for('.issue_toc', url_seg=article.journal.url_segment, url_seg_issue=issue.url_segment) }}?section={{ article.section|upper }}">
-                          {{ article.section }}
-                        </a>
-                      </h1>
-                    {% endif %}
-                    #}
-
                       <li data-date="{% if article.publication_date %}{{ article.publication_date.replace('-', "") }}{% endif %}">
 
                         {% if session.lang %}

--- a/opac/webapp/templates/issue/toc.html
+++ b/opac/webapp/templates/issue/toc.html
@@ -189,14 +189,10 @@
                             {% if article.article_pdf_languages|length > 0 %}
                             <li>
                               {% trans %}PDF{% endtrans %}:
-                              {% for lang in article.languages %}
-                                {% for pdf_lang, url in article.article_pdf_languages %}
-                                  {% if lang == pdf_lang %}
-                                    <a target='_blank' href="{{ url_for('.article_detail_pdf', url_seg=journal.url_segment, url_seg_issue=issue.url_segment, url_seg_article=article.url_segment, lang_code=lang) }}" data-toggle="tooltip" data-placement="bottom" title="{{lang|trans_alpha2}}">
-                                        {{ lang }}
-                                    </a>
-                                  {% endif %}
-                                {% endfor %}
+                              {% for lang, url in article.article_pdf_languages|sort(attribute='0') %}
+                                <a target='_blank' href="{{ url_for('.article_detail_pdf', url_seg=journal.url_segment, url_seg_issue=issue.url_segment, url_seg_article=article.url_segment, lang_code=lang) }}" data-toggle="tooltip" data-placement="bottom" title="{{lang|trans_alpha2}}">
+                                  {{ lang }}
+                                </a>
                               {% endfor %}
                             </li>
                             {% endif %}

--- a/opac/webapp/templates/issue/toc.html
+++ b/opac/webapp/templates/issue/toc.html
@@ -200,14 +200,10 @@
                             {% if config['READCUBE_ENABLED'] and article.doi and article.pid %}
                             <li>
                               {% trans %}ePDF{% endtrans %}:
-                              {% for lang in article.languages %}
-                                {% for pdf_lang, url in article.article_pdf_languages %}
-                                  {% if lang == pdf_lang %}
-                                    <a href="{{ url_for('.article_epdf', doi=article.doi, pid=article.pid, pdf_path=url, lang=lang) }}" data-toggle="tooltip" data-placement="bottom" title="{{lang|trans_alpha2}}">
-                                        {{ lang }}
-                                      </a>
-                                  {% endif %}
-                                {% endfor %}
+                              {% for lang, url in article.article_pdf_languages|sort(attribute='0') %}
+                                <a href="{{ url_for('.article_epdf', doi=article.doi, pid=article.pid, pdf_path=url, lang=lang) }}" data-toggle="tooltip" data-placement="bottom" title="{{lang|trans_alpha2}}">
+                                  {{ lang }}
+                                </a>
                               {% endfor %}
                             </li>
                             {% endif %}

--- a/opac/webapp/templates/issue/toc.html
+++ b/opac/webapp/templates/issue/toc.html
@@ -197,9 +197,6 @@
                             </li>
                             {% endif %}
 
-                              {#{% if lang in article.article_text_languages and lang in article.abstract_languages %}
-                              |
-                              {% endif %}#}
                         </ul>
 
                         {# Adicionar divs com os resumos #}

--- a/opac/webapp/templates/issue/toc.html
+++ b/opac/webapp/templates/issue/toc.html
@@ -178,12 +178,10 @@
                             {% if article.article_text_languages|length > 0 %}
                             <li>
                               {% trans %}Texto{% endtrans %}:
-                              {% for lang in article.languages %}
-                                {% if lang in article.article_text_languages %}
-                                  <a href="{{ url_for('.article_detail', url_seg=journal.url_segment, url_seg_issue=issue.url_segment, url_seg_article=article.url_segment, lang_code=lang) }}" data-toggle="tooltip" data-placement="bottom" title="{{lang|trans_alpha2}}">
-                                    {{ lang }}
-                                  </a>
-                                {% endif %}
+                              {% for lang in article.article_text_languages|sort %}
+                                <a href="{{ url_for('.article_detail', url_seg=journal.url_segment, url_seg_issue=issue.url_segment, url_seg_article=article.url_segment, lang_code=lang) }}" data-toggle="tooltip" data-placement="bottom" title="{{lang|trans_alpha2}}">
+                                  {{ lang }}
+                                </a>
                               {% endfor %}
                             </li>
                             {% endif %}


### PR DESCRIPTION
#### O que esse PR faz?

Simplifica o código responsável pela exibição dos links para resumo, textos e pdfs na tabela de conteúdos de um fascículo ao iterar diretamente sobre campos específicos ao invés de no superconjunto.

Realizei uma pesquisa pelo histórico do Git e perguntei para o @jamilatta (que trabalhou no desenvolvimento do projeto desde o início) para entender a justificativa desta abordagem mas não tive sucesso. Aparentemente é um código que deixou de ser necessário e não foi refatorado devidamente.

#### Onde a revisão poderia começar?

Há apenas 1 arquivo modificado.

#### Como este poderia ser testado manualmente?

Pode executar a suíte de testes automatizados e testar em uma instância local.

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
n/a

#### Quais são tickets relevantes?
n/a

### Referências
n/a

