### PR TITLE
Altera as URLs legadas para retorna HTTP status code 301.

### DIFF
--- a/opac/tests/test_legacy_urls.py
+++ b/opac/tests/test_legacy_urls.py
@@ -30,6 +30,24 @@ class LegacyURLTestCase(BaseTestCase):
 
                 self.assertTemplateUsed('journal/detail.html')
 
+    def test_journal_home_check_redirect(self):
+        """
+        Testa o acesso a home da revista pela URL antiga.
+        URL testa: scielo.php?script=sci_serial&pid=ISSN
+        """
+
+        with current_app.app_context():
+
+            journal = utils.makeOneJournal({'print_issn': '0000-0000'})
+
+            with self.client as c:
+
+                url = 'scielo.php?script=sci_serial&pid=%s' % journal.print_issn
+
+                response = c.get(url)
+
+                self.assertStatus(response, 301)
+
     def test_issue_grid(self):
         """
         Testa o acesso a grade de números da revista pela URL antiga.
@@ -51,6 +69,26 @@ class LegacyURLTestCase(BaseTestCase):
                 self.assertStatus(response, 200)
 
                 self.assertTemplateUsed('issue/grid.html')
+
+    def test_issue_grid_check_redirect(self):
+        """
+        Testa o acesso a grade de números da revista pela URL antiga.
+        URL testa: scielo.php?script=sci_issues&pid=ISSN
+        """
+
+        with current_app.app_context():
+
+            journal = utils.makeOneJournal({'print_issn': '0000-0000'})
+
+            issue = utils.makeOneIssue({'journal': journal.id, 'pid': '0000-0000'})
+
+            with self.client as c:
+
+                url = 'scielo.php?script=sci_issues&pid=%s' % issue.pid
+
+                response = c.get(url)
+
+                self.assertStatus(response, 301)
 
     def test_issue_toc(self):
         """
@@ -76,6 +114,29 @@ class LegacyURLTestCase(BaseTestCase):
                 self.assertStatus(response, 200)
 
                 self.assertTemplateUsed('issue/toc.html')
+
+    def test_issue_toc_check_redirect(self):
+        """
+        Testa o acesso ao toc de um números pela URL antiga.
+        URL testa: scielo.php?script=sci_issuetoc&pid=ISSN + ID DO número
+        """
+
+        with current_app.app_context():
+
+            journal = utils.makeOneJournal({'print_issn': '0000-0000'})
+
+            issue = utils.makeOneIssue({
+                'journal': journal.id,
+                'pid': '0000-000020160001'
+            })
+
+            with self.client as c:
+
+                url = 'scielo.php?script=sci_issuetoc&pid=%s' % issue.pid
+
+                response = c.get(url)
+
+                self.assertStatus(response, 301)
 
     def test_article_text(self):
         """
@@ -107,6 +168,35 @@ class LegacyURLTestCase(BaseTestCase):
                 self.assertStatus(response, 200)
 
                 self.assertTemplateUsed('article/detail.html')
+
+    def test_article_text_check_redirect(self):
+        """
+        Testa o acesso ao artigo pela URL antiga.
+        URL testa: scielo.php?script=sci_serial&pid=ISSN + ID DO número + ID DO ARTIGO
+        """
+
+        with current_app.app_context():
+
+            journal = utils.makeOneJournal({'print_issn': '0000-0000'})
+
+            issue = utils.makeOneIssue({
+                'journal': journal.id,
+                'pid': '0000-000020160001'
+            })
+
+            article = utils.makeOneArticle({
+                'journal': journal.id,
+                'issue': issue.id,
+                'pid': '0000-00002016000100251'
+            })
+
+            with self.client as c:
+
+                url = 'scielo.php?script=sci_arttext&pid=%s' % article.pid
+
+                response = c.get(url)
+
+                self.assertStatus(response, 301)
 
     @patch('requests.get')
     def test_router_legacy_pdf(self, mocked_requests_get):

--- a/opac/webapp/main/views.py
+++ b/opac/webapp/main/views.py
@@ -343,7 +343,8 @@ def router_legacy():
             if not journal.is_public:
                 abort(404, JOURNAL_UNPUBLISH + _(journal.unpublish_reason))
 
-            return journal_detail(journal.url_segment)
+            return redirect(url_for('main.journal_detail',
+                            url_seg=journal.url_segment), code=301)
 
         elif script_php == 'sci_issuetoc':
 
@@ -405,7 +406,8 @@ def router_legacy():
             if not journal.is_public:
                 abort(404, JOURNAL_UNPUBLISH + _(journal.unpublish_reason))
 
-            return issue_grid(journal.url_segment)
+            return redirect(url_for('main.issue_grid',
+                                    url_seg=journal.url_segment), 301)
 
         elif script_php == 'sci_pdf':
             # accesso ao pdf do artigo:
@@ -426,10 +428,15 @@ def router_legacy():
             if not article.journal.is_public:
                 abort(404, JOURNAL_UNPUBLISH + _(article.journal.unpublish_reason))
 
-            return article_detail_pdf(
-                article.journal.url_segment,
-                article.issue.url_segment,
-                article.url_segment)
+            return redirect(
+                url_for(
+                    'main.article_detail_pdf',
+                    url_seg=article.journal.url_segment,
+                    url_seg_issue=article.issue.url_segment,
+                    url_seg_article=article.url_segment,
+                ),
+                code=301
+            )
 
         else:
             abort(400, _(u'Requsição inválida ao tentar acessar o artigo com pid: %s' % pid))
@@ -1204,7 +1211,7 @@ def get_content_from_ssm(resource_ssm_media_path):
     try:
         ssm_response = fetch_data(url)
     except (NonRetryableError, RetryableError):
-        abort(404, _('Recruso não encontrado'))
+        abort(404, _('Recurso não encontrado'))
     else:
         return Response(ssm_response, mimetype=mimetype)
 


### PR DESCRIPTION
#### O que esse PR faz?
Esse PR tem como objetivo alterar o status code das URLs legadas para 301.

#### Onde a revisão poderia começar?

É possível revisar esse PR olhando os seguintes arquivos
- opac/tests/test_legacy_urls.py
- opac/webapp/main/views.py

#### Como este poderia ser testado manualmente?

Iniciando a aplicação com Docker:

```
make dev_compose_dev 
```

Acessando as seguintes páginas: 

- /scielo.php?script=sci_serial&pid=0066-782X&lng=en&nrm=iso
- /scielo.php?script=sci_issuetoc&pid=0066-782X20200002&lng=en&nrm=iso
- /scielo.php?script=sci_issues&pid=0066-782X&lng=en&nrm=iso

Foram adicionado novos testes no módulo de testes:

```
make dev_compose_make_test
```

#### Algum cenário de contexto que queira dar?
N/A

### Screenshots
N/A

#### Quais são tickets relevantes?
Tíquete referente a esse PR: https://github.com/scieloorg/opac/issues/1568

### Referências
N/A

