### PR TITLE
Adiciona rota para primeira versão do site clássico

### DIFF
--- a/opac/tests/test_controller.py
+++ b/opac/tests/test_controller.py
@@ -993,6 +993,48 @@ class ArticleControllerTestCase(BaseTestCase):
         """
         self.assertRaises(ValueError, controllers.get_articles_by_iid, [])
 
+    def test_get_article_by_scielo_pid_with_no_pid(self):
+        """
+        Testando a função controllers.get_article_by_scielo_pid(), sem pid
+        retorna um ValueError.
+        """
+        self.assertRaises(ValueError, controllers.get_article_by_scielo_pid, scielo_pid="")
+
+    def test_get_article_by_scielo_pid_returns_none_if_no_pid_in_scielo_pids(self):
+        """
+        Testando a função controllers.get_article_by_scielo_pid(), sem pid
+        retorna um ValueError.
+        """
+        self._make_one(attrib={
+            '_id': '012ijs9y24',
+            'issue': '90210j83',
+            'journal': 'oak,ajimn1',
+            'scielo_pids': {
+                'v1': 'S0101-0202(99)12345',
+                'v2': 'S0101-02021998123456',
+                'v3': 'cS2o3kdx93emd902m',
+            },
+        })
+        self.assertIsNone(controllers.get_article_by_scielo_pid("S0101-0202(99)12344"))
+
+    def test_get_article_by_scielo_pid_returns_article(self):
+        """
+        Testando a função controllers.get_article_by_scielo_pid(), retorna artigo com sucesso.
+        """
+        self._make_one(attrib={
+            '_id': '012ijs9y24',
+            'issue': '90210j83',
+            'journal': 'oak,ajimn1',
+            'scielo_pids': {
+                'v1': 'S0101-0202(99)12345',
+                'v2': 'S0101-02021998123456',
+                'v3': 'cS2o3kdx93emd902m',
+            },
+        })
+        article = controllers.get_article_by_scielo_pid("S0101-0202(99)12345")
+        self.assertEqual(article._id, '012ijs9y24')
+        self.assertEqual(article.scielo_pids["v1"], 'S0101-0202(99)12345')
+
     def test_get_recent_articles_of_issue(self):
         self._make_one(attrib={
             '_id': '012ijs9y24',

--- a/opac/webapp/controllers.py
+++ b/opac/webapp/controllers.py
@@ -938,6 +938,22 @@ def get_article_by_oap_pid(aop_pid, **kwargs):
     return Article.objects(aop_pid=aop_pid, **kwargs).first()
 
 
+def get_article_by_scielo_pid(scielo_pid, **kwargs):
+    """
+    Retorna um artigo considerando os parâmetros ``scielo_pid``.
+
+    - ``scielo_pid``: string, contendo o PID do artigo versão 1, 2 ou 3
+    """
+
+    if not scielo_pid:
+        raise ValueError(__('Obrigatório um pid.'))
+
+    return Article.objects(
+        (Q(scielo_pids__v1=scielo_pid) | Q(scielo_pids__v2=scielo_pid) | Q(scielo_pids__v3=scielo_pid)),
+        **kwargs
+    ).first()
+
+
 def get_recent_articles_of_issue(issue_iid, is_public=True):
     """
     Retorna a lista de artigos de um issue/


### PR DESCRIPTION
#### O que esse PR faz?
Este PR resolve o problema para acessar conteúdo em URLs legadas com path `/cgi-bin/fbpe/fbtext?got=last&pid=<pid versão 1>&usr=fbpe&lng=en&seq=<seq>&nrm=iso&sss=<sss>&aut=<aut>`, que funcionavam dessa forma anteriormente ao site atual.
Para isso, foi adicionada uma _view_ para atender URL no site novo e _controller_ para buscar artigo pelo SciELO PID em diferentes versões. Em caso de sucesso na busca, o site redireciona para os detalhes do artigo no site novo.

#### Onde a revisão poderia começar?
Em `opac/webapp/main/views.py`, onde foi implementada a nova _view function_.

#### Como este poderia ser testado manualmente?
- Sincronize do kernel para o site algum documento que tenha o SciELO PID versão 1
- Com um artigo que possua o campo `scielo_pids`, acesse-o utilizando a URL legada no formato descrito acima. Ex: http://new.scielo.br/cgi-bin/fbpe/fbtext?got=last&pid=S0103-9016(98)05500124&usr=fbpe&lng=en&seq=0103-9016-005&nrm=iso&sss=1&aut=71981947
- O site deve redirecionar para o conteúdo do artigo
- Acesse a URL legada do resumo, substituindo o "fbtext" pi "fbabs"
- O site também deve redirecionar para o conteúdo do artigo

#### Algum cenário de contexto que queira dar?
Esta alteração funcionará somente a partir da migração e utilização do novo fluxo de ingestão direta. Portanto, as instancias do novo site com o processamento atual do OPAC não funcionarão.

### Screenshots
N/A.

#### Quais são tickets relevantes?
#1485

### Referências
Nenhuma.
