### PR TITLE
Adiciona capacidade de ler diferentes versões de PIDs do SciELO.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ Flask-Migrate==2.2.1
 unicodecsv==0.14.1
 feedparser==5.2.1
 legendarium==2.0.2
--e git+https://git@github.com/scieloorg/opac_schema@v2.52#egg=opac_schema
+-e git+https://git@github.com/scieloorg/opac_schema@v2.53#egg=opac_schema
 Flask-HTMLmin==1.4.0
 python-slugify==1.2.4
 requests>=2.20.0


### PR DESCRIPTION
#### O que esse PR faz?
Esta alteração atualiza a versão do OPAC_Schema para a 2.53, que adiciona novo campo scielo_pids, usado para armazenar diferentes versões de SciELO PID.

#### Onde a revisão poderia começar?
Em `requirements.txt`

#### Como este poderia ser testado manualmente?
- Rodar a DAG `sync_kernel_to_website` com a versão 2.53 do OPAC_Schema, com documentos que contenham no `/front` do Kernel `scielo_pid_vn`
- Com a coleção MongoDB `article` do OPAC com o campo `scielo_pids`, acessar o site, que deve rodar sem obter erro HTTP 500.

#### Algum cenário de contexto que queira dar?
Detalhes no ticket scieloorg/opac-airflow/issues/138

### Screenshots
N/A

#### Quais são tickets relevantes?
scieloorg/opac-airflow/issues/138

### Referências
Especificação dos PIDs do SciELO: https://github.com/scieloorg/kernel/blob/master/docs/adr/0006-novo-pid-do-scielo.md

