### PR TITLE
Corrigi o caminho para os PDFs no modal.

### DIFF
--- a/opac/tests/test_main_views.py
+++ b/opac/tests/test_main_views.py
@@ -1428,6 +1428,75 @@ class MainTestCase(BaseTestCase):
         self.assertStatus(response, 404)
         self.assertIn(unpublish_reason, response.data.decode('utf-8'))
 
+    def test_pdf_url(self):
+        """
+        Testa se as URLs para os PDFs estão sendo montados com seus respectivos idiomas.
+
+        Exemplo de URL para o PDF: ``/pdf/ssp/2001.v78/e937749/en``
+        """
+
+        with current_app.app_context():
+
+            journal = utils.makeOneJournal({'print_issn': '0000-0000', 'acronym': 'cta'},)
+
+            issue = utils.makeOneIssue({
+                'journal': journal.id,
+                'label': 'v39s2',
+                'year': '2009',
+                'volume': '39',
+                'number': '1',
+                'suppl_text': '',
+            })
+
+            article = utils.makeOneArticle({
+                'journal': journal.id,
+                'issue': issue.id,
+                'elocation': 'e1',
+                'pdfs': [
+                    {
+                        'lang': 'en',
+                        'url': 'http://minio:9000/documentstore/1678-457X/JDH74Jr4SyDVpnkMyrqkDhF/e5e09c7d5e4e5052868372df837de4e1ee9d651aen.pdf',
+                        'file_path': '/pdf/cta/v39s2/0101-2061-cta-fst30618-en.pdf',
+                        'type': 'pdf'
+                    },
+                    {
+                        'lang': 'pt',
+                        'url': 'http://minio:9000/documentstore/1678-457X/JDH74Jr4SyDVpnkMyrqkDhF/e5e09c7d5e4e5052868372df837de4e1ee9d651apt.pdf',
+                        'file_path': '/pdf/cta/v39s2/0101-2061-cta-fst30618-pt.pdf',
+                        'type': 'pdf'
+                    },
+                    {
+                        'lang': 'es',
+                        'url': 'http://minio:9000/documentstore/1678-457X/JDH74Jr4SyDVpnkMyrqkDhF/e5e09c7d5e4e5052868372df837de4e1ee9d651aes.pdf',
+                        'file_path': '/pdf/cta/v39s2/0101-2061-cta-fst30618-es.pdf',
+                        'type': 'pdf'
+                    }
+                ]
+            })
+
+            response = self.client.get(url_for('main.article_detail',
+                                               url_seg=journal.url_segment,
+                                               url_seg_issue=issue.url_segment,
+                                               url_seg_article=article.url_segment,
+                                               lang_code='en'), follow_redirects=False)
+
+            self.assertStatus(response, 200)
+            self.assertTemplateUsed('article/detail.html')
+
+            content = response.data.decode('utf-8')
+            self.assertIn(
+                '/pdf/cta/2009.v39n1/e1/en',
+                content
+            )
+            self.assertIn(
+                '/pdf/cta/2009.v39n1/e1/pt',
+                content
+            )
+            self.assertIn(
+                '/pdf/cta/2009.v39n1/e1/pt',
+                content
+            )
+
     # HOMEPAGE
 
     def test_collection_sponsors_at_homepage(self):

--- a/opac/webapp/templates/article/includes/modal/download.html
+++ b/opac/webapp/templates/article/includes/modal/download.html
@@ -17,7 +17,7 @@
             {% if article and article.pdfs %}
               {% for pdf in article.pdfs  %}
                 <li>
-                  <a target='_blank' href="{{ url_for('.article_detail_pdf', url_seg=article.journal.url_segment, url_seg_issue=article.issue.url_segment, url_seg_article=article.url_segment) }}">
+                  <a target='_blank' href="{{ url_for('.article_detail_pdf', url_seg=article.journal.url_segment, url_seg_issue=article.issue.url_segment, url_seg_article=article.url_segment, lang_code=pdf.lang) }}">
                     {% if pdf.lang == 'es' %}
                       {% trans %}Espanhol{% endtrans %}
                     {% elif pdf.lang == 'en' %}


### PR DESCRIPTION
#### O que esse PR faz?

Corrigi o caminho para o PDF no modal da página do artigo

#### Onde a revisão poderia começar?

opac/tests/test_main_views.py:1431
opac/webapp/templates/article/includes/modal/download.html:20

#### Como este poderia ser testado manualmente?

Acessando uma instância do site com o PR aplicado e verificar se as URLs para os PDFs estão considerando o idioma. 

#### Algum cenário de contexto que queira dar?
N/A

### Screenshots

<img width="1594" alt="Screenshot 2020-03-06 11 08 00" src="https://user-images.githubusercontent.com/373745/76090683-c1d84580-5f9a-11ea-8933-9032cca55aaf.png">


#### Quais são tickets relevantes?
#1531 

### Referências
N/A

