### PR TITLE
Altera template de config de teste p/ evitar uso da base de produção

### DIFF
--- a/opac/webapp/config/templates/testing.template
+++ b/opac/webapp/config/templates/testing.template
@@ -88,7 +88,7 @@ SECRET_KEY = 'a-dummy-testing-secret'
 
 # Configurações do banco de dados Mongodb
 # -*- DEVE SER AJUSTADO NA INSTALAÇÃO -*-
-MONGODB_NAME = os.environ.get('OPAC_MONGODB_NAME', 'opac_test')
+MONGODB_NAME = 'opac_test'
 MONGODB_HOST = os.environ.get('OPAC_MONGODB_HOST', 'localhost')
 MONGODB_PORT = os.environ.get('OPAC_MONGODB_PORT', 27017)
 MONGODB_USER = os.environ.get('OPAC_MONGODB_USER', None)


### PR DESCRIPTION
#### O que esse PR faz?
Este PR resolve o problema dos testes unitários utilizarem a mesma base de dados da aplicação no MongoDB. Foi alterado o valor da variável `config.MONGODB_NAME` para utilizar um nome fixo de teste, evitando a utilização da base de dados configurada na variável de ambiente `OPAC_MONGODB_NAME`, nome da base real usada pelo site.

#### Onde a revisão poderia começar?
Em `opac/webapp/config/templates/testing.template`

#### Como este poderia ser testado manualmente?
- Rode o comando `make test`.
- Observe no MongoDB que o uma base com nome `opac_test` está sendo usada durante os testes unitários e que a base `opac` permanece como estava.
- Rode o comando `make dev_compose_make_test` para executar os testes unitários no Docker.
- Observe o mesmo efeito descrito no passo 2.

#### Algum cenário de contexto que queira dar?
Fiz experimentos com o `mongomock` e alterações no código de teste para tentar outros tipos de abordagem, na tentativa de não precisar da conexão com o MongoDB mas sem sucesso. Mesmo utilizando-os, a conexão real se faz necessária e a mesma base de dados de teste é criada.

### Screenshots
N/A

#### Quais são tickets relevantes?
#1549 

### Referências
Projeto mongomock: https://github.com/mongomock/mongomock
Utilização do mongomock com mongoengine: http://docs.mongoengine.org/guide/mongomock.html
