### PR TITLE
Adiciona capacidade de ligar e desligar a reescrita da URL dos XMLs

### DIFF
--- a/opac/webapp/config/default.py
+++ b/opac/webapp/config/default.py
@@ -106,6 +106,7 @@ import os
         - OPAC_SSM_DOMAIN: Dominio/FQDN do conexão com SSM. Ex: 'homolog.ssm.scielo.org - (default: 'ssm.scielo.org')
         - OPAC_SSM_PORT: Porta de conexão com o SSM. Ex. '8000'. (default: '80')
         - OPAC_SSM_MEDIA_PATH: Path da pasta media do assests no SSM. Ex. '/media/assets/' -  (default: '/media/assets/')
+        - OPAC_SSM_XML_URL_REWRITE: Troca o scheme + authority da URL armazenada em Article.xml por `OPAC_SSM_SCHEME + '://' + OPAC_SSM_DOMAIN + ':' + OPAC_SSM_PORT`. Variável booleana: 'False' (default: 'True')
 
       - Cookie de Sessão: (http://flask.pocoo.org/docs/0.12/config/#builtin-configuration-values)
         - OPAC_SERVER_NAME: Nome:IP do servidor - (default: None)
@@ -409,6 +410,7 @@ SSM_SCHEME = os.environ.get('OPAC_SSM_SCHEME', 'https')
 SSM_DOMAIN = os.environ.get('OPAC_SSM_DOMAIN', 'homolog.ssm.scielo.org')
 SSM_PORT = os.environ.get('OPAC_SSM_PORT', '443')
 SSM_MEDIA_PATH = os.environ.get('OPAC_SSM_MEDIA_PATH', '/media/assets/')
+SSM_XML_URL_REWRITE = os.environ.get('OPAC_SSM_XML_URL_REWRITE', 'True') == 'True'
 
 # SSM_BASE_URI ex: 'https://homolog.ssm.scielo.org:80/'
 SSM_BASE_URI = "{scheme}://{domain}:{port}".format(

--- a/opac/webapp/main/views.py
+++ b/opac/webapp/main/views.py
@@ -886,7 +886,10 @@ def article_detail_pid(pid):
 
 
 def render_html_from_xml(article, lang):
-    result = fetch_data(normalize_ssm_url(article.xml))
+    if current_app.config["SSM_XML_URL_REWRITE"]:
+        result = fetch_data(normalize_ssm_url(article.xml))
+    else:
+        result = fetch_data(article.xml)
 
     xml = etree.parse(BytesIO(result))
 
@@ -932,6 +935,16 @@ def render_html(article, lang):
 # TODO: Remover assim que o valor Article.xml estiver consistente na base de
 # dados
 def normalize_ssm_url(url):
+    """Normaliza a string `url` de acordo com os valores das diretivas de 
+    configuração OPAC_SSM_SCHEME, OPAC_SSM_DOMAIN e OPAC_SSM_PORT.
+
+    A normalização busca obter uma URL absoluta em função de uma relativa, ou
+    uma absoluta em função de uma absoluta, mas com as partes *scheme* e 
+    *authority* trocadas pelas definidas nas diretivas citadas anteriormente.
+
+    Este código deve ser removido assim que o valor de Article.xml estiver
+    consistente, i.e., todos os registros possuirem apenas URLs absolutas.
+    """
     if url.startswith("http"):
         parsed_url = urlparse(url)
         return current_app.config["SSM_BASE_URI"] + parsed_url.path


### PR DESCRIPTION
#### O que esse PR faz?
Adiciona capacidade de ligar e desligar a reescrita da URL dos XMLs

Esta funcionalidade é importante para a compatibilidade do site com a
nova arquitetura, onde o XML deve ser obtido a partir do Kernel e não do
Object Store (SSM).

Foi adicionada a diretiva `OPAC_SSM_XML_URL_REWRITE`, que recebe valores
booleanos.

É importante notar que a diretiva afeta apenas a obtenção do XML; a
obtenção dos HTMLs e PDFs permanece inalterada.

#### Onde a revisão poderia começar?

`opac/webapp/config/default.py`

#### Como este poderia ser testado manualmente?

Defina a diretiva `OPAC_SSM_XML_URL_REWRITE` nas configurações da aplicação e perceba que: (a) quando `False`, o dado presente em `Article.xml` é utilizado sem manipulação e, (b) quando `True`, o dado é alterado de acordo com os definidos nas diretivas `OPAC_SSM_*`.


#### Algum cenário de contexto que queira dar?
Este código é temporário e deve ser removido assim que o valor de `Article.xml` estiver consistente para todos os registros, i.e., todos os registros possuirem apenas URLs absolutas.

### Screenshots
n/a

#### Quais são tickets relevantes?
#1441 
Este PR substitui https://github.com/scieloorg/opac/pull/1443

### Referências
n/a

