### PR TITLE
Altera tradução de *sumário* na página do artigo

### DIFF
--- a/opac/webapp/translations/en/LC_MESSAGES/messages.po
+++ b/opac/webapp/translations/en/LC_MESSAGES/messages.po
@@ -1284,7 +1284,7 @@ msgstr "Home of journal"
 #: opac/webapp/templates/article/includes/levelMenu.html:70
 #: opac/webapp/templates/article/includes/levelMenu.html:123
 msgid "sumário"
-msgstr "summary"
+msgstr "table of contents"
 
 #: opac/webapp/templates/article/includes/levelMenu.html:30
 #: opac/webapp/templates/issue/includes/alternative_header.html:75

--- a/opac/webapp/translations/es/LC_MESSAGES/messages.po
+++ b/opac/webapp/translations/es/LC_MESSAGES/messages.po
@@ -1288,7 +1288,7 @@ msgstr ""
 #: opac/webapp/templates/article/includes/levelMenu.html:70
 #: opac/webapp/templates/article/includes/levelMenu.html:123
 msgid "sumário"
-msgstr "tabla de contenidos"
+msgstr "tabla de contenido"
 
 #: opac/webapp/templates/article/includes/levelMenu.html:30
 #: opac/webapp/templates/issue/includes/alternative_header.html:75

--- a/opac/webapp/translations/es_ES/LC_MESSAGES/messages.po
+++ b/opac/webapp/translations/es_ES/LC_MESSAGES/messages.po
@@ -1263,7 +1263,7 @@ msgstr ""
 #: opac/webapp/templates/article/includes/levelMenu.html:70
 #: opac/webapp/templates/article/includes/levelMenu.html:123
 msgid "sumário"
-msgstr ""
+msgstr "tabla de contenido"
 
 #: opac/webapp/templates/article/includes/levelMenu.html:30
 #: opac/webapp/templates/issue/includes/alternative_header.html:75

--- a/opac/webapp/translations/es_MX/LC_MESSAGES/messages.po
+++ b/opac/webapp/translations/es_MX/LC_MESSAGES/messages.po
@@ -1263,7 +1263,7 @@ msgstr ""
 #: opac/webapp/templates/article/includes/levelMenu.html:70
 #: opac/webapp/templates/article/includes/levelMenu.html:123
 msgid "sumário"
-msgstr ""
+msgstr "tabla de contenido"
 
 #: opac/webapp/templates/article/includes/levelMenu.html:30
 #: opac/webapp/templates/issue/includes/alternative_header.html:75


### PR DESCRIPTION
Seguindo a mesma alteração realizada na página do sumário do fascículo [baf5ac28311ee3174ac09e679d4b165bb750dbb0],
agora a alteração foi realizada na página do artigo.

#### Onde a revisão poderia começar?
n/a

#### Como este poderia ser testado manualmente?
Caso seja instalado diretamente na máquina local será necessário executar `make compile_messages` após aplicar o patch e antes de executar o servidor de aplicação.

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
n/a

#### Quais são tickets relevantes?
#859 

### Referências
n/a

