### PR TITLE
Cria nova rota para o sumário (de /toc/acron/issue_url_seg para /j/acron/i/issue_url_seg

### DIFF
--- a/opac/tests/test_main_views.py
+++ b/opac/tests/test_main_views.py
@@ -365,95 +365,6 @@ class MainTestCase(BaseTestCase):
 
     # ISSUE
 
-    def test_issue_toc(self):
-        """
-        Teste da ``view function`` ``issue_toc`` acessando a página do número,
-        deve retorna status_code 200 e o template ``issue/toc.html``.
-        """
-
-        with current_app.app_context():
-
-            utils.makeOneCollection()
-
-            journal = utils.makeOneJournal()
-
-            issue = utils.makeOneIssue({'number': '31',
-                                        'volume': '10',
-                                        'journal': journal})
-
-            response = self.client.get(url_for('main.issue_toc',
-                                       url_seg=journal.url_segment,
-                                       url_seg_issue=issue.url_segment))
-
-            self.assertStatus(response, 200)
-            self.assertTemplateUsed('issue/toc.html')
-            # self.assertIn(u'Vol. 10 No. 31', response.data.decode('utf-8'))
-            self.assertEqual(self.get_context_variable('issue').id, issue.id)
-
-    def test_issue_toc_unknow_issue_id(self):
-        """
-        Teste para avaliar o retorno da ``view function`` ``issue_toc``
-        quando é acessado utilizando um identificador do issue desconhecido,
-        deve retorna status_code 404 com a msg ``Número não encontrado``.
-        """
-        journal = utils.makeOneJournal()
-
-        utils.makeOneIssue({'journal': journal})
-
-        unknow_url_seg = '2014.v3n2'
-
-        unknow_url = url_for(
-            'main.issue_toc',
-            url_seg=journal.url_segment,
-            url_seg_issue=unknow_url_seg)
-
-        response = self.client.get(unknow_url)
-
-        self.assertStatus(response, 404)
-        self.assertIn('Número não encontrado', response.data.decode('utf-8'))
-
-    def test_issue_toc_with_attrib_is_public_false(self):
-        """
-        Teste da ``view function`` ``issue_toc`` acessando um número
-        com atributo is_public=False, deve retorna uma página com ``status_code``
-        404 e msg cadastrada no atributo ``reason``.
-        """
-        unpublish_reason = 'Número incorreto'
-        journal = utils.makeOneJournal()
-        issue = utils.makeOneIssue({
-            'is_public': False,
-            'unpublish_reason': unpublish_reason,
-            'journal': journal})
-
-        response = self.client.get(url_for('main.issue_toc',
-                                           url_seg=journal.url_segment,
-                                           url_seg_issue=issue.url_segment))
-
-        self.assertStatus(response, 404)
-        self.assertIn(unpublish_reason, response.data.decode('utf-8'))
-
-    def test_issue_toc_with_journal_attrib_is_public_false(self):
-        """
-        Teste da ``view function`` ``issue_toc`` acessando um número
-        com atributo is_public=True, porém com um periódico com atributo
-        is_public=False deve retorna uma página com ``status_code`` 404 e msg
-        cadastrada no atributo ``reason`` do periódico.
-        """
-        unpublish_reason = 'Revista removida da coleção'
-        journal = utils.makeOneJournal({
-            'is_public': False,
-            'unpublish_reason': unpublish_reason})
-        issue = utils.makeOneIssue({
-            'is_public': True,
-            'journal': journal.id})
-
-        response = self.client.get(url_for('main.issue_toc',
-                                           url_seg=journal.url_segment,
-                                           url_seg_issue=issue.url_segment))
-
-        self.assertStatus(response, 404)
-        self.assertIn(unpublish_reason, response.data.decode('utf-8'))
-
     def test_issue_feed(self):
         """
         Teste da ``view function`` ``issue_feed``, deve retornar um rss
@@ -1845,3 +1756,95 @@ class TestJournalGrid(BaseTestCase):
             response = self.client.get('/grid/{}'.format(journal.url_segment))
 
             self.assertStatus(response, 301)
+
+
+class TestIssueToc(BaseTestCase):
+
+    def test_issue_toc(self):
+        """
+        Teste da ``view function`` ``issue_toc`` acessando a página do número,
+        deve retorna status_code 200 e o template ``issue/toc.html``.
+        """
+
+        with current_app.app_context():
+
+            utils.makeOneCollection()
+
+            journal = utils.makeOneJournal()
+
+            issue = utils.makeOneIssue({'number': '31',
+                                        'volume': '10',
+                                        'journal': journal})
+
+            response = self.client.get(url_for('main.issue_toc',
+                                       url_seg=journal.url_segment,
+                                       url_seg_issue=issue.url_segment))
+
+            self.assertStatus(response, 200)
+            self.assertTemplateUsed('issue/toc.html')
+            # self.assertIn(u'Vol. 10 No. 31', response.data.decode('utf-8'))
+            self.assertEqual(self.get_context_variable('issue').id, issue.id)
+
+    def test_issue_toc_unknow_issue_id(self):
+        """
+        Teste para avaliar o retorno da ``view function`` ``issue_toc``
+        quando é acessado utilizando um identificador do issue desconhecido,
+        deve retorna status_code 404 com a msg ``Número não encontrado``.
+        """
+        journal = utils.makeOneJournal()
+
+        utils.makeOneIssue({'journal': journal})
+
+        unknow_url_seg = '2014.v3n2'
+
+        unknow_url = url_for(
+            'main.issue_toc',
+            url_seg=journal.url_segment,
+            url_seg_issue=unknow_url_seg)
+
+        response = self.client.get(unknow_url)
+
+        self.assertStatus(response, 404)
+        self.assertIn('Número não encontrado', response.data.decode('utf-8'))
+
+    def test_issue_toc_with_attrib_is_public_false(self):
+        """
+        Teste da ``view function`` ``issue_toc`` acessando um número
+        com atributo is_public=False, deve retorna uma página com ``status_code``
+        404 e msg cadastrada no atributo ``reason``.
+        """
+        unpublish_reason = 'Número incorreto'
+        journal = utils.makeOneJournal()
+        issue = utils.makeOneIssue({
+            'is_public': False,
+            'unpublish_reason': unpublish_reason,
+            'journal': journal})
+
+        response = self.client.get(url_for('main.issue_toc',
+                                           url_seg=journal.url_segment,
+                                           url_seg_issue=issue.url_segment))
+
+        self.assertStatus(response, 404)
+        self.assertIn(unpublish_reason, response.data.decode('utf-8'))
+
+    def test_issue_toc_with_journal_attrib_is_public_false(self):
+        """
+        Teste da ``view function`` ``issue_toc`` acessando um número
+        com atributo is_public=True, porém com um periódico com atributo
+        is_public=False deve retorna uma página com ``status_code`` 404 e msg
+        cadastrada no atributo ``reason`` do periódico.
+        """
+        unpublish_reason = 'Revista removida da coleção'
+        journal = utils.makeOneJournal({
+            'is_public': False,
+            'unpublish_reason': unpublish_reason})
+        issue = utils.makeOneIssue({
+            'is_public': True,
+            'journal': journal.id})
+
+        response = self.client.get(url_for('main.issue_toc',
+                                           url_seg=journal.url_segment,
+                                           url_seg_issue=issue.url_segment))
+
+        self.assertStatus(response, 404)
+        self.assertIn(unpublish_reason, response.data.decode('utf-8'))

--- a/opac/tests/test_main_views.py
+++ b/opac/tests/test_main_views.py
@@ -1848,3 +1848,25 @@ class TestIssueToc(BaseTestCase):
 
         self.assertStatus(response, 404)
         self.assertIn(unpublish_reason, response.data.decode('utf-8'))
+
+    def test_issue_toc_legacy_redirects_to_issue_toc(self):
+        """
+        Teste da ``view function`` ``issue_toc`` acessando a página do número,
+        deve retorna status_code 200 e o template ``issue/toc.html``.
+        """
+
+        with current_app.app_context():
+
+            utils.makeOneCollection()
+
+            journal = utils.makeOneJournal()
+
+            issue = utils.makeOneIssue({'number': '31',
+                                        'volume': '10',
+                                        'journal': journal})
+
+            response = self.client.get(url_for('main.issue_toc_legacy',
+                                       url_seg=journal.url_segment,
+                                       url_seg_issue=issue.url_segment))
+
+            self.assertStatus(response, 301)

--- a/opac/webapp/main/views.py
+++ b/opac/webapp/main/views.py
@@ -358,7 +358,13 @@ def router_legacy():
             if not issue.journal.is_public:
                 abort(404, JOURNAL_UNPUBLISH + _(issue.journal.unpublish_reason))
 
-            return issue_toc(issue.journal.url_segment, issue.url_segment)
+            return redirect(
+                url_for(
+                    "main.issue_toc",
+                    url_seg=issue.journal.url_segment,
+                    url_seg_issue=issue.url_segment),
+                301
+            )
 
         elif script_php == 'sci_arttext' or script_php == 'sci_abstract':
 
@@ -789,12 +795,6 @@ def issue_toc(url_seg, url_seg_issue):
 
     issue = controllers.get_issue_by_url_seg(url_seg, url_seg_issue)
 
-    if issue and issue.journal:
-        issue_legend = descriptive_short_format(
-            title=issue.journal.title, short_title=issue.journal.short_title,
-            pubdate=str(issue.year), volume=issue.volume, number=issue.number,
-            suppl=issue.suppl_text, language=language[:2].lower())
-
     if not issue:
         abort(404, _('Número não encontrado'))
 
@@ -829,6 +829,11 @@ def issue_toc(url_seg, url_seg_issue):
 
         setattr(article, "article_text_languages", article_text_languages)
         setattr(article, "article_pdf_languages", article_pdf_languages)
+
+    issue_legend = descriptive_short_format(
+        title=issue.journal.title, short_title=issue.journal.short_title,
+        pubdate=str(issue.year), volume=issue.volume, number=issue.number,
+        suppl=issue.suppl_text, language=language[:2].lower())
 
     context = {
         'next_issue': next_issue,

--- a/opac/webapp/main/views.py
+++ b/opac/webapp/main/views.py
@@ -801,10 +801,11 @@ def issue_toc(url_seg, url_seg_issue):
     if not issue.is_public:
         abort(404, ISSUE_UNPUBLISH + _(issue.unpublish_reason))
 
-    if not issue.journal.is_public:
-        abort(404, JOURNAL_UNPUBLISH + _(issue.journal.unpublish_reason))
-
     journal = issue.journal
+
+    if not journal.is_public:
+        abort(404, JOURNAL_UNPUBLISH + _(journal.unpublish_reason))
+
     articles = controllers.get_articles_by_iid(issue.iid, is_public=True)
 
     if articles:
@@ -831,7 +832,7 @@ def issue_toc(url_seg, url_seg_issue):
         setattr(article, "article_pdf_languages", article_pdf_languages)
 
     issue_legend = descriptive_short_format(
-        title=issue.journal.title, short_title=issue.journal.short_title,
+        title=journal.title, short_title=journal.short_title,
         pubdate=str(issue.year), volume=issue.volume, number=issue.number,
         suppl=issue.suppl_text, language=language[:2].lower())
 

--- a/opac/webapp/main/views.py
+++ b/opac/webapp/main/views.py
@@ -771,6 +771,7 @@ def issue_grid(url_seg):
 
 
 @main.route('/toc/<string:url_seg>/<string:url_seg_issue>/')
+@main.route('/j/<string:url_seg>/i/<string:url_seg_issue>/')
 @cache.cached(key_prefix=cache_key_with_lang_with_qs)
 def issue_toc(url_seg, url_seg_issue):
     # idioma da sessão

--- a/opac/webapp/main/views.py
+++ b/opac/webapp/main/views.py
@@ -771,6 +771,14 @@ def issue_grid(url_seg):
 
 
 @main.route('/toc/<string:url_seg>/<string:url_seg_issue>/')
+def issue_toc_legacy(url_seg, url_seg_issue):
+    return redirect(
+        url_for('main.issue_toc',
+                url_seg=url_seg,
+                url_seg_issue=url_seg_issue),
+        code=301)
+
+
 @main.route('/j/<string:url_seg>/i/<string:url_seg_issue>/')
 @cache.cached(key_prefix=cache_key_with_lang_with_qs)
 def issue_toc(url_seg, url_seg_issue):


### PR DESCRIPTION
#### O que esse PR faz?
Cria nova rota para o sumário (de /toc/acron/issue_url_seg para /j/acron/i/issue_url_seg

#### Onde a revisão poderia começar?
Por commits

#### Como este poderia ser testado manualmente?
Acessar a página de todos os fascículos e acessar qualquer fascículo.
Notar o novo padrão de rota.
Com o padrão antigo, verificar que é redirecionado.
Também é possível executar os testes de unidade

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
n/a

#### Quais são tickets relevantes?
Resolve parte de #1548

### Referências
n/a
