### PR TITLE
Altera padrão da URL dos documentos

### DIFF
--- a/opac/tests/test_interface_menu.py
+++ b/opac/tests/test_interface_menu.py
@@ -414,7 +414,7 @@ class MenuTestCase(BaseTestCase):
                 self.assertIn(btn, response.data.decode('utf-8'))
 
     # Article Menu
-    def test_article_detail_menu(self):
+    def test_article_detail_v3_menu(self):
         """
         Teste para verificar se os botões estão ``anterior``, ``atual``,
         ``próximo`` estão disponíveis no ``article/detail.html``.
@@ -453,10 +453,9 @@ class MenuTestCase(BaseTestCase):
             })
 
             article_detail_url = url_for(
-                'main.article_detail',
+                'main.article_detail_v3',
                 url_seg=journal.url_segment,
-                url_seg_issue=issue.url_segment,
-                url_seg_article=article2.url_segment)
+                article_pid_v3=article2.aid)
 
             response = self.client.get(article_detail_url)
 
@@ -464,18 +463,16 @@ class MenuTestCase(BaseTestCase):
             self.assertTemplateUsed('article/detail.html')
 
             expect_btn_anterior = '<a href="%s" class="btn group">' % url_for(
-                '.article_detail',
+                '.article_detail_v3',
                 url_seg=journal.url_segment,
-                url_seg_issue=issue.url_segment,
-                url_seg_article=article1.url_segment)  # artigo anterior
+                article_pid_v3=article1.aid)  # artigo anterior
 
             expect_btn_atual = '<a href="#" class="btn group disabled">'  # número atual
 
             expect_btn_proximo = '<a href="%s" class="btn group">' % url_for(
-                '.article_detail',
+                '.article_detail_v3',
                 url_seg=journal.url_segment,
-                url_seg_issue=issue.url_segment,
-                url_seg_article=article3.url_segment)  # artigo seguinte
+                article_pid_v3=article3.aid)  # artigo seguinte
 
             expected_btns = [expect_btn_anterior, expect_btn_atual, expect_btn_proximo]
 
@@ -483,7 +480,7 @@ class MenuTestCase(BaseTestCase):
             for btn in expected_btns:
                 self.assertIn(btn, response.data.decode('utf-8'))
 
-    def test_article_detail_menu_when_last_article(self):
+    def test_article_detail_v3_menu_when_last_article(self):
         """
         Teste para verificar se os botões estão ``anterior``, ``atual``,
         ``próximo`` estão disponíveis no ``article/detail.html`` quando é o
@@ -523,10 +520,9 @@ class MenuTestCase(BaseTestCase):
             })
 
             article_detail_url = url_for(
-                'main.article_detail',
+                'main.article_detail_v3',
                 url_seg=journal.url_segment,
-                url_seg_issue=issue.url_segment,
-                url_seg_article=article3.url_segment)
+                article_pid_v3=article3.aid)
 
             response = self.client.get(article_detail_url)
 
@@ -538,10 +534,9 @@ class MenuTestCase(BaseTestCase):
             expect_btn_atual = '<a href="#" class="btn group disabled">'  # número atual
 
             expect_btn_proximo = '<a href="%s" class="btn group">' % url_for(
-                '.article_detail',
+                '.article_detail_v3',
                 url_seg=journal.url_segment,
-                url_seg_issue=issue.url_segment,
-                url_seg_article=article2.url_segment)  # artigo seguinte
+                article_pid_v3=article2.aid)  # artigo seguinte
 
             expected_btns = [expect_btn_anterior, expect_btn_atual, expect_btn_proximo]
 
@@ -549,7 +544,7 @@ class MenuTestCase(BaseTestCase):
             for btn in expected_btns:
                 self.assertIn(btn, response.data.decode('utf-8'))
 
-    def test_article_detail_menu_when_first_article(self):
+    def test_article_detail_v3_menu_when_first_article(self):
         """
         Teste para verificar se os botões estão ``anterior``, ``atual``,
         ``próximo`` estão disponíveis no ``article/detail.html`` quando é o
@@ -587,10 +582,9 @@ class MenuTestCase(BaseTestCase):
             })
 
             article_detail_url = url_for(
-                'main.article_detail',
+                'main.article_detail_v3',
                 url_seg=journal.url_segment,
-                url_seg_issue=issue.url_segment,
-                url_seg_article=article1.url_segment)
+                article_pid_v3=article1.aid)
 
             response = self.client.get(article_detail_url)
 
@@ -602,10 +596,9 @@ class MenuTestCase(BaseTestCase):
             expect_btn_atual = '<a href="#" class="btn group disabled">'  # número atual
 
             expect_btn_proximo = '<a href="%s" class="btn group">' % url_for(
-                '.article_detail',
+                '.article_detail_v3',
                 url_seg=journal.url_segment,
-                url_seg_issue=issue.url_segment,
-                url_seg_article=article2.url_segment)  # artigo seguinte
+                article_pid_v3=article2.aid)  # artigo seguinte
 
             expected_btns = [
                 expect_btn_anterior,

--- a/opac/tests/test_main_views.py
+++ b/opac/tests/test_main_views.py
@@ -759,7 +759,7 @@ class MainTestCase(BaseTestCase):
 
     # ARTICLE
 
-    def test_article_detail(self):
+    def test_article_detail_v3(self):
         """
         Teste da ``view function`` ``article_detail``, deve retornar uma página
         que usa o template ``article/detail.html``.
@@ -783,10 +783,9 @@ class MainTestCase(BaseTestCase):
                                             'journal': journal,
                                             'url_segment': '10-11'})
 
-            response = self.client.get(url_for('main.article_detail',
+            response = self.client.get(url_for('main.article_detail_v3',
                                                url_seg=journal.url_segment,
-                                               url_seg_issue=issue.url_segment,
-                                               url_seg_article=article.url_segment,
+                                               article_pid_v3=article.aid,
                                                lang_code='en'))
 
             self.assertStatus(response, 200)
@@ -888,10 +887,9 @@ class MainTestCase(BaseTestCase):
                                                 ]
                                             })
 
-            response = self.client.get(url_for('main.article_detail',
+            response = self.client.get(url_for('main.article_detail_v3',
                                                url_seg=journal.url_segment,
-                                               url_seg_issue=issue.url_segment,
-                                               url_seg_article=article.url_segment,
+                                               article_pid_v3=article.aid,
                                                lang_code='pt'))
 
             self.assertStatus(response, 200)
@@ -899,10 +897,9 @@ class MainTestCase(BaseTestCase):
             content = response.data.decode('utf-8')
 
             urls = {html['lang']: url_for(
-                                   'main.article_detail',
+                                   'main.article_detail_v3',
                                    url_seg=journal.url_segment,
-                                   url_seg_issue=issue.url_segment,
-                                   url_seg_article=article.url_segment,
+                                   article_pid_v3=article.aid,
                                    lang_code=html['lang'])
                     for html in article.htmls
                     }
@@ -953,10 +950,9 @@ class MainTestCase(BaseTestCase):
                                                 ]
                                             })
 
-            response = self.client.get(url_for('main.article_detail',
+            response = self.client.get(url_for('main.article_detail_v3',
                                                url_seg=journal.url_segment,
-                                               url_seg_issue=issue.url_segment,
-                                               url_seg_article=article.url_segment,
+                                               article_pid_v3=article.aid,
                                                lang_code='pt'))
 
             self.assertStatus(response, 200)
@@ -1009,10 +1005,9 @@ class MainTestCase(BaseTestCase):
                                                 ]
                                             })
 
-            response = self.client.get(url_for('main.article_detail',
+            response = self.client.get(url_for('main.article_detail_v3',
                                                url_seg=journal.url_segment,
-                                               url_seg_issue=issue.url_segment,
-                                               url_seg_article=article.url_segment,
+                                               article_pid_v3=article.aid,
                                                lang_code='es'))
 
             self.assertStatus(response, 200)
@@ -1045,10 +1040,9 @@ class MainTestCase(BaseTestCase):
                                             'journal': journal,
                                             'url_segment': '10-11'})
 
-            response = self.client.get(url_for('main.article_detail',
+            response = self.client.get(url_for('main.article_detail_v3',
                                                url_seg=journal.url_segment,
-                                               url_seg_issue=issue.url_segment,
-                                               url_seg_article=article.url_segment,
+                                               article_pid_v3=article.aid,
                                                lang_code='pt'))
 
             self.assertStatus(response, 200)
@@ -1065,7 +1059,7 @@ class MainTestCase(BaseTestCase):
             self.assertIn('Google', page_content)
             self.assertIn('/scholar', page_content)
 
-    def test_article_detail_links_to_gscholar_for_article_without_title(self):
+    def test_article_detail_v3_links_to_gscholar_for_article_without_title(self):
         """
         Teste da ``view function`` ``article_detail``, deve retornar uma página
         que usa o template ``article/detail.html``.
@@ -1082,10 +1076,9 @@ class MainTestCase(BaseTestCase):
                                             'journal': journal,
                                             'url_segment': '10-11'})
 
-            response = self.client.get(url_for('main.article_detail',
+            response = self.client.get(url_for('main.article_detail_v3',
                                                url_seg=journal.url_segment,
-                                               url_seg_issue=issue.url_segment,
-                                               url_seg_article=article.url_segment,
+                                               article_pid_v3=article.aid,
                                                lang_code='pt'))
 
             self.assertStatus(response, 200)
@@ -1286,7 +1279,7 @@ class MainTestCase(BaseTestCase):
             self.assertStatus(response, 404)
             self.assertIn('Artigo não encontrado', response.data.decode('utf-8'))
 
-    def test_legacy_url_redirects_to_article_detail(self):
+    def test_legacy_url_redirects_to_article_detail_v3(self):
         """
         Teste da view ``router_legacy_article``, deve retornar redirecionar
         para os detalhes do artigo (main.article_detail)
@@ -1317,15 +1310,14 @@ class MainTestCase(BaseTestCase):
             self.assertRedirects(
                 response,
                 url_for(
-                    'main.article_detail',
+                    'main.article_detail_v3',
                     url_seg=journal.url_segment,
-                    url_seg_issue=issue.url_segment,
-                    url_seg_article=article.url_segment,
+                    article_pid_v3=article.aid,
                     lang_code='en'
                 ),
             )
 
-    def test_article_detail_without_articles(self):
+    def test_article_detail_v3_without_articles(self):
         """
         Teste para avaliar o retorno da ``view function`` ``article_detail``
         quando não existe artigos cadastrados deve retornar ``status_code`` 404
@@ -1336,16 +1328,15 @@ class MainTestCase(BaseTestCase):
 
         issue = utils.makeOneIssue({'journal': journal})
 
-        response = self.client.get(url_for('main.article_detail',
+        response = self.client.get(url_for('main.article_detail_v3',
                                            url_seg=journal.url_segment,
-                                           url_seg_issue=issue.url_segment,
-                                           url_seg_article='9827-817',
+                                           article_pid_v3='invalidpid',
                                            lang_code='pt'))
 
         self.assertStatus(response, 404)
         self.assertIn('Artigo não encontrado', response.data.decode('utf-8'))
 
-    def test_article_detail_with_journal_attrib_is_public_false(self):
+    def test_article_detail_v3_with_journal_attrib_is_public_false(self):
         """
         Teste da ``view function`` ``article_detail`` acessando um artigo
         com atributo is_public=True, porém com um periódico com atributo
@@ -1365,16 +1356,15 @@ class MainTestCase(BaseTestCase):
             'issue': issue,
             'journal': journal})
 
-        response = self.client.get(url_for('main.article_detail',
+        response = self.client.get(url_for('main.article_detail_v3',
                                            url_seg=journal.url_segment,
-                                           url_seg_issue=issue.url_segment,
-                                           url_seg_article=article.url_segment,
+                                           article_pid_v3=article.aid,
                                            lang_code='pt'))
 
         self.assertStatus(response, 404)
         self.assertIn(unpublish_reason, response.data.decode('utf-8'))
 
-    def test_article_detail_with_issue_attrib_is_public_false(self):
+    def test_article_detail_v3_with_issue_attrib_is_public_false(self):
         """
         Teste da ``view function`` ``article_detail`` acessando um artigo
         com atributo is_public=False, porém com um periódico com atributo
@@ -1393,16 +1383,15 @@ class MainTestCase(BaseTestCase):
             'issue': issue.id,
             'journal': journal.id})
 
-        response = self.client.get(url_for('main.article_detail',
+        response = self.client.get(url_for('main.article_detail_v3',
                                            url_seg=journal.url_segment,
-                                           url_seg_issue=issue.url_segment,
-                                           url_seg_article=article.url_segment,
+                                           article_pid_v3=article.aid,
                                            lang_code='pt'))
 
         self.assertStatus(response, 404)
         self.assertIn(unpublish_reason, response.data.decode('utf-8'))
 
-    def test_article_detail_with_article_attrib_is_public_false(self):
+    def test_article_detail_v3_with_article_attrib_is_public_false(self):
         """
         Teste da ``view function`` ``article_detail`` acessando um artigo
         com atributo is_public=False, deve retorna uma página com
@@ -1419,10 +1408,9 @@ class MainTestCase(BaseTestCase):
             'issue': issue,
             'journal': journal})
 
-        response = self.client.get(url_for('main.article_detail',
+        response = self.client.get(url_for('main.article_detail_v3',
                                            url_seg=journal.url_segment,
-                                           url_seg_issue=issue.url_segment,
-                                           url_seg_article=article.url_segment,
+                                           article_pid_v3=article.aid,
                                            lang_code='pt'))
 
         self.assertStatus(response, 404)
@@ -1474,10 +1462,9 @@ class MainTestCase(BaseTestCase):
                 ]
             })
 
-            response = self.client.get(url_for('main.article_detail',
+            response = self.client.get(url_for('main.article_detail_v3',
                                                url_seg=journal.url_segment,
-                                               url_seg_issue=issue.url_segment,
-                                               url_seg_article=article.url_segment,
+                                               article_pid_v3=article.aid,
                                                lang_code='en'), follow_redirects=False)
 
             self.assertStatus(response, 200)

--- a/opac/tests/test_main_views.py
+++ b/opac/tests/test_main_views.py
@@ -1471,18 +1471,10 @@ class MainTestCase(BaseTestCase):
             self.assertTemplateUsed('article/detail.html')
 
             content = response.data.decode('utf-8')
-            self.assertIn(
-                '/pdf/cta/2009.v39n1/e1/en',
-                content
-            )
-            self.assertIn(
-                '/pdf/cta/2009.v39n1/e1/pt',
-                content
-            )
-            self.assertIn(
-                '/pdf/cta/2009.v39n1/e1/pt',
-                content
-            )
+            base_resource = '/pdf/%s/%s' % (journal.url_segment, article.aid)
+            self.assertIn(base_resource + '/en', content)
+            self.assertIn(base_resource + '/es', content)
+            self.assertIn(base_resource + '/pt', content)
 
     # HOMEPAGE
 

--- a/opac/webapp/main/views.py
+++ b/opac/webapp/main/views.py
@@ -397,28 +397,14 @@ def router_legacy():
             return issue_grid(journal.url_segment)
 
         elif script_php == 'sci_pdf':
-            # accesso ao pdf do artigo:
             article = controllers.get_article_by_pid(pid)
-
-            if not article:
-                article = controllers.get_article_by_oap_pid(pid)
-
             if not article:
                 abort(404, _('Artigo não encontrado'))
 
-            if not article.is_public:
-                abort(404, ARTICLE_UNPUBLISH + _(article.unpublish_reason))
-
-            if not article.issue.is_public:
-                abort(404, ISSUE_UNPUBLISH + _(article.issue.unpublish_reason))
-
-            if not article.journal.is_public:
-                abort(404, JOURNAL_UNPUBLISH + _(article.journal.unpublish_reason))
-
-            return article_detail_pdf(
-                article.journal.url_segment,
-                article.issue.url_segment,
-                article.url_segment)
+            return redirect(url_for('main.article_detail_pdf_v3',
+                                    url_seg=article.journal.url_segment,
+                                    article_pid_v3=article.aid,
+                                    lang_code=tlng), code=301)
 
         else:
             abort(400, _(u'Requsição inválida ao tentar acessar o artigo com pid: %s' % pid))
@@ -1129,18 +1115,11 @@ def article_ssm_content_raw():
         return get_content_from_ssm(resource_ssm_path)
 
 
-@main.route('/pdf/<string:url_seg>/<string:url_seg_issue>/<string:url_seg_article>')
-@main.route('/pdf/<string:url_seg>/<string:url_seg_issue>/<string:url_seg_article>/<regex("(?:\w{2})"):lang_code>')
-@main.route('/pdf/<string:url_seg>/<string:url_seg_issue>/<regex("(.*)"):url_seg_article>')
-@main.route('/pdf/<string:url_seg>/<string:url_seg_issue>/<regex("(.*)"):url_seg_article>/<regex("(?:\w{2})"):lang_code>')
+@main.route('/pdf/<string:url_seg>/<string:article_pid_v3>')
+@main.route('/pdf/<string:url_seg>/<string:article_pid_v3>/<regex("(?:\w{2})"):lang_code>')
 @cache.cached(key_prefix=cache_key_with_lang)
-def article_detail_pdf(url_seg, url_seg_issue, url_seg_article, lang_code=''):
-    issue = controllers.get_issue_by_url_seg(url_seg, url_seg_issue)
-
-    if not issue:
-        abort(404, _('Issue não encontrado'))
-
-    article = controllers.get_article_by_issue_article_seg(issue.iid, url_seg_article)
+def article_detail_pdf_v3(url_seg, article_pid_v3, lang_code=''):
+    article = controllers.get_article_by_aid(article_pid_v3)
 
     if not article:
         abort(404, _('Artigo não encontrado'))
@@ -1181,6 +1160,30 @@ def article_detail_pdf(url_seg, url_seg_issue, url_seg_article, lang_code=''):
         raise abort(404, _('Recurso do Artigo não encontrado. Caminho inválido!'))
     else:
         return get_content_from_ssm(pdf_ssm_path)
+
+
+@main.route('/pdf/<string:url_seg>/<string:url_seg_issue>/<string:url_seg_article>')
+@main.route('/pdf/<string:url_seg>/<string:url_seg_issue>/<string:url_seg_article>/<regex("(?:\w{2})"):lang_code>')
+@main.route('/pdf/<string:url_seg>/<string:url_seg_issue>/<regex("(.*)"):url_seg_article>')
+@main.route('/pdf/<string:url_seg>/<string:url_seg_issue>/<regex("(.*)"):url_seg_article>/<regex("(?:\w{2})"):lang_code>')
+@cache.cached(key_prefix=cache_key_with_lang)
+def article_detail_pdf(url_seg, url_seg_issue, url_seg_article, lang_code=''):
+    issue = controllers.get_issue_by_url_seg(url_seg, url_seg_issue)
+    if not issue:
+        abort(404, _('Issue não encontrado'))
+
+    article = controllers.get_article_by_issue_article_seg(issue.iid, url_seg_article)
+    if not article:
+        abort(404, _('Artigo não encontrado'))
+
+    req_params = {
+            "url_seg": article.journal.acronym,
+            "article_pid_v3": article.aid,
+    }
+    if lang_code:
+        req_params["lang_code"] = lang_code
+
+    return redirect(url_for('main.article_detail_pdf_v3', **req_params))
 
 
 @main.route('/pdf/<string:journal_acron>/<string:issue_info>/<string:pdf_filename>.pdf')

--- a/opac/webapp/main/views.py
+++ b/opac/webapp/main/views.py
@@ -361,23 +361,10 @@ def router_legacy():
             return issue_toc(issue.journal.url_segment, issue.url_segment)
 
         elif script_php == 'sci_arttext' or script_php == 'sci_abstract':
-
-            article = controllers.get_article_by_pid(pid)
-
-            if not article:
-                article = controllers.get_article_by_oap_pid(pid)
-
+            article = controllers.get_article_by_pid(pid) or \
+                controllers.get_article_by_oap_pid(pid)
             if not article:
                 abort(404, _('Artigo não encontrado'))
-
-            if not article.is_public:
-                abort(404, ARTICLE_UNPUBLISH + _(article.unpublish_reason))
-
-            if not article.issue.is_public:
-                abort(404, ISSUE_UNPUBLISH + _(article.issue.unpublish_reason))
-
-            if not article.journal.is_public:
-                abort(404, JOURNAL_UNPUBLISH + _(article.journal.unpublish_reason))
 
             return redirect(url_for('main.article_detail_v3',
                                     url_seg=article.journal.url_segment,
@@ -1210,12 +1197,6 @@ def router_legacy_article(text_or_abstract):
     article = controllers.get_article_by_scielo_pid(pid, is_public=True)
     if not article:
         abort(404, _('Artigo não encontrado'))
-
-    if not article.issue.is_public:
-        abort(404, ISSUE_UNPUBLISH + _(article.issue.unpublish_reason))
-
-    if not article.journal.is_public:
-        abort(404, JOURNAL_UNPUBLISH + _(article.journal.unpublish_reason))
 
     return redirect(
         url_for(

--- a/opac/webapp/templates/article/includes/levelMenu.html
+++ b/opac/webapp/templates/article/includes/levelMenu.html
@@ -22,7 +22,7 @@
                     <a href="#" class="btn group disabled">
                 {% else %}
                   {% if is_pdf_page -%}
-                    <a target='_blank' href="{{ url_for('.article_detail_pdf', url_seg=journal.url_segment, url_seg_issue=issue.url_segment, url_seg_article=previous_article.url_segment) }}" class="btn group">
+                    <a target='_blank' href="{{ url_for('.article_detail_pdf_v3', url_seg=journal.url_segment, article_pid_v3=previous_article.aid) }}" class="btn group">
                   {%- else -%}
                     <a href="{{ url_for('.article_detail_v3', url_seg=journal.url_segment, article_pid_v3=previous_article.aid) }}" class="btn group">
                   {% endif %}
@@ -40,7 +40,7 @@
                   <a href="#" class="btn group disabled">
               {% else %}
                 {%- if is_pdf_page -%}
-                  <a target='_blank' href="{{ url_for('.article_detail_pdf', url_seg=journal.url_segment, url_seg_issue=issue.url_segment, url_seg_article=next_article.url_segment) }}" class="btn group">
+                  <a target='_blank' href="{{ url_for('.article_detail_pdf_v3', url_seg=journal.url_segment, article_pid_v3=next_article.aid) }}" class="btn group">
                 {%- else -%}
                   <a href="{{ url_for('.article_detail_v3', url_seg=journal.url_segment, article_pid_v3=next_article.aid) }}" class="btn group">
                 {%- endif %}
@@ -75,7 +75,7 @@
                     <a href="#" class="btn group disabled">
                 {% else %}
                   {% if is_pdf_page -%}
-                    <a target='_blank' href="{{ url_for('.article_detail_pdf', url_seg=journal.url_segment, url_seg_issue=issue.url_segment, url_seg_article=previous_article.url_segment) }}" class="btn group ">
+                    <a target='_blank' href="{{ url_for('.article_detail_pdf_v3', url_seg=journal.url_segment, article_pid_v3=previous_article.aid) }}" class="btn group ">
                   {%- else -%}
                     <a href="{{ url_for('.article_detail_v3', url_seg=journal.url_segment, article_pid_v3=previous_article.aid) }}" class="btn group">
                   {% endif %}
@@ -93,7 +93,7 @@
                   <a href="#" class="btn group disabled">
               {% else %}
                 {%- if is_pdf_page -%}
-                  <a target='_blank' href="{{ url_for('.article_detail_pdf', url_seg=journal.url_segment, url_seg_issue=issue.url_segment, url_seg_article=next_article.url_segment) }}" class="btn group">
+                  <a target='_blank' href="{{ url_for('.article_detail_pdf_v3', url_seg=journal.url_segment, article_pid_v3=next_article.aid) }}" class="btn group">
                 {%- else -%}
                   <a href="{{ url_for('.article_detail_v3', url_seg=journal.url_segment, article_pid_v3=next_article.aid) }}" class="btn group">
                 {%- endif %}
@@ -128,7 +128,7 @@
                     <a href="#" class="btn group disabled">
                 {% else %}
                   {% if is_pdf_page -%}
-                    <a target='_blank' href="{{ url_for('.article_detail_pdf', url_seg=journal.url_segment, url_seg_issue=issue.url_segment, url_seg_article=previous_article.url_segment) }}" class="btn group ">
+                    <a target='_blank' href="{{ url_for('.article_detail_pdf_v3', url_seg=journal.url_segment, article_pid_v3=previous_article.aid) }}" class="btn group ">
                   {%- else -%}
                     <a href="{{ url_for('.article_detail_v3', url_seg=journal.url_segment, article_pid_v3=previous_article.aid) }}" class="btn group">
                   {% endif %}
@@ -146,7 +146,7 @@
                   <a href="#" class="btn group disabled">
               {% else %}
                 {%- if is_pdf_page -%}
-                  <a target='_blank' href="{{ url_for('.article_detail_pdf', url_seg=journal.url_segment, url_seg_issue=issue.url_segment, url_seg_article=next_article.url_segment) }}" class="btn group">
+                  <a target='_blank' href="{{ url_for('.article_detail_pdf_v3', url_seg=journal.url_segment, article_pid_v3=next_article.aid) }}" class="btn group">
                 {%- else -%}
                   <a href="{{ url_for('.article_detail_v3', url_seg=journal.url_segment, article_pid_v3=next_article.aid) }}" class="btn group">
                 {%- endif %}
@@ -164,7 +164,7 @@
         <div class="col-lg-3 col-md-2 col-sm-4 hidden-md">
 
           {% if article and article.pdfs|length == 1 %}
-            <a target='_blank' href="{{ url_for('.article_detail_pdf', url_seg=article.journal.url_segment, url_seg_issue=article.issue.url_segment, url_seg_article=article.url_segment, lang_code=article.pdfs[0].lang) }}" class="btn">
+            <a target='_blank' href="{{ url_for('.article_detail_pdf_v3', url_seg=article.journal.url_segment, article_pid_v3=article.aid, lang_code=article.pdfs[0].lang) }}" class="btn">
               <span class="sci-ico-filePDF"></span> PDF
             </a>
           {% endif%}
@@ -188,7 +188,7 @@
               <ul class="dropdown-menu">
                 {% for pdf in article.pdfs  %}
                   <li>
-                    <a target='_blank' href="{{ url_for('.article_detail_pdf', url_seg=article.journal.url_segment, url_seg_issue=article.issue.url_segment, url_seg_article=article.url_segment, lang_code=pdf.lang) }}">
+                    <a target='_blank' href="{{ url_for('.article_detail_pdf_v3', url_seg=article.journal.url_segment, article_pid_v3=article.aid, lang_code=pdf.lang) }}">
                       {% if pdf.lang == 'es' %}
                         {% trans %}Download PDF (Espanhol){% endtrans %}
                       {% elif pdf.lang == 'en' %}
@@ -239,7 +239,7 @@
         <div class="col-lg-3 col-md-3 col-sm-4 hidden-sm hidden-lg">
 
           {% if article and article.pdfs|length == 1 %}
-            <a target='_blank' href="{{ url_for('.article_detail_pdf', url_seg=article.journal.url_segment, url_seg_issue=article.issue.url_segment, url_seg_article=article.url_segment, lang_code=article.pdfs[0].lang) }}" class="btn"><span class="sci-ico-filePDF"></span> PDF</a>
+            <a target='_blank' href="{{ url_for('.article_detail_pdf_v3', url_seg=article.journal.url_segment, article_pid_v3=article.aid, lang_code=article.pdfs[0].lang) }}" class="btn"><span class="sci-ico-filePDF"></span> PDF</a>
           {% endif%}
 
           {% if config['READCUBE_ENABLED'] and article.doi and article.pid %}
@@ -259,7 +259,7 @@
               <ul class="dropdown-menu">
                 {% for pdf in article.pdfs  %}
                   <li>
-                    <a target='_blank' href="{{ url_for('.article_detail_pdf', url_seg=article.journal.url_segment, url_seg_issue=article.issue.url_segment, url_seg_article=article.url_segment, lang_code=pdf.lang) }}">
+                    <a target='_blank' href="{{ url_for('.article_detail_pdf_v3', url_seg=article.journal.url_segment, article_pid_v3=article.aid, lang_code=pdf.lang) }}">
                       {% if pdf.lang == 'es' %}
                         {% trans %}Download PDF (Espanhol){% endtrans %}
                       {% elif pdf.lang == 'en' %}
@@ -384,7 +384,7 @@
             </a>
 
             {% if article and article.pdfs|length == 1 %}
-              <a target='_blank' href="{{ url_for('.article_detail_pdf', url_seg=article.journal.url_segment, url_seg_issue=article.issue.url_segment, url_seg_article=article.url_segment, lang_code=article.pdfs[0].lang) }}" class="btn">
+              <a target='_blank' href="{{ url_for('.article_detail_pdf_v3', url_seg=article.journal.url_segment, article_pid_v3=article.aid, lang_code=article.pdfs[0].lang) }}" class="btn">
                 <span class="sci-ico-filePDF"></span> PDF
               </a>
             {% endif%}
@@ -456,7 +456,7 @@
                 <a href="#" class="btn group disabled">
             {% else %}
               {% if is_pdf_page -%}
-                <a target='_blank' href="{{ url_for('.article_detail_pdf', url_seg=journal.url_segment, url_seg_issue=issue.url_segment, url_seg_article=previous_article.url_segment) }}" class="btn group">
+                <a target='_blank' href="{{ url_for('.article_detail_pdf_v3', url_seg=journal.url_segment, article_pid_v3=previous_article.aid) }}" class="btn group">
               {%- else -%}
                 <a href="{{ url_for('.article_detail_v3', url_seg=journal.url_segment, article_pid_v3=previous_article.aid) }}" class="btn group">
               {% endif %}
@@ -474,7 +474,7 @@
                 <a href="#" class="btn group disabled">
             {% else %}
               {%- if is_pdf_page -%}
-                <a target='_blank' href="{{ url_for('.article_detail_pdf', url_seg=journal.url_segment, url_seg_issue=issue.url_segment, url_seg_article=next_article.url_segment) }}" class="btn group">
+                <a target='_blank' href="{{ url_for('.article_detail_pdf_v3', url_seg=journal.url_segment, article_pid_v3=next_article.aid) }}" class="btn group">
               {%- else -%}
                 <a href="{{ url_for('.article_detail_v3', url_seg=journal.url_segment, article_pid_v3=next_article.aid) }}" class="btn group">
               {%- endif %}

--- a/opac/webapp/templates/article/includes/levelMenu.html
+++ b/opac/webapp/templates/article/includes/levelMenu.html
@@ -24,7 +24,7 @@
                   {% if is_pdf_page -%}
                     <a target='_blank' href="{{ url_for('.article_detail_pdf', url_seg=journal.url_segment, url_seg_issue=issue.url_segment, url_seg_article=previous_article.url_segment) }}" class="btn group">
                   {%- else -%}
-                    <a href="{{ url_for('.article_detail', url_seg=journal.url_segment, url_seg_issue=issue.url_segment, url_seg_article=previous_article.url_segment) }}" class="btn group">
+                    <a href="{{ url_for('.article_detail_v3', url_seg=journal.url_segment, article_pid_v3=previous_article.aid) }}" class="btn group">
                   {% endif %}
                 {%- endif %}
                   &laquo; {% trans %}anterior{% endtrans %}
@@ -42,7 +42,7 @@
                 {%- if is_pdf_page -%}
                   <a target='_blank' href="{{ url_for('.article_detail_pdf', url_seg=journal.url_segment, url_seg_issue=issue.url_segment, url_seg_article=next_article.url_segment) }}" class="btn group">
                 {%- else -%}
-                  <a href="{{ url_for('.article_detail', url_seg=journal.url_segment, url_seg_issue=issue.url_segment, url_seg_article=next_article.url_segment) }}" class="btn group">
+                  <a href="{{ url_for('.article_detail_v3', url_seg=journal.url_segment, article_pid_v3=next_article.aid) }}" class="btn group">
                 {%- endif %}
               {%- endif %}
                   {% trans %}seguinte{% endtrans %} &raquo;
@@ -77,7 +77,7 @@
                   {% if is_pdf_page -%}
                     <a target='_blank' href="{{ url_for('.article_detail_pdf', url_seg=journal.url_segment, url_seg_issue=issue.url_segment, url_seg_article=previous_article.url_segment) }}" class="btn group ">
                   {%- else -%}
-                    <a href="{{ url_for('.article_detail', url_seg=journal.url_segment, url_seg_issue=issue.url_segment, url_seg_article=previous_article.url_segment) }}" class="btn group">
+                    <a href="{{ url_for('.article_detail_v3', url_seg=journal.url_segment, article_pid_v3=previous_article.aid) }}" class="btn group">
                   {% endif %}
                 {%- endif %}
                   <span class="sci-ico-arrowLeft">
@@ -95,7 +95,7 @@
                 {%- if is_pdf_page -%}
                   <a target='_blank' href="{{ url_for('.article_detail_pdf', url_seg=journal.url_segment, url_seg_issue=issue.url_segment, url_seg_article=next_article.url_segment) }}" class="btn group">
                 {%- else -%}
-                  <a href="{{ url_for('.article_detail', url_seg=journal.url_segment, url_seg_issue=issue.url_segment, url_seg_article=next_article.url_segment) }}" class="btn group">
+                  <a href="{{ url_for('.article_detail_v3', url_seg=journal.url_segment, article_pid_v3=next_article.aid) }}" class="btn group">
                 {%- endif %}
               {%- endif %}
                   <span class="sci-ico-arrowRight">
@@ -130,7 +130,7 @@
                   {% if is_pdf_page -%}
                     <a target='_blank' href="{{ url_for('.article_detail_pdf', url_seg=journal.url_segment, url_seg_issue=issue.url_segment, url_seg_article=previous_article.url_segment) }}" class="btn group ">
                   {%- else -%}
-                    <a href="{{ url_for('.article_detail', url_seg=journal.url_segment, url_seg_issue=issue.url_segment, url_seg_article=previous_article.url_segment) }}" class="btn group">
+                    <a href="{{ url_for('.article_detail_v3', url_seg=journal.url_segment, article_pid_v3=previous_article.aid) }}" class="btn group">
                   {% endif %}
                 {%- endif %}
                   <span class="sci-ico-arrowLeft">
@@ -148,7 +148,7 @@
                 {%- if is_pdf_page -%}
                   <a target='_blank' href="{{ url_for('.article_detail_pdf', url_seg=journal.url_segment, url_seg_issue=issue.url_segment, url_seg_article=next_article.url_segment) }}" class="btn group">
                 {%- else -%}
-                  <a href="{{ url_for('.article_detail', url_seg=journal.url_segment, url_seg_issue=issue.url_segment, url_seg_article=next_article.url_segment) }}" class="btn group">
+                  <a href="{{ url_for('.article_detail_v3', url_seg=journal.url_segment, article_pid_v3=next_article.aid) }}" class="btn group">
                 {%- endif %}
               {%- endif %}
                   <span class="sci-ico-arrowRight">
@@ -458,7 +458,7 @@
               {% if is_pdf_page -%}
                 <a target='_blank' href="{{ url_for('.article_detail_pdf', url_seg=journal.url_segment, url_seg_issue=issue.url_segment, url_seg_article=previous_article.url_segment) }}" class="btn group">
               {%- else -%}
-                <a href="{{ url_for('.article_detail', url_seg=journal.url_segment, url_seg_issue=issue.url_segment, url_seg_article=previous_article.url_segment) }}" class="btn group">
+                <a href="{{ url_for('.article_detail_v3', url_seg=journal.url_segment, article_pid_v3=previous_article.aid) }}" class="btn group">
               {% endif %}
             {%- endif %}
               <span class="sci-ico-arrowLeft"></span>
@@ -476,7 +476,7 @@
               {%- if is_pdf_page -%}
                 <a target='_blank' href="{{ url_for('.article_detail_pdf', url_seg=journal.url_segment, url_seg_issue=issue.url_segment, url_seg_article=next_article.url_segment) }}" class="btn group">
               {%- else -%}
-                <a href="{{ url_for('.article_detail', url_seg=journal.url_segment, url_seg_issue=issue.url_segment, url_seg_article=next_article.url_segment) }}" class="btn group">
+                <a href="{{ url_for('.article_detail_v3', url_seg=journal.url_segment, article_pid_v3=next_article.aid) }}" class="btn group">
               {%- endif %}
             {%- endif %}
                 <span class="sci-ico-arrowRight"></span>

--- a/opac/webapp/templates/article/includes/modal/download.html
+++ b/opac/webapp/templates/article/includes/modal/download.html
@@ -17,7 +17,7 @@
             {% if article and article.pdfs %}
               {% for pdf in article.pdfs  %}
                 <li>
-                  <a target='_blank' href="{{ url_for('.article_detail_pdf', url_seg=article.journal.url_segment, url_seg_issue=article.issue.url_segment, url_seg_article=article.url_segment, lang_code=pdf.lang) }}">
+                  <a target='_blank' href="{{ url_for('.article_detail_pdf_v3', url_seg=article.journal.url_segment, article_pid_v3=article.aid, lang_code=pdf.lang) }}">
                     {% if pdf.lang == 'es' %}
                       {% trans %}Espanhol{% endtrans %}
                     {% elif pdf.lang == 'en' %}

--- a/opac/webapp/templates/article/includes/recent_articles_row.html
+++ b/opac/webapp/templates/article/includes/recent_articles_row.html
@@ -1,6 +1,6 @@
 <div class="slide-item release">
   <div class="col-md-12">
-    <a href="{{ url_for('.article_detail', url_seg=article.journal.url_segment, url_seg_issue=article.issue.url_segment, url_seg_article=article.url_segment) }}">
+    <a href="{{ url_for('.article_detail_v3', url_seg=article.journal.url_segment, article_pid_v3=article.aid) }}">
       {% if session.lang %}
         <h3 class="ellipsis">
           {{ article.get_title_by_lang(session.lang[:2])|default(_('Documento sem título'), true)|striptags }}

--- a/opac/webapp/templates/issue/toc.html
+++ b/opac/webapp/templates/issue/toc.html
@@ -188,7 +188,7 @@
                             <li>
                               {% trans %}PDF{% endtrans %}:
                               {% for lang, url in article.article_pdf_languages|sort(attribute='0') %}
-                                <a target='_blank' href="{{ url_for('.article_detail_pdf', url_seg=journal.url_segment, url_seg_issue=issue.url_segment, url_seg_article=article.url_segment, lang_code=lang) }}" data-toggle="tooltip" data-placement="bottom" title="{{lang|trans_alpha2}}">
+                                <a target='_blank' href="{{ url_for('.article_detail_pdf_v3', url_seg=journal.url_segment, article_pid_v3=article.aid, lang_code=lang) }}" data-toggle="tooltip" data-placement="bottom" title="{{lang|trans_alpha2}}">
                                   {{ lang }}
                                 </a>
                               {% endfor %}

--- a/opac/webapp/templates/issue/toc.html
+++ b/opac/webapp/templates/issue/toc.html
@@ -177,7 +177,7 @@
                             <li>
                               {% trans %}Texto{% endtrans %}:
                               {% for lang in article.article_text_languages|sort %}
-                                <a href="{{ url_for('.article_detail', url_seg=journal.url_segment, url_seg_issue=issue.url_segment, url_seg_article=article.url_segment, lang_code=lang) }}" data-toggle="tooltip" data-placement="bottom" title="{{lang|trans_alpha2}}">
+                                <a href="{{ url_for('.article_detail_v3', url_seg=journal.url_segment, article_pid_v3=article.aid, lang_code=lang) }}" data-toggle="tooltip" data-placement="bottom" title="{{lang|trans_alpha2}}">
                                   {{ lang }}
                                 </a>
                               {% endfor %}


### PR DESCRIPTION
Adiciona suporte à nova URL canônica dos documentos e PDFs, com o formato
`/article/:journal_acron/:article_pid_v3` e `/pdf/:journal_acron/:article_pid_v3`, respectivamente. As URLs nos formatos anteriores passam a redirecionar o cliente para as novas.

#### Onde a revisão poderia começar?

Sugiro revisar os _commits_ individualmente e na ordem de execução.

#### Como este poderia ser testado manualmente?

Inicialize uma instância local e navegue pelo site, percebendo as URLs para documentos HTML e PDF. Verifique também as URLs legadas.

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
n/a

#### Quais são tickets relevantes?
#1547 

### Referências
n/a

