### PR TITLE
Atualiza o requirements.txt com a nova versão do packtools, indiretamente resolve o tíquete: 1278 do opac

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -32,4 +32,4 @@ rq-scheduler==0.8.2
 rq-scheduler-dashboard==0.0.2
 lxml==4.2.4
 Werkzeug==0.14.1
-https://github.com/scieloorg/packtools/archive/2.5.5.tar.gz#egg=packtools
+https://github.com/scieloorg/packtools/archive/2.5.6.tar.gz#egg=packtools


### PR DESCRIPTION
#### O que esse PR faz?

Atualiza a versão do packtools para a versão 2.5.6.

#### Onde a revisão poderia começar?

No **requirements.txt**

#### Como este poderia ser testado manualmente?

Localmente acessando o artigo: http://0.0.0.0:8000/scielo.php?script=sci_arttext&pid=S2175-78602018000401513&lng=en&nrm=iso&tlng=en#

Necessário rodar previamente a aplicação.

#### Algum cenário de contexto que queira dar?

Essa atualização resolve o tíquete: https://github.com/scieloorg/opac/issues/1458 

Repare como ficou o texto da citação: 

<img width="1319" alt="Screenshot 2019-10-30 10 47 49" src="https://user-images.githubusercontent.com/373745/67864286-26bef300-fb04-11e9-80cc-161abd2c910f.png">

#### Quais são tickets relevantes?

https://github.com/scieloorg/opac/issues/1458
https://github.com/scieloorg/opac/issues/1278

### Referências
N/A

