### PR TITLE
Alterar o código de status para 500 quando um erro de integração ocorre

### DIFF
--- a/opac/webapp/main/views.py
+++ b/opac/webapp/main/views.py
@@ -1140,8 +1140,10 @@ def article_detail_v3(url_seg, article_pid_v3):
 
         try:
             html, text_languages = render_html(article, qs_lang)
-        except (ValueError, NonRetryableError, RetryableError):
+        except (ValueError, NonRetryableError):
             abort(404, _('HTML do Artigo não encontrado ou indisponível'))
+        except RetryableError:
+            abort(500, _('Erro inesperado'))
         
         text_versions = sorted(
                [
@@ -1237,8 +1239,10 @@ def get_content_from_ssm(resource_ssm_media_path):
 
     try:
         ssm_response = fetch_data(url)
-    except (NonRetryableError, RetryableError):
+    except NonRetryableError:
         abort(404, _('Recurso não encontrado'))
+    except RetryableError:
+        abort(500, _('Erro inesperado'))
     else:
         return Response(ssm_response, mimetype=mimetype)
 


### PR DESCRIPTION
#### O que esse PR faz?

Este pull request modifica os _status_ de retorno para `500` quando acontece alguma falha de integração entre o site o kernel e/ou minio. Antes o status de retorno era o `404` indicando que aquele recurso não existia, isso obviamente era um erro.

#### Onde a revisão poderia começar?

- Pelo arquivo `opac/webapp/main/views.py`

#### Como este poderia ser testado manualmente?

Para testar este PR manualmente, deve-se:
- Suba uma instância funcional do site integrado com o Kernel e Minio;
- Navegue entre os arquivos para garantir que estão abrindo;
- Desligue o serviço do Kernel ou o minio;
- Tente navegar entre os artigos ou acessar os pdfs;
- Observe que o site deve informar erros 500 em vez de 400.

#### Algum cenário de contexto que queira dar?

Talvez devêssemos implementar rotinas para realizar retentativas de acesso  aos objetos do kernel e do minio. Isso poderia minimizar erros de apresentação para os clientes.

### Screenshots
N/A

#### Quais são tickets relevantes?

#1649

### Referências
N/A