### PR TITLE
Adicionar suporte as URLs das páginas informativas

### DIFF
--- a/opac/tests/test_utils_journal_static_page.py
+++ b/opac/tests/test_utils_journal_static_page.py
@@ -4,6 +4,9 @@ import os
 import unittest
 from .base import BaseTestCase
 
+from flask import current_app, url_for
+
+from . import utils
 from webapp.utils.journal_static_page import (
     OldJournalPageFile,
 )
@@ -268,3 +271,63 @@ class OldJournalPageTestCase(BaseTestCase):
     def _count_antes_e_depois(self, file_content, body, text, antes=0, depois=0):
         self.assertEqual(file_content.count(text), antes)
         self.assertEqual(body.count(text), depois)
+
+    def test_legacy_info_page_iaboutj(self):
+        """
+        Teste da ``view function`` ``router_legacy_info_pages``, deve retorna status_code 301 para a página iaboutj
+        """
+
+        with current_app.app_context():
+
+            utils.makeOneCollection()
+
+            journal = utils.makeOneJournal({'title': 'Revista X', 'acronym': 'acron_ia'})
+
+            response = self.client.get("/revistas/%s/iaboutj.htm" % journal.url_segment)
+
+            self.assertTrue(301, response.status_code)
+
+    def test_legacy_info_page_edboard(self):
+        """
+        Teste da ``view function`` ``router_legacy_info_pages``, deve retorna status_code 301 para a página edboard
+        """
+
+        with current_app.app_context():
+
+            utils.makeOneCollection()
+
+            journal = utils.makeOneJournal({'title': 'Revista X', 'acronym': 'acron_ed'})
+
+            response = self.client.get("/revistas/%s/edboard.htm" % journal.url_segment)
+
+            self.assertTrue(301, response.status_code)
+
+    def test_legacy_info_page_iinstruc(self):
+        """
+        Teste da ``view function`` ``router_legacy_info_pages``, deve retorna status_code 301 para a página iinstruc
+        """
+
+        with current_app.app_context():
+
+            utils.makeOneCollection()
+
+            journal = utils.makeOneJournal({'title': 'Revista X', 'acronym': 'acron_ii'})
+
+            response = self.client.get("/revistas/%s/iinstruc.htm" % journal.url_segment)
+
+            self.assertTrue(301, response.status_code)
+
+    def test_legacy_info_page_isubscrp(self):
+        """
+        Teste da ``view function`` ``router_legacy_info_pages``, deve retorna status_code 301 para a página isubscrp
+        """
+
+        with current_app.app_context():
+
+            utils.makeOneCollection()
+
+            journal = utils.makeOneJournal({'title': 'Revista X', 'acronym': 'acron_isu'})
+
+            response = self.client.get("/revistas/%s/isubscrp.htm" % journal.url_segment)
+
+            self.assertTrue(301, response.status_code)

--- a/opac/webapp/main/views.py
+++ b/opac/webapp/main/views.py
@@ -1222,7 +1222,7 @@ def router_legacy_article(text_or_abstract):
     )
 
 
-# ###############################E-mail share####################################
+# ###############################E-mail share##################################
 
 
 @main.route("/email_share_ajax/", methods=['POST'])
@@ -1290,7 +1290,7 @@ def error_form():
     return render_template("includes/error_form.html", **context)
 
 
-# ##################################Others#######################################
+# ###############################Others########################################
 
 
 @main.route("/media/<path:filename>/", methods=['GET'])
@@ -1308,3 +1308,33 @@ def full_text_image():
 @main.route("/robots.txt", methods=['GET'])
 def get_robots_txt_file():
     return send_from_directory('static', 'robots.txt')
+
+
+@main.route("/revistas/<path:journal_seg>/<string:page>.htm", methods=['GET'])
+def router_legacy_info_pages(journal_seg, page):
+    """
+    Essa view function realiza o redirecionamento das URLs antigas para as novas URLs.
+
+    Mantém um dicionário como uma tabela relacionamento entre o nome das páginas que pode ser:
+
+       Página      âncora
+
+    [iaboutj.htm, eaboutj.htm, paboutj.htm] -> #about
+    [iedboard.htm, eedboard.htm, pedboard.htm] -> #editors
+    [iinstruc.htm einstruc.htm, pinstruc.htm]-> #instructions
+    isubscrp.htm -> Sem âncora
+    """
+
+    page_anchor = {
+        'iaboutj': '#about',
+        'eaboutj': '#about',
+        'paboutj': '#about',
+        'eedboard': '#editors',
+        'iedboard': '#editors',
+        'pedboard': '#editors',
+        'iinstruc': '#instructions',
+        'pinstruc': '#instructions',
+        'einstruc': '#instructions'
+        }
+    return redirect('%s%s' % (url_for('main.about_journal',
+                                      url_seg=journal_seg), page_anchor.get(page, '')), code=301)


### PR DESCRIPTION
#### O que esse PR faz?
Adiciona suporte para as seguintes URL das páginas informativas no novo site: 

- http://www.scielo.br/revistas/rpc/iaboutj.htm
- http://www.scielo.br/revistas/rpc/iedboard.htm
- http://www.scielo.br/revistas/rpc/iinstruc.htm
- http://www.scielo.br/revistas/rpc/isubscrp.htm

#### Onde a revisão poderia começar?

- opac/webapp/main/views.py:1313
- opac/tests/test_utils_journal_static_page.py

#### Como este poderia ser testado manualmente?

Acessando uma instância pela URL informada acima e ou rodando os testes: 

`export OPAC_CONFIG="config/templates/testing.template" && python opac/manager.py test test_utils_journal_static_page`

#### Algum cenário de contexto que queira dar?
N/A.

### Screenshots
N/A.

#### Quais são tickets relevantes?

#1535 

### Referências
N/A.

