### PR TITLE
Adiciona um arquivo de fixture com os PIDs dos artigo na versão em HTML e um command manager que permite atualizar os caminhos dos registros de artigo

### DIFF
--- a/opac/manager.py
+++ b/opac/manager.py
@@ -335,6 +335,49 @@ def populate_database(domain="http://127.0.0.1", filename="fixtures/default_info
 
 
 @manager.command
+@manager.option('-f', '--filename', dest="filename")
+def populate_pdfs_path_html_version(filename="fixtures/pdfs_path_file_html_version.json"):
+    """
+    Esse comando tem como responsabilidade enriquecer os registros de artigos com o caminho da URL do site anterior para os PDFs.
+
+    Além do nome dos arquivos em PDF o site precisa dos caminhos dos PDFs para que seja possível resolver URLs como http://www.scielo.br/pdf/aa/v36n2/v36n2a09.pdf
+
+    O arquivo ``fixtures/pdfs_path_file_html_version.json` é extraído uma única vez, contendo todos os PIDs da versão HTML, caminho dos PDFs e idioma.
+
+    Estrutura do arquivo: ``pdfs_path_file_html_version.json``:
+
+    [
+      {
+        "pid": "S0044-59672004000100001",
+        "file_path": "/pdf/aa/v34n1/v34n1a01.pdf",
+        "lang": "pt"
+      },
+    ]
+
+    """
+
+    with open(filename) as fp:
+
+        data_json = json.load(fp)
+
+    for art_pdf_path in data_json:
+
+        art = controllers.get_article_by_pid(art_pdf_path['pid'])
+
+        if art.pdfs:
+            for pdf in art.pdfs:
+                if art_pdf_path.get('lang', '') == pdf.get('lang'):
+                    pdf['file_path'] = art_pdf_path.get('file_path')
+
+            art.save()
+
+            print("PDF do PID: %s atualizado com sucesso, caminho %s" % (art_pdf_path.get('pid'), art_pdf_path.get('file_path')))
+        else:
+
+            print("PDF do PID: %s não encontrado na base de dados do OPAC." % (art_pdf_path.get('pid')))
+
+
+@manager.command
 def populate_journal_pages():
     """
     Esse comando faz o primeiro registro das páginas secundárias


### PR DESCRIPTION

#### O que esse PR faz?
Adiciona um arquivo de fixture com os PIDs dos artigo na versão em HTML e um command manager que permite atualizar os registros de articgo da aplicação com o caminho dos PDFs

#### Onde a revisão poderia começar?

A revisão pode iniciar nos seguintes arquivo: 

- opac/manager.py
- opac/fixtures/pdfs_path_file_html_version.json

#### Como este poderia ser testado manualmente?
 Para testar manualmente é necessário uma base de dados com alguns registros para que possamos executar os seguinte commando: ```python manager.py populate_pdfs_path_html_version```

Uma tela de exemplo da saída: 

![Screenshot 2020-01-28 14 43 36](https://user-images.githubusercontent.com/373745/73297089-aafb4200-41e9-11ea-9a7e-4253bf5aae08.png)

#### Algum cenário de contexto que queira dar?

O arquivo **.json** é somente do SciELO Brasil (SCL).

#### Quais são tickets relevantes?

#1511

### Referências

- https://github.com/scieloorg/opac/issues/1495
- https://github.com/scieloorg/opac-airflow/pull/149
- https://github.com/scieloorg/opac-airflow/issues/115

