### PR TITLE
Altera o padrão de URL dos documentos

### DIFF
--- a/opac/tests/test_interface_menu.py
+++ b/opac/tests/test_interface_menu.py
@@ -414,7 +414,7 @@ class MenuTestCase(BaseTestCase):
                 self.assertIn(btn, response.data.decode('utf-8'))
 
     # Article Menu
-    def test_article_detail_menu(self):
+    def test_article_detail_v3_menu(self):
         """
         Teste para verificar se os botões estão ``anterior``, ``atual``,
         ``próximo`` estão disponíveis no ``article/detail.html``.
@@ -453,10 +453,9 @@ class MenuTestCase(BaseTestCase):
             })
 
             article_detail_url = url_for(
-                'main.article_detail',
+                'main.article_detail_v3',
                 url_seg=journal.url_segment,
-                url_seg_issue=issue.url_segment,
-                url_seg_article=article2.url_segment)
+                article_pid_v3=article2.aid)
 
             response = self.client.get(article_detail_url)
 
@@ -464,18 +463,16 @@ class MenuTestCase(BaseTestCase):
             self.assertTemplateUsed('article/detail.html')
 
             expect_btn_anterior = '<a href="%s" class="btn group">' % url_for(
-                '.article_detail',
+                '.article_detail_v3',
                 url_seg=journal.url_segment,
-                url_seg_issue=issue.url_segment,
-                url_seg_article=article1.url_segment)  # artigo anterior
+                article_pid_v3=article1.aid)  # artigo anterior
 
             expect_btn_atual = '<a href="#" class="btn group disabled">'  # número atual
 
             expect_btn_proximo = '<a href="%s" class="btn group">' % url_for(
-                '.article_detail',
+                '.article_detail_v3',
                 url_seg=journal.url_segment,
-                url_seg_issue=issue.url_segment,
-                url_seg_article=article3.url_segment)  # artigo seguinte
+                article_pid_v3=article3.aid)  # artigo seguinte
 
             expected_btns = [expect_btn_anterior, expect_btn_atual, expect_btn_proximo]
 
@@ -483,7 +480,7 @@ class MenuTestCase(BaseTestCase):
             for btn in expected_btns:
                 self.assertIn(btn, response.data.decode('utf-8'))
 
-    def test_article_detail_menu_when_last_article(self):
+    def test_article_detail_v3_menu_when_last_article(self):
         """
         Teste para verificar se os botões estão ``anterior``, ``atual``,
         ``próximo`` estão disponíveis no ``article/detail.html`` quando é o
@@ -523,10 +520,9 @@ class MenuTestCase(BaseTestCase):
             })
 
             article_detail_url = url_for(
-                'main.article_detail',
+                'main.article_detail_v3',
                 url_seg=journal.url_segment,
-                url_seg_issue=issue.url_segment,
-                url_seg_article=article3.url_segment)
+                article_pid_v3=article3.aid)
 
             response = self.client.get(article_detail_url)
 
@@ -538,10 +534,9 @@ class MenuTestCase(BaseTestCase):
             expect_btn_atual = '<a href="#" class="btn group disabled">'  # número atual
 
             expect_btn_proximo = '<a href="%s" class="btn group">' % url_for(
-                '.article_detail',
+                '.article_detail_v3',
                 url_seg=journal.url_segment,
-                url_seg_issue=issue.url_segment,
-                url_seg_article=article2.url_segment)  # artigo seguinte
+                article_pid_v3=article2.aid)  # artigo seguinte
 
             expected_btns = [expect_btn_anterior, expect_btn_atual, expect_btn_proximo]
 
@@ -549,7 +544,7 @@ class MenuTestCase(BaseTestCase):
             for btn in expected_btns:
                 self.assertIn(btn, response.data.decode('utf-8'))
 
-    def test_article_detail_menu_when_first_article(self):
+    def test_article_detail_v3_menu_when_first_article(self):
         """
         Teste para verificar se os botões estão ``anterior``, ``atual``,
         ``próximo`` estão disponíveis no ``article/detail.html`` quando é o
@@ -587,10 +582,9 @@ class MenuTestCase(BaseTestCase):
             })
 
             article_detail_url = url_for(
-                'main.article_detail',
+                'main.article_detail_v3',
                 url_seg=journal.url_segment,
-                url_seg_issue=issue.url_segment,
-                url_seg_article=article1.url_segment)
+                article_pid_v3=article1.aid)
 
             response = self.client.get(article_detail_url)
 
@@ -602,10 +596,9 @@ class MenuTestCase(BaseTestCase):
             expect_btn_atual = '<a href="#" class="btn group disabled">'  # número atual
 
             expect_btn_proximo = '<a href="%s" class="btn group">' % url_for(
-                '.article_detail',
+                '.article_detail_v3',
                 url_seg=journal.url_segment,
-                url_seg_issue=issue.url_segment,
-                url_seg_article=article2.url_segment)  # artigo seguinte
+                article_pid_v3=article2.aid)  # artigo seguinte
 
             expected_btns = [
                 expect_btn_anterior,

--- a/opac/tests/test_main_views.py
+++ b/opac/tests/test_main_views.py
@@ -487,9 +487,9 @@ class MainTestCase(BaseTestCase):
 
     # ARTICLE
 
-    def test_article_detail(self):
+    def test_article_detail_v3(self):
         """
-        Teste da ``view function`` ``article_detail``, deve retornar uma página
+        Teste da ``view function`` ``article_detail_v3``, deve retornar uma página
         que usa o template ``article/detail.html``.
         """
         with current_app.app_context():
@@ -511,11 +511,9 @@ class MainTestCase(BaseTestCase):
                                             'journal': journal,
                                             'url_segment': '10-11'})
 
-            response = self.client.get(url_for('main.article_detail',
+            response = self.client.get(url_for('main.article_detail_v3',
                                                url_seg=journal.url_segment,
-                                               url_seg_issue=issue.url_segment,
-                                               url_seg_article=article.url_segment,
-                                               lang_code='en'))
+                                               article_pid_v3=article.aid))
 
             self.assertStatus(response, 200)
             self.assertTemplateUsed('article/detail.html')
@@ -533,9 +531,9 @@ class MainTestCase(BaseTestCase):
                 content
             )
 
-    def test_article_detail_redirects_to_original_language(self):
+    def test_article_detail_v3_redirects_to_original_language(self):
         """
-        Teste da ``view function`` ``article_detail``, deve retornar uma página
+        Teste da ``view function`` ``article_detail_v3``, deve retornar uma página
         que usa o template ``article/detail.html``.
         """
         with current_app.app_context():
@@ -557,11 +555,10 @@ class MainTestCase(BaseTestCase):
                                             'journal': journal,
                                             'url_segment': '10-11'})
 
-            response = self.client.get(url_for('main.article_detail',
+            response = self.client.get(url_for('main.article_detail_v3',
                                                url_seg=journal.url_segment,
-                                               url_seg_issue=issue.url_segment,
-                                               url_seg_article=article.url_segment,
-                                               lang_code='ru'))
+                                               article_pid_v3=article.aid,
+                                               lang='ru'))
 
             self.assertStatus(response, 301)
 
@@ -619,9 +616,9 @@ class MainTestCase(BaseTestCase):
             self.assertEqual(self.get_context_variable('issue').id, article.issue.id)
 
     @patch('requests.get')
-    def test_article_detail_translate_version_(self, mocked_requests_get):
+    def test_article_detail_v3_translate_version_(self, mocked_requests_get):
         """
-        Teste da ``view function`` ``article_detail``, deve retornar uma página
+        Teste da ``view function`` ``article_detail_v3``, deve retornar uma página
         que usa o template ``article/detail.html``.
         """
         mocked_response = Mock()
@@ -648,22 +645,20 @@ class MainTestCase(BaseTestCase):
                                                 ]
                                             })
 
-            response = self.client.get(url_for('main.article_detail',
+            response = self.client.get(url_for('main.article_detail_v3',
                                                url_seg=journal.url_segment,
-                                               url_seg_issue=issue.url_segment,
-                                               url_seg_article=article.url_segment,
-                                               lang_code='pt'))
+                                               article_pid_v3=article.aid,
+                                               lang='pt'))
 
             self.assertStatus(response, 200)
             self.assertTemplateUsed('article/detail.html')
             content = response.data.decode('utf-8')
 
             urls = {html['lang']: url_for(
-                                   'main.article_detail',
+                                   'main.article_detail_v3',
                                    url_seg=journal.url_segment,
-                                   url_seg_issue=issue.url_segment,
-                                   url_seg_article=article.url_segment,
-                                   lang_code=html['lang'])
+                                   article_pid_v3=article.aid,
+                                   lang=html['lang'])
                     for html in article.htmls
                     }
             self.assertIn('{}">Deutsch<'.format(urls['de']), content)
@@ -677,9 +672,9 @@ class MainTestCase(BaseTestCase):
                 content.count('{}">bla<'.format(urls['bla'])), 1)
 
     @patch('requests.get')
-    def test_article_detail_has_citation_title_in_pt(self, mocked_requests_get):
+    def test_article_detail_v3_has_citation_title_in_pt(self, mocked_requests_get):
         """
-        Teste da ``view function`` ``article_detail``, deve retornar uma página
+        Teste da ``view function`` ``article_detail_v3``, deve retornar uma página
         que usa o template ``article/detail.html``.
         """
         mocked_response = Mock()
@@ -713,11 +708,10 @@ class MainTestCase(BaseTestCase):
                                                 ]
                                             })
 
-            response = self.client.get(url_for('main.article_detail',
+            response = self.client.get(url_for('main.article_detail_v3',
                                                url_seg=journal.url_segment,
-                                               url_seg_issue=issue.url_segment,
-                                               url_seg_article=article.url_segment,
-                                               lang_code='pt'))
+                                               article_pid_v3=article.aid,
+                                               lang='pt'))
 
             self.assertStatus(response, 200)
             self.assertTemplateUsed('article/detail.html')
@@ -733,9 +727,9 @@ class MainTestCase(BaseTestCase):
             )
 
     @patch('requests.get')
-    def test_article_detail_has_citation_title_in_es(self, mocked_requests_get):
+    def test_article_detail_v3_has_citation_title_in_es(self, mocked_requests_get):
         """
-        Teste da ``view function`` ``article_detail``, deve retornar uma página
+        Teste da ``view function`` ``article_detail_v3``, deve retornar uma página
         que usa o template ``article/detail.html``.
         """
         mocked_response = Mock()
@@ -769,11 +763,10 @@ class MainTestCase(BaseTestCase):
                                                 ]
                                             })
 
-            response = self.client.get(url_for('main.article_detail',
+            response = self.client.get(url_for('main.article_detail_v3',
                                                url_seg=journal.url_segment,
-                                               url_seg_issue=issue.url_segment,
-                                               url_seg_article=article.url_segment,
-                                               lang_code='es'))
+                                               article_pid_v3=article.aid,
+                                               lang='es'))
 
             self.assertStatus(response, 200)
             self.assertTemplateUsed('article/detail.html')
@@ -787,9 +780,9 @@ class MainTestCase(BaseTestCase):
                 content
             )
 
-    def test_article_detail_links_to_gscholar(self):
+    def test_article_detail_v3_links_to_gscholar(self):
         """
-        Teste da ``view function`` ``article_detail``, deve retornar uma página
+        Teste da ``view function`` ``article_detail_v3``, deve retornar uma página
         que usa o template ``article/detail.html``.
         """
         with current_app.app_context():
@@ -805,11 +798,10 @@ class MainTestCase(BaseTestCase):
                                             'journal': journal,
                                             'url_segment': '10-11'})
 
-            response = self.client.get(url_for('main.article_detail',
+            response = self.client.get(url_for('main.article_detail_v3',
                                                url_seg=journal.url_segment,
-                                               url_seg_issue=issue.url_segment,
-                                               url_seg_article=article.url_segment,
-                                               lang_code='pt'))
+                                               article_pid_v3=article.aid,
+                                               lang='pt'))
 
             self.assertStatus(response, 200)
             page_content = response.data.decode('utf-8')
@@ -825,9 +817,9 @@ class MainTestCase(BaseTestCase):
             self.assertIn('Google', page_content)
             self.assertIn('/scholar', page_content)
 
-    def test_article_detail_links_to_gscholar_for_article_without_title(self):
+    def test_article_detail_v3_links_to_gscholar_for_article_without_title(self):
         """
-        Teste da ``view function`` ``article_detail``, deve retornar uma página
+        Teste da ``view function`` ``article_detail_v3``, deve retornar uma página
         que usa o template ``article/detail.html``.
         """
         with current_app.app_context():
@@ -842,11 +834,10 @@ class MainTestCase(BaseTestCase):
                                             'journal': journal,
                                             'url_segment': '10-11'})
 
-            response = self.client.get(url_for('main.article_detail',
+            response = self.client.get(url_for('main.article_detail_v3',
                                                url_seg=journal.url_segment,
-                                               url_seg_issue=issue.url_segment,
-                                               url_seg_article=article.url_segment,
-                                               lang_code='pt'))
+                                               article_pid_v3=article.aid,
+                                               lang='pt'))
 
             self.assertStatus(response, 200)
             page_content = response.data.decode('utf-8')
@@ -1046,10 +1037,10 @@ class MainTestCase(BaseTestCase):
             self.assertStatus(response, 404)
             self.assertIn('Artigo não encontrado', response.data.decode('utf-8'))
 
-    def test_legacy_url_redirects_to_article_detail(self):
+    def test_legacy_url_redirects_to_article_detail_v3(self):
         """
         Teste da view ``router_legacy_article``, deve retornar redirecionar
-        para os detalhes do artigo (main.article_detail)
+        para os detalhes do artigo (main.article_detail_v3)
         """
         with current_app.app_context():
             utils.makeOneCollection()
@@ -1077,17 +1068,16 @@ class MainTestCase(BaseTestCase):
             self.assertRedirects(
                 response,
                 url_for(
-                    'main.article_detail',
+                    'main.article_detail_v3',
                     url_seg=journal.url_segment,
-                    url_seg_issue=issue.url_segment,
-                    url_seg_article=article.url_segment,
-                    lang_code='en'
+                    article_pid_v3=article.aid,
+                    lang='en'
                 ),
             )
 
-    def test_article_detail_without_articles(self):
+    def test_article_detail_v3_without_articles(self):
         """
-        Teste para avaliar o retorno da ``view function`` ``article_detail``
+        Teste para avaliar o retorno da ``view function`` ``article_detail_v3``
         quando não existe artigos cadastrados deve retornar ``status_code`` 404
         e a msg ``Artigo não encontrado``
         """
@@ -1096,18 +1086,17 @@ class MainTestCase(BaseTestCase):
 
         issue = utils.makeOneIssue({'journal': journal})
 
-        response = self.client.get(url_for('main.article_detail',
+        response = self.client.get(url_for('main.article_detail_v3',
                                            url_seg=journal.url_segment,
-                                           url_seg_issue=issue.url_segment,
-                                           url_seg_article='9827-817',
-                                           lang_code='pt'))
+                                           article_pid_v3='unknown-article',
+                                           lang='pt'))
 
         self.assertStatus(response, 404)
         self.assertIn('Artigo não encontrado', response.data.decode('utf-8'))
 
-    def test_article_detail_with_journal_attrib_is_public_false(self):
+    def test_article_detail_v3_with_journal_attrib_is_public_false(self):
         """
-        Teste da ``view function`` ``article_detail`` acessando um artigo
+        Teste da ``view function`` ``article_detail_v3`` acessando um artigo
         com atributo is_public=True, porém com um periódico com atributo
         is_public=False deve retorna uma página com ``status_code`` 404 e msg
         cadastrada no atributo ``reason`` do periódico.
@@ -1125,18 +1114,17 @@ class MainTestCase(BaseTestCase):
             'issue': issue,
             'journal': journal})
 
-        response = self.client.get(url_for('main.article_detail',
+        response = self.client.get(url_for('main.article_detail_v3',
                                            url_seg=journal.url_segment,
-                                           url_seg_issue=issue.url_segment,
-                                           url_seg_article=article.url_segment,
-                                           lang_code='pt'))
+                                           article_pid_v3=article.aid,
+                                           lang='pt'))
 
         self.assertStatus(response, 404)
         self.assertIn(unpublish_reason, response.data.decode('utf-8'))
 
     def test_article_detail_with_issue_attrib_is_public_false(self):
         """
-        Teste da ``view function`` ``article_detail`` acessando um artigo
+        Teste da ``view function`` ``article_detail_v3`` acessando um artigo
         com atributo is_public=False, porém com um periódico com atributo
         is_public=True deve retorna uma página com ``status_code`` 404 e msg
         cadastrada no atributo ``reason`` do número.
@@ -1153,18 +1141,17 @@ class MainTestCase(BaseTestCase):
             'issue': issue.id,
             'journal': journal.id})
 
-        response = self.client.get(url_for('main.article_detail',
+        response = self.client.get(url_for('main.article_detail_v3',
                                            url_seg=journal.url_segment,
-                                           url_seg_issue=issue.url_segment,
-                                           url_seg_article=article.url_segment,
-                                           lang_code='pt'))
+                                           article_pid_v3=article.aid,
+                                           lang='pt'))
 
         self.assertStatus(response, 404)
         self.assertIn(unpublish_reason, response.data.decode('utf-8'))
 
     def test_article_detail_with_article_attrib_is_public_false(self):
         """
-        Teste da ``view function`` ``article_detail`` acessando um artigo
+        Teste da ``view function`` ``article_detail_v3`` acessando um artigo
         com atributo is_public=False, deve retorna uma página com
          ``status_code`` 404 e msg cadastrada no atributo ``reason`` do artigo.
         """
@@ -1179,11 +1166,10 @@ class MainTestCase(BaseTestCase):
             'issue': issue,
             'journal': journal})
 
-        response = self.client.get(url_for('main.article_detail',
+        response = self.client.get(url_for('main.article_detail_v3',
                                            url_seg=journal.url_segment,
-                                           url_seg_issue=issue.url_segment,
-                                           url_seg_article=article.url_segment,
-                                           lang_code='pt'))
+                                           article_pid_v3=article.aid,
+                                           lang='pt'))
 
         self.assertStatus(response, 404)
         self.assertIn(unpublish_reason, response.data.decode('utf-8'))
@@ -1236,11 +1222,10 @@ class MainTestCase(BaseTestCase):
                 ]
             })
 
-            response = self.client.get(url_for('main.article_detail',
+            response = self.client.get(url_for('main.article_detail_v3',
                                                url_seg=journal.url_segment,
-                                               url_seg_issue=issue.url_segment,
-                                               url_seg_article=article.url_segment,
-                                               lang_code='en'), follow_redirects=False)
+                                               article_pid_v3=article.aid,
+                                               lang='en'), follow_redirects=False)
 
             self.assertStatus(response, 200)
             self.assertTemplateUsed('article/detail.html')
@@ -1309,7 +1294,7 @@ class MainTestCase(BaseTestCase):
                                                url_seg=journal.url_segment,
                                                url_seg_issue=issue.url_segment,
                                                url_seg_article=article.url_segment,
-                                               lang_code='ru'), follow_redirects=False)
+                                               lang='ru'), follow_redirects=False)
 
             self.assertStatus(response, 301)
 

--- a/opac/webapp/templates/article/includes/_dont_display_full_text.html
+++ b/opac/webapp/templates/article/includes/_dont_display_full_text.html
@@ -16,7 +16,7 @@
                 <a
                   rel="noreferrer"
                   target="_blank"
-                  href="{{ url_for('.article_detail_pdf', url_seg=article.journal.url_segment, url_seg_issue=article.issue.url_segment, url_seg_article=article.url_segment, lang_code=article.pdfs[0].lang) }}">
+                  href="{{ url_for('.article_detail_v3', url_seg=article.journal.url_segment, article_pid_v3=article.aid, lang=article.pdfs[0].lang, format='pdf') }}">
                   {% trans %}Texto completo em{% endtrans %} PDF
                 </a>
               </p>

--- a/opac/webapp/templates/article/includes/levelMenu.html
+++ b/opac/webapp/templates/article/includes/levelMenu.html
@@ -24,7 +24,7 @@
                   {% if is_pdf_page -%}
                     <a target='_blank' href="{{ url_for('.article_detail_pdf', url_seg=journal.url_segment, url_seg_issue=issue.url_segment, url_seg_article=previous_article.url_segment) }}" class="btn group">
                   {%- else -%}
-                    <a href="{{ url_for('.article_detail', url_seg=journal.url_segment, url_seg_issue=issue.url_segment, url_seg_article=previous_article.url_segment) }}" class="btn group">
+                    <a href="{{ url_for('.article_detail_v3', url_seg=journal.url_segment, article_pid_v3=previous_article.aid) }}" class="btn group">
                   {% endif %}
                 {%- endif %}
                   &laquo; {% trans %}anterior{% endtrans %}
@@ -42,7 +42,7 @@
                 {%- if is_pdf_page -%}
                   <a target='_blank' href="{{ url_for('.article_detail_pdf', url_seg=journal.url_segment, url_seg_issue=issue.url_segment, url_seg_article=next_article.url_segment) }}" class="btn group">
                 {%- else -%}
-                  <a href="{{ url_for('.article_detail', url_seg=journal.url_segment, url_seg_issue=issue.url_segment, url_seg_article=next_article.url_segment) }}" class="btn group">
+                  <a href="{{ url_for('.article_detail_v3', url_seg=journal.url_segment, article_pid_v3=next_article.aid) }}" class="btn group">
                 {%- endif %}
               {%- endif %}
                   {% trans %}seguinte{% endtrans %} &raquo;
@@ -77,7 +77,7 @@
                   {% if is_pdf_page -%}
                     <a target='_blank' href="{{ url_for('.article_detail_pdf', url_seg=journal.url_segment, url_seg_issue=issue.url_segment, url_seg_article=previous_article.url_segment) }}" class="btn group ">
                   {%- else -%}
-                    <a href="{{ url_for('.article_detail', url_seg=journal.url_segment, url_seg_issue=issue.url_segment, url_seg_article=previous_article.url_segment) }}" class="btn group">
+                    <a href="{{ url_for('.article_detail_v3', url_seg=journal.url_segment, article_pid_v3=previous_article.aid) }}" class="btn group">
                   {% endif %}
                 {%- endif %}
                   <span class="sci-ico-arrowLeft">
@@ -95,7 +95,7 @@
                 {%- if is_pdf_page -%}
                   <a target='_blank' href="{{ url_for('.article_detail_pdf', url_seg=journal.url_segment, url_seg_issue=issue.url_segment, url_seg_article=next_article.url_segment) }}" class="btn group">
                 {%- else -%}
-                  <a href="{{ url_for('.article_detail', url_seg=journal.url_segment, url_seg_issue=issue.url_segment, url_seg_article=next_article.url_segment) }}" class="btn group">
+                  <a href="{{ url_for('.article_detail_v3', url_seg=journal.url_segment, article_pid_v3=next_article.aid) }}" class="btn group">
                 {%- endif %}
               {%- endif %}
                   <span class="sci-ico-arrowRight">
@@ -130,7 +130,7 @@
                   {% if is_pdf_page -%}
                     <a target='_blank' href="{{ url_for('.article_detail_pdf', url_seg=journal.url_segment, url_seg_issue=issue.url_segment, url_seg_article=previous_article.url_segment) }}" class="btn group ">
                   {%- else -%}
-                    <a href="{{ url_for('.article_detail', url_seg=journal.url_segment, url_seg_issue=issue.url_segment, url_seg_article=previous_article.url_segment) }}" class="btn group">
+                    <a href="{{ url_for('.article_detail_v3', url_seg=journal.url_segment, article_pid_v3=previous_article.aid) }}" class="btn group">
                   {% endif %}
                 {%- endif %}
                   <span class="sci-ico-arrowLeft">
@@ -148,7 +148,7 @@
                 {%- if is_pdf_page -%}
                   <a target='_blank' href="{{ url_for('.article_detail_pdf', url_seg=journal.url_segment, url_seg_issue=issue.url_segment, url_seg_article=next_article.url_segment) }}" class="btn group">
                 {%- else -%}
-                  <a href="{{ url_for('.article_detail', url_seg=journal.url_segment, url_seg_issue=issue.url_segment, url_seg_article=next_article.url_segment) }}" class="btn group">
+                  <a href="{{ url_for('.article_detail_v3', url_seg=journal.url_segment, article_pid_v3=next_article.aid) }}" class="btn group">
                 {%- endif %}
               {%- endif %}
                   <span class="sci-ico-arrowRight">
@@ -458,7 +458,7 @@
               {% if is_pdf_page -%}
                 <a target='_blank' href="{{ url_for('.article_detail_pdf', url_seg=journal.url_segment, url_seg_issue=issue.url_segment, url_seg_article=previous_article.url_segment) }}" class="btn group">
               {%- else -%}
-                <a href="{{ url_for('.article_detail', url_seg=journal.url_segment, url_seg_issue=issue.url_segment, url_seg_article=previous_article.url_segment) }}" class="btn group">
+                <a href="{{ url_for('.article_detail_v3', url_seg=journal.url_segment, article_pid_v3=previous_article.aid) }}" class="btn group">
               {% endif %}
             {%- endif %}
               <span class="sci-ico-arrowLeft"></span>
@@ -476,7 +476,7 @@
               {%- if is_pdf_page -%}
                 <a target='_blank' href="{{ url_for('.article_detail_pdf', url_seg=journal.url_segment, url_seg_issue=issue.url_segment, url_seg_article=next_article.url_segment) }}" class="btn group">
               {%- else -%}
-                <a href="{{ url_for('.article_detail', url_seg=journal.url_segment, url_seg_issue=issue.url_segment, url_seg_article=next_article.url_segment) }}" class="btn group">
+                <a href="{{ url_for('.article_detail_v3', url_seg=journal.url_segment, article_pid_v3=next_article.aid) }}" class="btn group">
               {%- endif %}
             {%- endif %}
                 <span class="sci-ico-arrowRight"></span>

--- a/opac/webapp/templates/article/includes/levelMenu.html
+++ b/opac/webapp/templates/article/includes/levelMenu.html
@@ -22,7 +22,7 @@
                     <a href="#" class="btn group disabled">
                 {% else %}
                   {% if is_pdf_page -%}
-                    <a target='_blank' href="{{ url_for('.article_detail_pdf', url_seg=journal.url_segment, url_seg_issue=issue.url_segment, url_seg_article=previous_article.url_segment) }}" class="btn group">
+                    <a target='_blank' href="{{ url_for('.article_detail_v3', url_seg=journal.url_segment, article_pid_v3=previous_article.aid, format='pdf') }}" class="btn group">
                   {%- else -%}
                     <a href="{{ url_for('.article_detail_v3', url_seg=journal.url_segment, article_pid_v3=previous_article.aid) }}" class="btn group">
                   {% endif %}
@@ -40,7 +40,7 @@
                   <a href="#" class="btn group disabled">
               {% else %}
                 {%- if is_pdf_page -%}
-                  <a target='_blank' href="{{ url_for('.article_detail_pdf', url_seg=journal.url_segment, url_seg_issue=issue.url_segment, url_seg_article=next_article.url_segment) }}" class="btn group">
+                  <a target='_blank' href="{{ url_for('.article_detail_v3', url_seg=journal.url_segment, article_pid_v3=next_article.aid, format='pdf') }}" class="btn group">
                 {%- else -%}
                   <a href="{{ url_for('.article_detail_v3', url_seg=journal.url_segment, article_pid_v3=next_article.aid) }}" class="btn group">
                 {%- endif %}
@@ -75,7 +75,7 @@
                     <a href="#" class="btn group disabled">
                 {% else %}
                   {% if is_pdf_page -%}
-                    <a target='_blank' href="{{ url_for('.article_detail_pdf', url_seg=journal.url_segment, url_seg_issue=issue.url_segment, url_seg_article=previous_article.url_segment) }}" class="btn group ">
+                    <a target='_blank' href="{{ url_for('.article_detail_v3', url_seg=journal.url_segment, article_pid_v3=previous_article.aid, format='pdf') }}" class="btn group ">
                   {%- else -%}
                     <a href="{{ url_for('.article_detail_v3', url_seg=journal.url_segment, article_pid_v3=previous_article.aid) }}" class="btn group">
                   {% endif %}
@@ -93,7 +93,7 @@
                   <a href="#" class="btn group disabled">
               {% else %}
                 {%- if is_pdf_page -%}
-                  <a target='_blank' href="{{ url_for('.article_detail_pdf', url_seg=journal.url_segment, url_seg_issue=issue.url_segment, url_seg_article=next_article.url_segment) }}" class="btn group">
+                  <a target='_blank' href="{{ url_for('.article_detail_v3', url_seg=journal.url_segment, article_pid_v3=next_article.aid, format='pdf') }}" class="btn group">
                 {%- else -%}
                   <a href="{{ url_for('.article_detail_v3', url_seg=journal.url_segment, article_pid_v3=next_article.aid) }}" class="btn group">
                 {%- endif %}
@@ -128,7 +128,7 @@
                     <a href="#" class="btn group disabled">
                 {% else %}
                   {% if is_pdf_page -%}
-                    <a target='_blank' href="{{ url_for('.article_detail_pdf', url_seg=journal.url_segment, url_seg_issue=issue.url_segment, url_seg_article=previous_article.url_segment) }}" class="btn group ">
+                    <a target='_blank' href="{{ url_for('.article_detail_v3', url_seg=journal.url_segment, article_pid_v3=previous_article.aid, format='pdf') }}" class="btn group ">
                   {%- else -%}
                     <a href="{{ url_for('.article_detail_v3', url_seg=journal.url_segment, article_pid_v3=previous_article.aid) }}" class="btn group">
                   {% endif %}
@@ -146,7 +146,7 @@
                   <a href="#" class="btn group disabled">
               {% else %}
                 {%- if is_pdf_page -%}
-                  <a target='_blank' href="{{ url_for('.article_detail_pdf', url_seg=journal.url_segment, url_seg_issue=issue.url_segment, url_seg_article=next_article.url_segment) }}" class="btn group">
+                  <a target='_blank' href="{{ url_for('.article_detail_v3', url_seg=journal.url_segment, article_pid_v3=next_article.aid, format='pdf') }}" class="btn group">
                 {%- else -%}
                   <a href="{{ url_for('.article_detail_v3', url_seg=journal.url_segment, article_pid_v3=next_article.aid) }}" class="btn group">
                 {%- endif %}
@@ -164,7 +164,7 @@
         <div class="col-lg-3 col-md-2 col-sm-4 hidden-md">
 
           {% if article and article.pdfs|length == 1 %}
-            <a target='_blank' href="{{ url_for('.article_detail_pdf', url_seg=article.journal.url_segment, url_seg_issue=article.issue.url_segment, url_seg_article=article.url_segment, lang_code=article.pdfs[0].lang) }}" class="btn">
+            <a target='_blank' href="{{ url_for('.article_detail_v3', url_seg=article.journal.url_segment, article_pid_v3=article.aid, format='pdf', lang=article.pdfs[0].lang) }}" class="btn">
               <span class="sci-ico-filePDF"></span> PDF
             </a>
           {% endif%}
@@ -188,7 +188,7 @@
               <ul class="dropdown-menu">
                 {% for pdf in article.pdfs  %}
                   <li>
-                    <a target='_blank' href="{{ url_for('.article_detail_pdf', url_seg=article.journal.url_segment, url_seg_issue=article.issue.url_segment, url_seg_article=article.url_segment, lang_code=pdf.lang) }}">
+                    <a target='_blank' href="{{ url_for('.article_detail_v3', url_seg=article.journal.url_segment, article_pid_v3=article.aid, format='pdf', lang=pdf.lang) }}">
                       {% if pdf.lang == 'es' %}
                         {% trans %}Download PDF (Espanhol){% endtrans %}
                       {% elif pdf.lang == 'en' %}
@@ -239,7 +239,7 @@
         <div class="col-lg-3 col-md-3 col-sm-4 hidden-sm hidden-lg">
 
           {% if article and article.pdfs|length == 1 %}
-            <a target='_blank' href="{{ url_for('.article_detail_pdf', url_seg=article.journal.url_segment, url_seg_issue=article.issue.url_segment, url_seg_article=article.url_segment, lang_code=article.pdfs[0].lang) }}" class="btn"><span class="sci-ico-filePDF"></span> PDF</a>
+            <a target='_blank' href="{{ url_for('.article_detail_v3', url_seg=article.journal.url_segment, article_pid_v3=article.pid, format='pdf', lang=article.pdfs[0].lang) }}" class="btn"><span class="sci-ico-filePDF"></span> PDF</a>
           {% endif%}
 
           {% if config['READCUBE_ENABLED'] and article.doi and article.pid %}
@@ -259,7 +259,7 @@
               <ul class="dropdown-menu">
                 {% for pdf in article.pdfs  %}
                   <li>
-                    <a target='_blank' href="{{ url_for('.article_detail_pdf', url_seg=article.journal.url_segment, url_seg_issue=article.issue.url_segment, url_seg_article=article.url_segment, lang_code=pdf.lang) }}">
+                    <a target='_blank' href="{{ url_for('.article_detail_v3', url_seg=article.journal.url_segment, article_pid_v3=article.aid, format='pdf', lang=pdf.lang) }}">
                       {% if pdf.lang == 'es' %}
                         {% trans %}Download PDF (Espanhol){% endtrans %}
                       {% elif pdf.lang == 'en' %}
@@ -384,7 +384,7 @@
             </a>
 
             {% if article and article.pdfs|length == 1 %}
-              <a target='_blank' href="{{ url_for('.article_detail_pdf', url_seg=article.journal.url_segment, url_seg_issue=article.issue.url_segment, url_seg_article=article.url_segment, lang_code=article.pdfs[0].lang) }}" class="btn">
+              <a target='_blank' href="{{ url_for('.article_detail_v3', url_seg=article.journal.url_segment, article_pid_v3=article.aid, format='pdf', lang=article.pdfs[0].lang) }}" class="btn">
                 <span class="sci-ico-filePDF"></span> PDF
               </a>
             {% endif%}
@@ -456,7 +456,7 @@
                 <a href="#" class="btn group disabled">
             {% else %}
               {% if is_pdf_page -%}
-                <a target='_blank' href="{{ url_for('.article_detail_pdf', url_seg=journal.url_segment, url_seg_issue=issue.url_segment, url_seg_article=previous_article.url_segment) }}" class="btn group">
+                <a target='_blank' href="{{ url_for('.article_detail_v3', url_seg=journal.url_segment, article_pid_v3=previous_article.aid, format='pdf') }}" class="btn group">
               {%- else -%}
                 <a href="{{ url_for('.article_detail_v3', url_seg=journal.url_segment, article_pid_v3=previous_article.aid) }}" class="btn group">
               {% endif %}
@@ -474,7 +474,7 @@
                 <a href="#" class="btn group disabled">
             {% else %}
               {%- if is_pdf_page -%}
-                <a target='_blank' href="{{ url_for('.article_detail_pdf', url_seg=journal.url_segment, url_seg_issue=issue.url_segment, url_seg_article=next_article.url_segment) }}" class="btn group">
+                <a target='_blank' href="{{ url_for('.article_detail_v3', url_seg=journal.url_segment, article_pid_v3=next_article.aid, format='pdf') }}" class="btn group">
               {%- else -%}
                 <a href="{{ url_for('.article_detail_v3', url_seg=journal.url_segment, article_pid_v3=next_article.aid) }}" class="btn group">
               {%- endif %}

--- a/opac/webapp/templates/article/includes/modal/download.html
+++ b/opac/webapp/templates/article/includes/modal/download.html
@@ -17,7 +17,7 @@
             {% if article and article.pdfs %}
               {% for pdf in article.pdfs  %}
                 <li>
-                  <a target='_blank' href="{{ url_for('.article_detail_pdf', url_seg=article.journal.url_segment, url_seg_issue=article.issue.url_segment, url_seg_article=article.url_segment, lang_code=pdf.lang) }}">
+                  <a target='_blank' href="{{ url_for('.article_detail_v3', url_seg=article.journal.url_segment, article_pid_v3=article.aid, lang=pdf.lang, format='pdf') }}">
                     {% if pdf.lang == 'es' %}
                       {% trans %}Espanhol{% endtrans %}
                     {% elif pdf.lang == 'en' %}

--- a/opac/webapp/templates/article/includes/recent_articles_row.html
+++ b/opac/webapp/templates/article/includes/recent_articles_row.html
@@ -1,6 +1,6 @@
 <div class="slide-item release">
   <div class="col-md-12">
-    <a href="{{ url_for('.article_detail', url_seg=article.journal.url_segment, url_seg_issue=article.issue.url_segment, url_seg_article=article.url_segment) }}">
+    <a href="{{ url_for('.article_detail_v3', url_seg=article.journal.url_segment, article_pid_v3=article.aid) }}">
       {% if session.lang %}
         <h3 class="ellipsis">
           {{ article.get_title_by_lang(session.lang[:2])|default(_('Documento sem título'), true)|striptags }}

--- a/opac/webapp/templates/issue/toc.html
+++ b/opac/webapp/templates/issue/toc.html
@@ -182,7 +182,7 @@
                             <li>
                               {% trans %}PDF{% endtrans %}:
                               {% for lang, url in article.article_pdf_languages|sort(attribute='0') %}
-                                <a target='_blank' href="{{ url_for('.article_detail_pdf', url_seg=journal.url_segment, url_seg_issue=issue.url_segment, url_seg_article=article.url_segment, lang_code=lang) }}" data-toggle="tooltip" data-placement="bottom" title="{{lang|trans_alpha2}}">
+                                <a target='_blank' href="{{ url_for('.article_detail_v3', url_seg=journal.url_segment, article_pid_v3=article.aid, format='pdf', lang=lang) }}" data-toggle="tooltip" data-placement="bottom" title="{{lang|trans_alpha2}}">
                                   {{ lang }}
                                 </a>
                               {% endfor %}

--- a/opac/webapp/templates/issue/toc.html
+++ b/opac/webapp/templates/issue/toc.html
@@ -171,7 +171,7 @@
                             <li>
                               {% trans %}Texto{% endtrans %}:
                               {% for lang in article.article_text_languages|sort %}
-                                <a href="{{ url_for('.article_detail', url_seg=journal.url_segment, url_seg_issue=issue.url_segment, url_seg_article=article.url_segment, lang_code=lang) }}" data-toggle="tooltip" data-placement="bottom" title="{{lang|trans_alpha2}}">
+                                <a href="{{ url_for('.article_detail_v3', url_seg=journal.url_segment, article_pid_v3=article.aid, lang=lang) }}" data-toggle="tooltip" data-placement="bottom" title="{{lang|trans_alpha2}}">
                                   {{ lang }}
                                 </a>
                               {% endfor %}


### PR DESCRIPTION
Altera o padrão de URL dos documentos em HTML e PDF, conforme descrito em #1580. As URLs para HTML e PDF foram unificadas e o argumento `format`, da querystring, passou a ser utilizado para especificar o formato desejado. 

#### Onde a revisão poderia começar?
N/A

#### Como este poderia ser testado manualmente?
1. Inicie uma instância povoada com documentos em HTML e PDF.
2. Acesse o sumário de um periódico e verifique que os links para as versões HTML e PDF dos documentos estão conforme o padrão `/j/:acron/a/:id_doc?format=:format&lang=:lang`, sendo opcionais todos os argumentos da querystring.
3. Acesse a página de um periódico e em seguida clique no ícone de RSS, no canto inferior direito da tela e no canto superior direito da "moldura" aonde são apresentados os conteúdos do periódico, e verifique que as URLs dos documentos estão conforme o mesmo padrão descrito anteriormente.
4. Acesse a página de um periódico e verifique que os links para as versões HTML dos documentos na área "Artigos mais recentes" estão conforme o padrão descrito.
5. Acesse a página do texto completo de um documento e verifique se os links dos botões "Anterior", "Seguinte" e "PDF", na barra de navegação estão conforme o mesmo padrão descrito anteriormente. Para os links dos PDFs, perceba a presença do argumento `format=pdf` na querystring.
6. Acesse a página do texto completo de um documento e verifique se o link para o PDF no menu flutuante (canto inferior direito) está conforme o mesmo padrão descrito anteriormente. Perceba a presença do argumento `format=pdf` na querystring.
7. Acesse a página do texto completo de um documento e verifique se os links para as versões HTML em outros idiomas, no menu flutuante (canto inferior direito), opção "Versões e traduções", estão conforme o padrão descrito. Perceba a presença do argumento `lang` na querystring.
8. Acesse as URLs antigas do site clássico e verifique que é retornado o código http 301, direcionando o cliente para a URL no novo padrão. Para este teste sugiro o uso do programa `curl` com a opção `--head`, na linha de comando.

#### Algum cenário de contexto que queira dar?
N/A

### Screenshots
N/A

#### Quais são tickets relevantes?
#1580 

### Referências
N/A

