### PR TITLE
Bug1486 - Corrige a exibição do campo ``áreas`` no cabeçalho da grade.

### DIFF
--- a/opac/webapp/main/views.py
+++ b/opac/webapp/main/views.py
@@ -581,6 +581,9 @@ def about_journal(url_seg):
         'journal': journal,
         'latest_issue_legend': latest_issue_legend,
         'last_issue': latest_issue,
+        'journal_study_areas': [
+            STUDY_AREAS.get(study_area.upper()) for study_area in journal.study_areas
+        ],
     }
 
     if page:
@@ -744,6 +747,9 @@ def issue_grid(url_seg):
         'volume_issue': issues_data['volume_issue'],
         'ahead': issues_data['ahead'],
         'result_dict': issues_data['ordered_for_grid'],
+        'journal_study_areas': [
+            STUDY_AREAS.get(study_area.upper()) for study_area in journal.study_areas
+        ],
     }
 
     return render_template("issue/grid.html", **context)
@@ -935,11 +941,11 @@ def render_html(article, lang):
 # TODO: Remover assim que o valor Article.xml estiver consistente na base de
 # dados
 def normalize_ssm_url(url):
-    """Normaliza a string `url` de acordo com os valores das diretivas de 
+    """Normaliza a string `url` de acordo com os valores das diretivas de
     configuração OPAC_SSM_SCHEME, OPAC_SSM_DOMAIN e OPAC_SSM_PORT.
 
     A normalização busca obter uma URL absoluta em função de uma relativa, ou
-    uma absoluta em função de uma absoluta, mas com as partes *scheme* e 
+    uma absoluta em função de uma absoluta, mas com as partes *scheme* e
     *authority* trocadas pelas definidas nas diretivas citadas anteriormente.
 
     Este código deve ser removido assim que o valor de Article.xml estiver


### PR DESCRIPTION
#### O que esse PR faz?

Resolve a necessidade de variaveis de contexto esperadas pelos templates de toc e grid.

#### Onde a revisão poderia começar?

No módulo: opac/webapp/main/views.py:747

#### Como este poderia ser testado manualmente?

Acessando um periódico, página da grade, exemplo: https://homolog.opac.scielo.br/grid/abb/

#### Algum cenário de contexto que queira dar?
N/A

### Screenshots

![Screenshot 2019-12-03 15 18 50](https://user-images.githubusercontent.com/373745/70077769-3b4d4a00-15e0-11ea-838c-5e4078d86eaa.png)


#### Quais são tickets relevantes?

TK #1486 
