### PR TITLE
Substitui a rota /grid/acron por /j/acron/grid

### DIFF
--- a/opac/tests/test_main_views.py
+++ b/opac/tests/test_main_views.py
@@ -365,89 +365,6 @@ class MainTestCase(BaseTestCase):
 
     # ISSUE
 
-    def test_issue_grid(self):
-        """
-        Teste da ``view function`` ``issue_grid`` acessando a grade de números
-        de um periódico, nesse teste deve ser retornado todos os números com
-        o atributo is_public=True de um número, sendo que o template deve ser
-        ``issue/grid.html``.
-        """
-
-        with current_app.app_context():
-            utils.makeOneCollection()
-
-            journal = utils.makeOneJournal()
-
-            issues = utils.makeAnyIssue(attrib={'journal': journal.id})
-
-            response = self.client.get(url_for('main.issue_grid',
-                                       url_seg=journal.url_segment))
-
-            self.assertStatus(response, 200)
-            self.assertTemplateUsed('issue/grid.html')
-
-            for issue in issues:
-                self.assertIn('/journal_acron', response.data.decode('utf-8'))
-
-    def test_issue_grid_without_issues(self):
-        """
-        Teste para avaliar o retorno da ``view function`` ``issue_grid``
-        quando não existe número cadastrado deve retornar ``status_code`` 200
-        e a msg ``Nenhum número encontrado para esse perióico``
-        """
-
-        with current_app.app_context():
-
-            utils.makeOneCollection()
-
-            journal = utils.makeOneJournal()
-
-            response = self.client.get(
-                url_for('main.issue_grid', url_seg=journal.url_segment))
-
-            self.assertStatus(response, 200)
-            self.assertTemplateUsed('issue/grid.html')
-
-            self.assertIn('Nenhum número encontrado para esse periódico',
-                          response.data.decode('utf-8'))
-
-    def test_issue_grid_with_unknow_journal_id(self):
-        """
-        Teste para avaliar o retorno da ``view function`` ``issue_grid``
-        quando é acessado utilizando um identificador do periódico desconhecido,
-        deve retornar status_code 404 com a msg ```Periódico não encontrado``.
-        """
-
-        journal = utils.makeOneJournal()
-
-        utils.makeAnyIssue(attrib={'journal': journal.id})
-
-        unknow_url_seg = '9km2g78o2mnu7'
-
-        response = self.client.get(
-            url_for('main.issue_grid', url_seg=unknow_url_seg))
-
-        self.assertStatus(response, 404)
-
-        self.assertIn('Periódico não encontrado',
-                      response.data.decode('utf-8'))
-
-    def test_issue_grid_with_attrib_is_public_false(self):
-        """
-        Teste da ``view function`` ``issue_grid`` acessando um periódico
-        com atributo is_public=False, deve retorna uma página com ``status_code``
-        404 e msg cadastrada no atributo ``reason``.
-        """
-        unpublish_reason = 'Problema de Direito Autoral'
-        journal = utils.makeOneJournal({'is_public': False,
-                                       'unpublish_reason': unpublish_reason})
-
-        response = self.client.get(url_for('main.issue_grid',
-                                           url_seg=journal.url_segment))
-
-        self.assertStatus(response, 404)
-        self.assertIn(unpublish_reason, response.data.decode('utf-8'))
-
     def test_issue_toc(self):
         """
         Teste da ``view function`` ``issue_toc`` acessando a página do número,
@@ -1830,4 +1747,101 @@ class TestJournaDetail(BaseTestCase):
 
         self.assertStatus(response, 404)
         self.assertIn(unpublish_reason, response.data.decode('utf-8'))
-        
+
+
+class TestJournalGrid(BaseTestCase):
+
+    def test_issue_grid(self):
+        """
+        Teste da ``view function`` ``issue_grid`` acessando a grade de números
+        de um periódico, nesse teste deve ser retornado todos os números com
+        o atributo is_public=True de um número, sendo que o template deve ser
+        ``issue/grid.html``.
+        """
+
+        with current_app.app_context():
+            utils.makeOneCollection()
+
+            journal = utils.makeOneJournal()
+
+            issues = utils.makeAnyIssue(attrib={'journal': journal.id})
+
+            response = self.client.get(url_for('main.issue_grid',
+                                       url_seg=journal.url_segment))
+
+            self.assertStatus(response, 200)
+            self.assertTemplateUsed('issue/grid.html')
+
+            for issue in issues:
+                self.assertIn('/journal_acron', response.data.decode('utf-8'))
+
+    def test_issue_grid_without_issues(self):
+        """
+        Teste para avaliar o retorno da ``view function`` ``issue_grid``
+        quando não existe número cadastrado deve retornar ``status_code`` 200
+        e a msg ``Nenhum número encontrado para esse perióico``
+        """
+
+        with current_app.app_context():
+
+            utils.makeOneCollection()
+
+            journal = utils.makeOneJournal()
+
+            response = self.client.get(
+                url_for('main.issue_grid', url_seg=journal.url_segment))
+
+            self.assertStatus(response, 200)
+            self.assertTemplateUsed('issue/grid.html')
+
+            self.assertIn('Nenhum número encontrado para esse periódico',
+                          response.data.decode('utf-8'))
+
+    def test_issue_grid_with_unknow_journal_id(self):
+        """
+        Teste para avaliar o retorno da ``view function`` ``issue_grid``
+        quando é acessado utilizando um identificador do periódico desconhecido,
+        deve retornar status_code 404 com a msg ```Periódico não encontrado``.
+        """
+
+        journal = utils.makeOneJournal()
+
+        utils.makeAnyIssue(attrib={'journal': journal.id})
+
+        unknow_url_seg = '9km2g78o2mnu7'
+
+        response = self.client.get(
+            url_for('main.issue_grid', url_seg=unknow_url_seg))
+
+        self.assertStatus(response, 404)
+
+        self.assertIn('Periódico não encontrado',
+                      response.data.decode('utf-8'))
+
+    def test_issue_grid_with_attrib_is_public_false(self):
+        """
+        Teste da ``view function`` ``issue_grid`` acessando um periódico
+        com atributo is_public=False, deve retorna uma página com ``status_code``
+        404 e msg cadastrada no atributo ``reason``.
+        """
+        unpublish_reason = 'Problema de Direito Autoral'
+        journal = utils.makeOneJournal({'is_public': False,
+                                       'unpublish_reason': unpublish_reason})
+
+        response = self.client.get(url_for('main.issue_grid',
+                                           url_seg=journal.url_segment))
+
+        self.assertStatus(response, 404)
+        self.assertIn(unpublish_reason, response.data.decode('utf-8'))
+
+    def test_issue_grid_legacy_redirects(self):
+        with current_app.app_context():
+            utils.makeOneCollection()
+
+            journal = utils.makeOneJournal()
+
+            issues = utils.makeAnyIssue(attrib={'journal': journal.id})
+
+            response = self.client.get('/grid/{}'.format(journal.url_segment))
+
+            self.assertStatus(response, 301)

--- a/opac/webapp/main/views.py
+++ b/opac/webapp/main/views.py
@@ -723,7 +723,11 @@ def form_contact(url_seg):
 # ###################################Issue#######################################
 
 
-#@main.route('/grid/<string:url_seg>/')
+@main.route('/grid/<string:url_seg>/')
+def issue_grid_legacy(url_seg):
+    return redirect(url_for('main.issue_grid', url_seg=url_seg), 301)
+
+
 @main.route('/j/<string:url_seg>/grid')
 @cache.cached(key_prefix=cache_key_with_lang)
 def issue_grid(url_seg):

--- a/opac/webapp/main/views.py
+++ b/opac/webapp/main/views.py
@@ -723,7 +723,8 @@ def form_contact(url_seg):
 # ###################################Issue#######################################
 
 
-@main.route('/grid/<string:url_seg>/')
+#@main.route('/grid/<string:url_seg>/')
+@main.route('/j/<string:url_seg>/grid')
 @cache.cached(key_prefix=cache_key_with_lang)
 def issue_grid(url_seg):
     journal = controllers.get_journal_by_url_seg(url_seg)


### PR DESCRIPTION
#### O que esse PR faz?
Substitui a rota /grid/acron por /j/acron/grid que corresponde à grade de fascículos

#### Onde a revisão poderia começar?
Por commits

#### Como este poderia ser testado manualmente?
- Rodando os testes conforme o README
- Acessando a página de qualquer periódico e depois da grade de fascículos, notar que o padrão de url é  /j/acron/grid
- Acessando a página da grade de fascículos de qualquer periódico:
  - /grid/acron, notar que redireciona
  - /j/acron/grid notar que está acessível
 
#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
n/a

#### Quais são tickets relevantes?
Resolve parcialmente #1564 

### Referências
n/a
