### PR TITLE
Cria uma rota nova para os sumários de aop 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,9 +26,9 @@ RUN apk --update add --no-cache \
 COPY . /app
 WORKDIR /app
 
-RUN pip --no-cache-dir install -r requirements.txt && \
+RUN pip --no-cache-dir install -U pip \
+    pip --no-cache-dir install -r requirements.txt && \
     pip --no-cache-dir install -r /app/requirements.dev.txt
-
 
 RUN sed -i 's/\r//' start_worker.sh \
     && sed -i 's/\r//' start_scheduler.sh \

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,8 +26,8 @@ RUN apk --update add --no-cache \
 COPY . /app
 WORKDIR /app
 
-RUN pip --no-cache-dir install -U pip \
-    pip --no-cache-dir install -r requirements.txt && \
+RUN pip --no-cache-dir install -U pip && \
+    pip --no-cache-dir install -r /app/requirements.txt && \
     pip --no-cache-dir install -r /app/requirements.dev.txt
 
 RUN sed -i 's/\r//' start_worker.sh \

--- a/opac/tests/test_interface_TOC.py
+++ b/opac/tests/test_interface_TOC.py
@@ -258,7 +258,7 @@ class TOCTestCase(BaseTestCase):
 
             self.assertIn("Título Del Artículo En Portugués", response.data.decode('utf-8'))
 
-    def test_sumary_text_change_when_issue_is_ahead(self):
+    def test_ahead_of_print_is_displayed_at_table_of_contents(self):
         """
         Teste para verificar se caso o issue for um ahead o valor da legenda bibliográfica é alterada para 'ahead of print'.
         """
@@ -270,7 +270,7 @@ class TOCTestCase(BaseTestCase):
 
             issue = utils.makeOneIssue({'journal': journal, 'type': 'ahead'})
 
-            response = c.get(url_for('main.issue_toc',
+            response = c.get(url_for('main.aop_toc',
                                      url_seg=journal.url_segment,
                                      url_seg_issue=issue.url_segment))
 

--- a/opac/tests/test_main_views.py
+++ b/opac/tests/test_main_views.py
@@ -1871,6 +1871,64 @@ class TestIssueToc(BaseTestCase):
 
             self.assertStatus(response, 301)
 
+    def test_issue_toc_legacy_redirects_to_aop_toc(self):
+        """
+        Teste da ``view function`` ``issue_toc`` acessando a página do número,
+        deve retorna status_code 200 e o template ``issue/toc.html``.
+        """
+
+        with current_app.app_context():
+
+            utils.makeOneCollection()
+
+            journal = utils.makeOneJournal()
+
+            issue = utils.makeOneIssue({'number': 'ahead',
+                                        'type': 'ahead',
+                                        'journal': journal})
+
+            response = self.client.get(url_for('main.issue_toc_legacy',
+                                       url_seg=journal.url_segment,
+                                       url_seg_issue=issue.url_segment))
+
+            self.assertStatus(response, 301)
+            self.assertRedirects(
+                response,
+                url_for(
+                    'main.aop_toc',
+                    url_seg=journal.url_segment
+                ),
+            )
+
+    def test_issue_toc_redirects_to_aop_toc(self):
+        """
+        Teste da ``view function`` ``issue_toc`` acessando a página do número,
+        deve retorna status_code 200 e o template ``issue/toc.html``.
+        """
+
+        with current_app.app_context():
+
+            utils.makeOneCollection()
+
+            journal = utils.makeOneJournal()
+
+            issue = utils.makeOneIssue({'number': 'ahead',
+                                        'type': 'ahead',
+                                        'journal': journal})
+
+            response = self.client.get(url_for('main.issue_toc',
+                                       url_seg=journal.url_segment,
+                                       url_seg_issue=issue.url_segment))
+
+            self.assertStatus(response, 301)
+            self.assertRedirects(
+                response,
+                url_for(
+                    'main.aop_toc',
+                    url_seg=journal.url_segment
+                ),
+            )
+
 
 class TestAOPToc(BaseTestCase):
 

--- a/opac/tests/test_main_views.py
+++ b/opac/tests/test_main_views.py
@@ -1870,3 +1870,29 @@ class TestIssueToc(BaseTestCase):
                                        url_seg_issue=issue.url_segment))
 
             self.assertStatus(response, 301)
+
+
+class TestAOPToc(BaseTestCase):
+
+    def test_aop_toc(self):
+        """
+        Teste da ``view function`` ``ahead_toc`` acessando a página do número,
+        deve retorna status_code 200 e o template ``issue/toc.html``.
+        """
+
+        with current_app.app_context():
+
+            utils.makeOneCollection()
+
+            journal = utils.makeOneJournal()
+
+            issue = utils.makeOneIssue({'number': 'ahead',
+                                        'journal': journal})
+
+            response = self.client.get(url_for('main.aop_toc',
+                                       url_seg=journal.url_segment))
+
+            self.assertStatus(response, 200)
+            self.assertTemplateUsed('issue/toc.html')
+            # self.assertIn(u'Vol. 10 No. 31', response.data.decode('utf-8'))
+            self.assertEqual(self.get_context_variable('issue').id, issue.id)

--- a/opac/tests/utils.py
+++ b/opac/tests/utils.py
@@ -108,6 +108,8 @@ def makeOneJournal(attrib=None):  # noqa
             ]
         )
     }
+    if not journal.get("is_public") and not journal.get("unpublish_reason"):
+        journal["unpublish_reason"] = "<unpublish_reason>"
     journal.update(attrib)
     return models.Journal(**journal).save()
 

--- a/opac/webapp/controllers.py
+++ b/opac/webapp/controllers.py
@@ -1270,3 +1270,12 @@ def related_links(article):
         ),
     ]
 
+
+def get_aop_issues(url_seg):
+    try:
+        journal = get_journal_by_url_seg(url_seg)
+    except ValueError:
+        raise ValueError(__('Obrigatório url_seg para get_aop_issues'))
+    else:
+        order_by = ["-year"]
+        return Issue.objects(journal=journal, type='ahead').order_by(*order_by)

--- a/opac/webapp/main/views.py
+++ b/opac/webapp/main/views.py
@@ -358,6 +358,10 @@ def router_legacy():
             if not issue.journal.is_public:
                 abort(404, JOURNAL_UNPUBLISH + _(issue.journal.unpublish_reason))
 
+            if issue.url_segment and "ahead" in issue.url_segment:
+                return redirect(
+                    url_for('main.aop_toc', url_seg=url_seg), code=301)
+
             return redirect(
                 url_for(
                     "main.issue_toc",
@@ -778,6 +782,9 @@ def issue_grid(url_seg):
 
 @main.route('/toc/<string:url_seg>/<string:url_seg_issue>/')
 def issue_toc_legacy(url_seg, url_seg_issue):
+    if url_seg_issue and "ahead" in url_seg_issue:
+        return redirect(url_for('main.aop_toc', url_seg=url_seg), code=301)
+
     return redirect(
         url_for('main.issue_toc',
                 url_seg=url_seg,
@@ -788,6 +795,9 @@ def issue_toc_legacy(url_seg, url_seg_issue):
 @main.route('/j/<string:url_seg>/i/<string:url_seg_issue>/')
 @cache.cached(key_prefix=cache_key_with_lang_with_qs)
 def issue_toc(url_seg, url_seg_issue):
+    if url_seg_issue and "ahead" in url_seg_issue:
+        return redirect(url_for('main.aop_toc', url_seg=url_seg), code=301)
+
     # idioma da sessão
     language = session.get('lang', get_locale())
 

--- a/opac/webapp/main/views.py
+++ b/opac/webapp/main/views.py
@@ -847,7 +847,10 @@ def issue_toc(url_seg, url_seg_issue):
         suppl=issue.suppl_text, language=language[:2].lower())
 
     context = {
-        'this_page_url': '/j/{}/i/{}/'.format(url_seg, url_seg_issue),
+        'this_page_url': url_for(
+                            'main.issue_toc',
+                            url_seg=url_seg,
+                            url_seg_issue=, url_seg_issue),
         'next_issue': next_issue,
         'previous_issue': previous_issue,
         'journal': journal,
@@ -869,17 +872,11 @@ def issue_toc(url_seg, url_seg_issue):
 @main.route('/j/<string:url_seg>/aop')
 @cache.cached(key_prefix=cache_key_with_lang_with_qs)
 def aop_toc(url_seg):
-    # idioma da sessão
-    language = session.get('lang', get_locale())
 
     section_filter = request.args.get('section', '', type=str)
 
-    aop_issues = controllers.get_aop_issues(url_seg)
-
-    if not aop_issues:
-        abort(404, _('Artigos ahead of print não encontrados'))
-
-    aop_issues = [aop_issue for aop_issue in aop_issues if aop_issue.is_public]
+    aop_issues = controllers.get_aop_issues(url_seg) or []
+    aop_issues = [i for i in aop_issues if i.is_public]
     if not aop_issues:
         abort(404, _('Artigos ahead of print não encontrados'))
 
@@ -920,7 +917,7 @@ def aop_toc(url_seg):
         setattr(article, "article_pdf_languages", article_pdf_languages)
 
     context = {
-        'this_page_url': '/j/{}/aop'.format(url_seg),
+        'this_page_url': url_for("main.aop_toc", url_seg),
         'next_issue': next_issue,
         'previous_issue': previous_issue,
         'journal': journal,

--- a/opac/webapp/main/views.py
+++ b/opac/webapp/main/views.py
@@ -850,7 +850,7 @@ def issue_toc(url_seg, url_seg_issue):
         'this_page_url': url_for(
                             'main.issue_toc',
                             url_seg=url_seg,
-                            url_seg_issue=, url_seg_issue),
+                            url_seg_issue=url_seg_issue),
         'next_issue': next_issue,
         'previous_issue': previous_issue,
         'journal': journal,
@@ -917,7 +917,7 @@ def aop_toc(url_seg):
         setattr(article, "article_pdf_languages", article_pdf_languages)
 
     context = {
-        'this_page_url': url_for("main.aop_toc", url_seg),
+        'this_page_url': url_for("main.aop_toc", url_seg=url_seg),
         'next_issue': next_issue,
         'previous_issue': previous_issue,
         'journal': journal,

--- a/opac/webapp/main/views.py
+++ b/opac/webapp/main/views.py
@@ -831,7 +831,7 @@ def issue_toc(url_seg, url_seg_issue):
         setattr(article, "article_text_languages", article_text_languages)
         setattr(article, "article_pdf_languages", article_pdf_languages)
 
-    issue_legend = descriptive_short_format(
+    issue_bibliographic_strip = descriptive_short_format(
         title=journal.title, short_title=journal.short_title,
         pubdate=str(issue.year), volume=issue.volume, number=issue.number,
         suppl=issue.suppl_text, language=language[:2].lower())
@@ -842,7 +842,7 @@ def issue_toc(url_seg, url_seg_issue):
         'previous_issue': previous_issue,
         'journal': journal,
         'issue': issue,
-        'issue_legend': issue_legend,
+        'issue_bibliographic_strip': issue_bibliographic_strip,
         'articles': articles,
         'sections': sections,
         'section_filter': section_filter,
@@ -888,14 +888,17 @@ def aop_toc(url_seg):
             if section_filter != '':
                 _articles = _articles.filter(section__iexact=section_filter)
             articles.extend(_articles)
+    if not articles:
+        abort(404, _('Artigos ahead of print não encontrados'))
 
     if sections:
         sections = sorted([k for k in sections if k is not None])
 
+    previous_issue = None
     next_issue = None
-    issues = controllers.get_issues_by_jid(journal.id, is_public=True)
+    issues = controllers.get_issues_by_jid(journal.id, is_public=True) or []
     for i in issues:
-        if i.number != "ahead":
+        if i not in aop_issues:
             previous_issue = i
             break
 
@@ -906,18 +909,13 @@ def aop_toc(url_seg):
         setattr(article, "article_text_languages", article_text_languages)
         setattr(article, "article_pdf_languages", article_pdf_languages)
 
-    issue_legend = descriptive_short_format(
-        title=journal.title, short_title=journal.short_title,
-        pubdate=datetime.now().isoformat()[:4], number="ahead",
-        language=language[:2].lower())
-
     context = {
         'this_page_url': '/j/{}/aop'.format(url_seg),
         'next_issue': next_issue,
         'previous_issue': previous_issue,
         'journal': journal,
-        'issue': issue,
-        'issue_legend': issue_legend,
+        'issue': aop_issues[0],
+        'issue_bibliographic_strip': "ahead of print",
         'articles': articles,
         'sections': sections,
         'section_filter': section_filter,

--- a/opac/webapp/templates/issue/grid.html
+++ b/opac/webapp/templates/issue/grid.html
@@ -49,8 +49,7 @@
                 <th> - </th>
                 <td class="left">
                   <span class="rigth">
-                    <a href="{{ url_for('.issue_toc', url_seg=journal.url_segment,
-                  url_seg_issue=ahead.url_segment) }}" class="btn ahead">ahead of print</a>
+                    <a href="{{ url_for('.aop_toc', url_seg=journal.url_segment) }}" class="btn ahead">ahead of print</a>
                   </span>
                 </td>
               {% endif %}

--- a/opac/webapp/templates/issue/toc.html
+++ b/opac/webapp/templates/issue/toc.html
@@ -32,7 +32,7 @@
               <div class="issueInfo">
                 {% if issue.cover_url %}
                   <div class="cover">
-                      <img src="{{ issue.cover_url }}" class="image" alt="Capa: Vol. {{ issue.volume }} No. {{ issue.number }}" />
+                      <img src="{{ issue.cover_url }}" class="image" alt="Capa: {{issue_legend}}" />
                   </div>
                 {% endif %}
                 <div class="editor">
@@ -106,7 +106,7 @@
 
                       {% if sections %}
                         <li>
-                          <a href="{{ url_for('.issue_toc', url_seg=issue.journal.url_segment, url_seg_issue=issue.url_segment) }}">
+                          <a href="{{this_page_url}}">
                             {% if section_filter|length == 0 %}
                               {% trans %}Todas as seções{% endtrans %} <span style="color: #6789d3;">&laquo;</span>
                             {% else %}
@@ -119,7 +119,7 @@
                       {% for section in sections %}
                         {% if section %}
                           <li>
-                            <a href="{{ url_for('.issue_toc', url_seg=issue.journal.url_segment, url_seg_issue=issue.url_segment) }}?section={{ section|upper }}">
+                            <a href="{{this_page_url}}?section={{ section|upper }}">
                               {% if section_filter|upper == section|upper %}
                                 {{ section }} <span style="color: #6789d3;">&laquo;</span>
                               {% else %}

--- a/opac/webapp/templates/issue/toc.html
+++ b/opac/webapp/templates/issue/toc.html
@@ -1,6 +1,6 @@
 {% extends "issue/base.html" %}
 
-{% block title %}{{ issue_legend|default('--', True) }}{% endblock %}
+{% block title %}{{ issue_bibliographic_strip|default('--', True) }}{% endblock %}
 
 {% block main_content %}
 
@@ -32,7 +32,7 @@
               <div class="issueInfo">
                 {% if issue.cover_url %}
                   <div class="cover">
-                      <img src="{{ issue.cover_url }}" class="image" alt="Capa: {{issue_legend}}" />
+                      <img src="{{ issue.cover_url }}" class="image" alt="Capa: {{issue_bibliographic_strip}}" />
                   </div>
                 {% endif %}
                 <div class="editor">
@@ -92,13 +92,7 @@
 
                     <div class="collapse-content issueIndent">
                     <strong>
-
-                      {% if issue.type == 'ahead' %}
-                        {{ journal.title }} ahead of print
-                      {% else %}
-                        {{ issue_legend|default('--', True) }}
-                      {% endif %}
-
+                      {{ issue_bibliographic_strip|default('--', True) }}
                     </strong>
                     <!-- Cabeçalho do Issue Toc -->
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,3 +37,4 @@ blinker==1.4
 certifi==2019.11.28
 elastic-apm==5.5.2
 urllib3==1.25.8
+email_validator==1.0.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,7 @@ beautifulsoup4==4.6.3
 Flask-WTF==0.14.2
 Flask-Caching==1.4.0
 redis==2.10.6
-rq==0.9.2
+rq==0.12
 rq-dashboard==0.3.10
 rq-scheduler==0.8.2
 rq-scheduler-dashboard==0.0.2


### PR DESCRIPTION
#### O que esse PR faz?
Cria uma nova rota `/j/<acron>/aop` no lugar de:

- `/toc/<acron>/2019.nahead`
- `/j/<acron>/i/2019.nahead`
- `/scielo.php?script=sci_issuetoc&pid=0101-280020200050&lng=en&nrm=iso`

e redireciona as rotas antigas para a nova

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
com testes de unidade
`python opac/manager.py test -p test_main_views.py`
`python opac/manager.py test -p test_interface_TOC.py`

Ou acessando periódicos que contenha aop, verificando a rota nova e os redirecionamentos.

- 0004-274920200050 abo
- 0004-280320200050 ag
- 0004-282x20200050 anp
- 0006-870520200050 brag
- 0066-782x20200050 abc
- 0100-398420200050 rb
- 0101-206120200050 cta
- 0101-280020200050 jbn
- 0102-763820200050 rbccv
- 0103-218620200050 eh
- 0104-403620200050 ensaio
- 1413-415220200050 esa
- 1414-462x20200050 cadsc
- 1516-318020200050 spmj
- 1516-444620200050 rbp
- 1517-106x20200050 alea
- 1517-452220200050 soc
- 1519-698420200050 bjb
- 1519-707720200050 rcf
- 2237-608920200050 trends
- 2359-399720200050 aem
- 2359-564720200050 ijcs
- 2526-891020200050 cadbto

No entanto, não foram carregados no dsteste.

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
n/a

#### Quais são tickets relevantes?
Resolve parcialmente #1548 

### Referências
n/a
