### PR TITLE
A URL antiga do artigo no site SciELO passa a retornar HTTP status 302, atualizado a versão do opac_schema de 2.53 para 2.54.

### DIFF
--- a/opac/tests/test_legacy_urls.py
+++ b/opac/tests/test_legacy_urls.py
@@ -106,6 +106,70 @@ class LegacyURLTestCase(BaseTestCase):
 
                 self.assertTemplateUsed('article/detail.html')
 
+    def test_article_text_with_lng(self):
+        """
+        Testa o acesso ao artigo pela URL antiga.
+        URL testa: scielo.php?script=sci_arttext&pid=ISSN + ID DO número + ID  + idioma DO ARTIGO
+        Exemplo: scielo.php?script=sci_arttext&pid=0000-000020160001&tlng=en
+        """
+
+        with current_app.app_context():
+
+            journal = utils.makeOneJournal({'print_issn': '0000-0000'})
+
+            issue = utils.makeOneIssue({
+                'journal': journal.id,
+                'pid': '0000-000020160001'
+            })
+
+            article = utils.makeOneArticle({
+                'journal': journal.id,
+                'issue': issue.id,
+                'pid': '0000-00002016000100251',
+
+            })
+
+            with self.client as c:
+
+                url = 'scielo.php?script=sci_arttext&pid=%s&tlng=%s' % (article.pid, 'en')
+
+                response = c.get(url, follow_redirects=True)
+
+                self.assertStatus(response, 200)
+
+                self.assertTemplateUsed('article/detail.html')
+
+    def test_article_text_return_redirect_from_legacy_urls(self):
+        """
+        Testa o acesso ao artigo pela URL antiga.
+        URL testa: scielo.php?script=sci_arttext&pid=ISSN + ID DO número + ID  + idioma DO ARTIGO
+        Exemplo: scielo.php?script=sci_arttext&pid=0000-000020160001&tlng=en
+        """
+
+        with current_app.app_context():
+
+            journal = utils.makeOneJournal({'print_issn': '0000-0000'})
+
+            issue = utils.makeOneIssue({
+                'journal': journal.id,
+                'pid': '0000-000020160001'
+            })
+
+            article = utils.makeOneArticle({
+                'journal': journal.id,
+                'issue': issue.id,
+                'pid': '0000-00002016000100251',
+
+            })
+
+            with self.client as c:
+
+                url = 'scielo.php?script=sci_arttext&pid=%s&tlng=%s' % (article.pid, 'en')
+
+                response = c.get(url)
+
+                self.assertStatus(response, 301)
+
     def test_article_abstract(self):
         """
         Testa o acesso ao abstract do artigo pela URL antiga.

--- a/opac/tests/test_main_views.py
+++ b/opac/tests/test_main_views.py
@@ -1085,7 +1085,7 @@ class MainTestCase(BaseTestCase):
             url = '%s?script=sci_arttext&pid=%s' % (
                 url_for('main.router_legacy'), aop_pid)
 
-            response = self.client.get(url)
+            response = self.client.get(url, follow_redirects=True)
 
             self.assertStatus(response, 200)
             self.assertTemplateUsed('article/detail.html')

--- a/opac/webapp/main/views.py
+++ b/opac/webapp/main/views.py
@@ -324,6 +324,7 @@ def router_legacy():
 
     script_php = request.args.get('script', None)
     pid = request.args.get('pid', None)
+    tlng = request.args.get('tlng', None)
     allowed_scripts = [
         'sci_serial', 'sci_issuetoc', 'sci_arttext', 'sci_abstract', 'sci_issues', 'sci_pdf'
     ]
@@ -378,9 +379,11 @@ def router_legacy():
             if not article.journal.is_public:
                 abort(404, JOURNAL_UNPUBLISH + _(article.journal.unpublish_reason))
 
-            return article_detail(article.journal.url_segment,
-                                  article.issue.url_segment,
-                                  article.url_segment)
+            return redirect(url_for('main.article_detail',
+                                    url_seg=article.journal.url_segment,
+                                    url_seg_issue=article.issue.url_segment,
+                                    url_seg_article=article.url_segment,
+                                    lang_code=tlng), code=301)
 
         elif script_php == 'sci_issues':
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ Flask-Migrate==2.2.1
 unicodecsv==0.14.1
 feedparser==5.2.1
 legendarium==2.0.2
--e git+https://git@github.com/scieloorg/opac_schema@v2.53#egg=opac_schema
+-e git+https://git@github.com/scieloorg/opac_schema@v2.54#egg=opac_schema
 Flask-HTMLmin==1.4.0
 python-slugify==1.2.4
 requests>=2.20.0


### PR DESCRIPTION
#### O que esse PR faz?

Agora as URLs antigas do site SciELO passa a retornar status 302, responde pelo idioma (tlng) e também foi atualizado a versão do **opac_schema** 2.53 -> 2.54.

### Onde a revisão poderia começar?

opac/tests/test_legacy_urls.py
opac/tests/test_main_views.py
opac/webapp/main/views.py
requirements.txt

#### Como este poderia ser testado manualmente?

1. Acesse o artigo na versão em inglês [Smoking cessation during pregnancy: a population-based study](http://www.scielosp.org/scielo.php?script=sci_arttext&pid=S0034-89102019000100202&lng=pt&tlng=en)
2. Acesse o artigo na versão em português [Cessação do tabagismo na gestação: estudo de base populacional](http://www.scielosp.org/scielo.php?script=sci_arttext&pid=S0034-89102019000100202&lng=pt&tlng=pt)
3. Verifique que a tradução está sendo exibida corretamente.

Executando os teste com o comando: 

```
make dev_compose_make_test
```

#### Algum cenário de contexto que queira dar?
N/A

### Screenshots
N/A

#### Quais são tickets relevantes?
#1413 
#1492 

### Referências
N/A

