### PR TITLE
Adiciona a capacidade de obter o PDF utilizando a URL antiga do site em que o processamento tenha sido realizado pelo OPAC-AirFlow

### DIFF
--- a/opac/tests/test_controller.py
+++ b/opac/tests/test_controller.py
@@ -1160,36 +1160,6 @@ class ArticleControllerTestCase(BaseTestCase):
             "article.pdf"
         )
 
-    @patch('webapp.controllers.Article.objects')
-    def test_get_article_by_pdf_filename_returns_article_filter_result(
-        self, mk_article_objects
-    ):
-        attrib = {
-            "pdfs" : [
-                {
-                    "lang" : "pt",
-                    "url" : "https://ssm.scielo.br/media/assets/abc/v1n3s2/article.pdf",
-                    "type" : "pdf"
-                },
-                {
-                    "lang" : "en",
-                    "url" : "https://ssm.scielo.br/media/assets/abc/v1n3s2/en_article.pdf",
-                    "type" : "pdf"
-                },
-            ]
-        }
-        article = utils.makeOneArticle(attrib)
-        mk_article_objects.only.return_value.filter.return_value.first.side_effect = [
-            None, article
-        ]
-        article_filter_results = [None, attrib['pdfs'][0]["url"]]
-        for filter_result in article_filter_results:
-            with self.subTest(filter_result=filter_result):
-                result = controllers.get_article_by_pdf_filename(
-                    "abc", "v1n3s2", "article.pdf"
-                )
-                self.assertEqual(result, filter_result)
-
 
 class UserControllerTestCase(BaseTestCase):
 
@@ -1467,7 +1437,7 @@ class PageControllerTestCase(BaseTestCase):
         """
         page = self._make_one()
         self.assertEqual(
-            [page.language for page in controllers.get_pages()], 
+            [page.language for page in controllers.get_pages()],
             [page['language']])
         self.assertEqual(
             [page.language for page in controllers.get_pages_by_lang(


### PR DESCRIPTION
#### O que esse PR faz?

Esse PR tem como objetivo adiciona a capacidade o site novo passar a atenter URL legadas em que o processamento dos artigos tenham sido executado pelo OPAC-AirFLow.

Com o processamento do **opac-airflow** o armazenamento das URL para os PDFs mudaram e passaram a não mas preservar o nome do arquivo.

Recentemente adicionamos um novo campo no modelo do opac para garantir que tenhamos a resolução das URL atendidas após essa mudança, exemplo de URL: 

http://www.scielo.br/pdf/aob/v27n2/1809-4406-aob-27-02-0080.pdf
http://www.scielo.br/pdf/aem/v63n2/2359-4292-aem-2359-3997000000120.pdf 

#### Onde a revisão poderia começar?

A alteração desse PR está basicamente no módulo **opac/webapp/controllers.py**

#### Como este poderia ser testado manualmente?

Para testar manualmente é possível contento na base local um registro como a imagem a baixo:

<img width="1050" alt="Screenshot 2020-01-22 10 26 14" src="https://user-images.githubusercontent.com/373745/72897859-a8887c00-3d01-11ea-9414-cb6e5e3c3def.png">

E acessando esse registro com a seguinte URL: 
http://www.scielo.br/pdf/cta/v39s2/FILENAME

#### Algum cenário de contexto que queira dar?

Foi necessário remover o teste **test_get_article_by_pdf_filename_returns_article_filter_result**, pois a função controllers:get_article_by_pdf_filename passou a não satisfazê-ló. 

### Screenshots
N/A

#### Quais são tickets relevantes?

O tíquete referente a essa atividade é: https://github.com/scieloorg/opac/issues/1495

### Referências

O tíquete https://github.com/scieloorg/opac-airflow/issues/115 está relacionado.



