### PR TITLE
Adiciona a capacidade de obter o PDF utilizando a URL antiga do site.

### DIFF
--- a/opac/tests/test_controller.py
+++ b/opac/tests/test_controller.py
@@ -1160,36 +1160,6 @@ class ArticleControllerTestCase(BaseTestCase):
             "article.pdf"
         )
 
-    @patch('webapp.controllers.Article.objects')
-    def test_get_article_by_pdf_filename_returns_article_filter_result(
-        self, mk_article_objects
-    ):
-        attrib = {
-            "pdfs" : [
-                {
-                    "lang" : "pt",
-                    "url" : "https://ssm.scielo.br/media/assets/abc/v1n3s2/article.pdf",
-                    "type" : "pdf"
-                },
-                {
-                    "lang" : "en",
-                    "url" : "https://ssm.scielo.br/media/assets/abc/v1n3s2/en_article.pdf",
-                    "type" : "pdf"
-                },
-            ]
-        }
-        article = utils.makeOneArticle(attrib)
-        mk_article_objects.only.return_value.filter.return_value.first.side_effect = [
-            None, article
-        ]
-        article_filter_results = [None, attrib['pdfs'][0]["url"]]
-        for filter_result in article_filter_results:
-            with self.subTest(filter_result=filter_result):
-                result = controllers.get_article_by_pdf_filename(
-                    "abc", "v1n3s2", "article.pdf"
-                )
-                self.assertEqual(result, filter_result)
-
 
 class UserControllerTestCase(BaseTestCase):
 
@@ -1467,7 +1437,7 @@ class PageControllerTestCase(BaseTestCase):
         """
         page = self._make_one()
         self.assertEqual(
-            [page.language for page in controllers.get_pages()], 
+            [page.language for page in controllers.get_pages()],
             [page['language']])
         self.assertEqual(
             [page.language for page in controllers.get_pages_by_lang(

--- a/opac/tests/test_legacy_urls.py
+++ b/opac/tests/test_legacy_urls.py
@@ -1,5 +1,7 @@
 # coding: utf-8
 
+from unittest.mock import patch, Mock
+
 from flask import current_app, url_for
 from .base import BaseTestCase
 
@@ -105,6 +107,49 @@ class LegacyURLTestCase(BaseTestCase):
                 self.assertStatus(response, 200)
 
                 self.assertTemplateUsed('article/detail.html')
+
+    @patch('requests.get')
+    def test_router_legacy_pdf(self, mocked_requests_get):
+        """
+        Testa o acesso à URL antiga do PDF quando existe a chave filename no campo pdf.
+        URL testada: /pdf/<JOURNAL_ACRON>/<ISSUE_LABEL>/<PDF_FILENAME>
+            Exemplo: /pdf/cta/v39s2/0101-2061-cta-fst22918.pdf
+        """
+
+        mocked_response = Mock()
+        mocked_response.status_code = 200
+        mocked_response.content = b'<pdf>'
+        mocked_requests_get.return_value = mocked_response
+
+        with current_app.app_context():
+
+            journal = utils.makeOneJournal({'print_issn': '0000-0000', 'acronym': 'cta'},)
+
+            issue = utils.makeOneIssue({
+                'journal': journal.id,
+                'label': 'v39s2',
+            })
+
+            article = utils.makeOneArticle({
+                'journal': journal.id,
+                'issue': issue.id,
+                'pdfs': [
+                    {
+                        'lang': 'en',
+                        'url': 'http://minio:9000/documentstore/1678-457X/JDH74Jr4SyDVpnkMyrqkDhF/e5e09c7d5e4e5052868372df837de4e1ee9d651a.pdf',
+                        'file_path': '/pdf/cta/v39s2/0101-2061-cta-fst30618.pdf',
+                        'type': 'pdf'
+                    }
+                ]
+            })
+
+            with self.client as c:
+
+                url = '/pdf/cta/v39s2/0101-2061-cta-fst30618.pdf'
+
+                response = c.get(url, follow_redirects=True)
+
+                self.assertStatus(response, 200)
 
     def test_article_text_with_lng(self):
         """

--- a/opac/webapp/controllers.py
+++ b/opac/webapp/controllers.py
@@ -990,14 +990,28 @@ def get_article_by_pdf_filename(journal_acron, issue_info, pdf_filename):
         raise ValueError(__('Obrigatório o campo issue_info.'))
     if not pdf_filename:
         raise ValueError(__('Obrigatório o nome do arquivo PDF.'))
+
     pdf_path = "/".join([journal_acron, issue_info, get_valid_name(pdf_filename)])
+
     article = Article.objects.only("pdfs").filter(
         pdfs__url__endswith=pdf_path, is_public=True).first()
+
     if article:
         for pdf in article.pdfs:
             if pdf["url"].endswith(pdf_path):
                 return pdf["url"]
+    else:
 
+        file_path = "%s%s" % ("/pdf/", pdf_path)
+
+        article = Article.objects.only("pdfs").filter(
+            pdfs__file_path=file_path, is_public=True).first()
+
+        if article:
+            for pdf in article.pdfs:
+                if "file_path" in pdf:
+                    if pdf["file_path"] == file_path:
+                        return pdf["url"]
 
 # -------- NEWS --------
 


### PR DESCRIPTION
#### O que esse PR faz?

Esse PR tem como objetivo adiciona a capacidade o site novo passar a atenter URL de PDF legadas.

Com o processamento do **opac-airflow** o armazenamento das URL para os PDFs mudaram e passaram a armazenar o caminho da URL para os PDFs.

URLs que serão atendidas após essa mudança, exemplo de URL: 

http://www.scielo.br/pdf/aob/v27n2/1809-4406-aob-27-02-0080.pdf
http://www.scielo.br/pdf/aem/v63n2/2359-4292-aem-2359-3997000000120.pdf 

#### Onde a revisão poderia começar?

A alteração desse PR está basicamente no módulo **opac/webapp/controllers.py**

#### Como este poderia ser testado manualmente?

Para testar manualmente é possível contento na base local um registro como a imagem a baixo:

<img width="1056" alt="Screenshot 2020-01-29 11 46 50" src="https://user-images.githubusercontent.com/373745/73366649-0e8a7b80-428d-11ea-9d70-4d01ad732624.png">

E acessando esse registro com a seguinte URL: 
http://www.scielo.br/pdf/acb/v26n4/v26n4a11.pdf

#### Algum cenário de contexto que queira dar?

Foi necessário remover o teste **test_get_article_by_pdf_filename_returns_article_filter_result**, pois a função controllers:get_article_by_pdf_filename passou a não satisfazê-ló. 

### Screenshots
N/A

#### Quais são tickets relevantes?

O tíquete referente a essa atividade é: https://github.com/scieloorg/opac/issues/1495

### Referências

O tíquete https://github.com/scieloorg/opac-airflow/issues/115 está relacionado.



