### PR TITLE
Adiciona suporte as URLs antigas do site classico

### DIFF
--- a/opac/tests/test_main_views.py
+++ b/opac/tests/test_main_views.py
@@ -302,6 +302,47 @@ class MainTestCase(BaseTestCase):
                           response.data.decode('utf-8'))
             self.assertEqual(self.get_context_variable('journal').id, journal.id)
 
+    def test_journal_detail_legacy_url(self):
+        """
+        Teste da ``view function`` ``journal_detail_legacy_url``, deve retorna status_code 301
+        """
+
+        with current_app.app_context():
+
+            utils.makeOneCollection()
+
+            journal = utils.makeOneJournal({'title': 'Revista X'})
+
+            response = self.client.get(url_for(
+                                       'main.journal_detail_legacy_url', journal_seg=journal.url_segment)
+                                       )
+
+            self.assertTrue(301, response.status_code)
+
+    def test_journal_detail_legacy_url_follow_redirect(self):
+        """
+        Teste da ``view function`` ``journal_detail_legacy_url``, deve retornar uma página
+        que usa o template ``journal/detail.html`` e o título do periódico no
+        corpo da página.
+        """
+
+        with current_app.app_context():
+
+            utils.makeOneCollection()
+
+            journal = utils.makeOneJournal({'title': 'Revista X'})
+
+            response = self.client.get(
+                                    url_for(
+                                       'main.journal_detail_legacy_url', journal_seg=journal.url_segment),
+                                    follow_redirects=True)
+
+            self.assertTrue(200, response.status_code)
+            self.assertTemplateUsed('journal/detail.html')
+            self.assertIn('Revista X',
+                          response.data.decode('utf-8'))
+            self.assertEqual(self.get_context_variable('journal').id, journal.id)
+
     def test_journal_detail_with_unknow_id(self):
         """
         Teste da ``view function`` ``journal_detail`` com um id desconhecido

--- a/opac/webapp/main/views.py
+++ b/opac/webapp/main/views.py
@@ -428,6 +428,13 @@ def router_legacy():
         return redirect('/')
 
 
+@main.route('/<string:journal_seg>')
+def journal_detail_legacy_url(journal_seg):
+
+    return redirect(url_for('main.journal_detail',
+                            url_seg=journal_seg), code=301)
+
+
 @main.route('/journal/<string:url_seg>/')
 @cache.cached(key_prefix=cache_key_with_lang)
 def journal_detail(url_seg):


### PR DESCRIPTION
#### O que esse PR faz?

Esse PR tem o objetivo de adicionar suporte as URLs para os **periódicos** do site clássico.

Exemplo: 
http://www.scielo.br/rae 

A idéia é que a URL http://new.scielo.br/rae seja redirecionado para http://new.scielo.br/journal/rae.

#### Onde a revisão poderia começar?

- opac/webapp/main/views.py:431

Rodar os testes: 

`make dev_compose_make_test`

#### Como este poderia ser testado manualmente?

Acessar em uma instância do OPAC a URL  http://new.scielo.br/ACRON

#### Algum cenário de contexto que queira dar?

Não foi realizado qualquer validação do impacto dessa mudança nos logs de acessos coletados pelos arquivo de logs no **nginx**.

### Screenshots
Nenhum

#### Quais são tickets relevantes?
#1523 

### Referências
Nenhum

