### PR TITLE
Altera as rotas legadas para considerar todos os PIDS.

### DIFF
--- a/opac/tests/test_legacy_urls.py
+++ b/opac/tests/test_legacy_urls.py
@@ -169,6 +169,41 @@ class LegacyURLTestCase(BaseTestCase):
 
                 self.assertTemplateUsed('article/detail.html')
 
+    def test_article_text_looking_scielo_pids(self):
+        """
+        Testa o acesso ao artigo pela URL antiga considerando o campo ``scielo_pids``.
+        URL testa: scielo.php?script=sci_serial&pid=ISSN + ID DO número + ID DO ARTIGO
+        """
+
+        with current_app.app_context():
+
+            journal = utils.makeOneJournal({'print_issn': '0000-0000'})
+
+            issue = utils.makeOneIssue({
+                'journal': journal.id,
+                'pid': '0000-000000000000'
+            })
+
+            article = utils.makeOneArticle({
+                'journal': journal.id,
+                'issue': issue.id,
+                'pid': '0000-00000000000000001',
+                'scielo_pids': {'v2': '0000-00000000000000002',
+                                'v3': '0000-00000000000000003'}
+            })
+
+            with self.client as c:
+
+                for pid in article.scielo_pids.values():
+
+                    url = 'scielo.php?script=sci_arttext&pid=%s' % pid
+
+                    response = c.get(url, follow_redirects=True)
+
+                    self.assertStatus(response, 200)
+
+                    self.assertTemplateUsed('article/detail.html')
+
     def test_article_text_check_redirect(self):
         """
         Testa o acesso ao artigo pela URL antiga.
@@ -197,6 +232,100 @@ class LegacyURLTestCase(BaseTestCase):
                 response = c.get(url)
 
                 self.assertStatus(response, 301)
+
+    @patch('requests.get')
+    def test_article_pdf(self, mocked_requests_get):
+        """
+        Testa o acesso ao PDF pela URL antiga verificando em todas as versões do pid
+        campo ``scielo_pids``.
+        URL testa: scielo.php?script=sci_pdf&pid=ISSN + ID DO número + ID DO ARTIGO
+        """
+        mocked_response = Mock()
+        mocked_response.status_code = 200
+        mocked_response.content = b'<pdf>'
+        mocked_requests_get.return_value = mocked_response
+
+        with current_app.app_context():
+
+            journal = utils.makeOneJournal({'print_issn': '0000-0000'})
+
+            issue = utils.makeOneIssue({
+                'journal': journal.id,
+                'pid': '0000-000000000000'
+            })
+
+            article = utils.makeOneArticle({
+                'journal': journal.id,
+                'issue': issue.id,
+                'original_language': 'en',
+                'pid': '0000-00000000000000001',
+                'pdfs': [
+                    {
+                        'lang': 'en',
+                        'url': 'http://minio:9000/documentstore/1678-457X/JDH74Jr4SyDVpnkMyrqkDhF/e5e09c7d5e4e5052868372df837de4e1ee9d651a.pdf',
+                        'file_path': '/pdf/cta/v39s2/0101-2061-cta-fst30618.pdf',
+                        'type': 'pdf'
+                    }
+                ]
+
+            })
+
+            with self.client as c:
+
+                url = 'scielo.php?script=sci_pdf&pid=%s' % article.pid
+
+                response = c.get(url, follow_redirects=True)
+
+                self.assertStatus(response, 200)
+
+    @patch('requests.get')
+    def test_article_pdf_looking_scielo_pids(self, mocked_requests_get):
+        """
+        Testa o acesso ao PDF pela URL antiga verificando em todas as versões do pid
+        campo ``scielo_pids``.
+        URL testa: scielo.php?script=sci_pdf&pid=ISSN + ID DO número + ID DO ARTIGO
+        """
+        mocked_response = Mock()
+        mocked_response.status_code = 200
+        mocked_response.content = b'<pdf>'
+        mocked_requests_get.return_value = mocked_response
+
+        with current_app.app_context():
+
+            journal = utils.makeOneJournal({'print_issn': '0000-0000'})
+
+            issue = utils.makeOneIssue({
+                'journal': journal.id,
+                'pid': '0000-000000000000'
+            })
+
+            article = utils.makeOneArticle({
+                'journal': journal.id,
+                'issue': issue.id,
+                'original_language': 'en',
+                'pid': '0000-00000000000000001',
+                'scielo_pids': {'v2': '0000-00000000000000002',
+                                'v3': '0000-00000000000000003'},
+                'pdfs': [
+                    {
+                        'lang': 'en',
+                        'url': 'http://minio:9000/documentstore/1678-457X/JDH74Jr4SyDVpnkMyrqkDhF/e5e09c7d5e4e5052868372df837de4e1ee9d651a.pdf',
+                        'file_path': '/pdf/cta/v39s2/0101-2061-cta-fst30618.pdf',
+                        'type': 'pdf'
+                    }
+                ]
+
+            })
+
+            with self.client as c:
+
+                for pid in article.scielo_pids.values():
+
+                    url = 'scielo.php?script=sci_pdf&pid=%s' % pid
+
+                    response = c.get(url, follow_redirects=True)
+
+                    self.assertStatus(response, 200)
 
     @patch('requests.get')
     def test_router_legacy_pdf(self, mocked_requests_get):

--- a/opac/webapp/controllers.py
+++ b/opac/webapp/controllers.py
@@ -956,7 +956,7 @@ def get_article_by_scielo_pid(scielo_pid, **kwargs):
         raise ValueError(__('Obrigatório um pid.'))
 
     return Article.objects(
-        (Q(scielo_pids__v1=scielo_pid) | Q(scielo_pids__v2=scielo_pid) | Q(scielo_pids__v3=scielo_pid)),
+        (Q(pid=scielo_pid) | Q(scielo_pids__v1=scielo_pid) | Q(scielo_pids__v2=scielo_pid) | Q(scielo_pids__v3=scielo_pid)),
         **kwargs
     ).first()
 

--- a/opac/webapp/main/views.py
+++ b/opac/webapp/main/views.py
@@ -373,7 +373,7 @@ def router_legacy():
 
         elif script_php == 'sci_arttext' or script_php == 'sci_abstract':
 
-            article = controllers.get_article_by_pid(pid)
+            article = controllers.get_article_by_scielo_pid(pid)
 
             if not article:
                 article = controllers.get_article_by_oap_pid(pid)
@@ -401,7 +401,7 @@ def router_legacy():
 
         elif script_php == 'sci_pdf':
             # accesso ao pdf do artigo:
-            article = controllers.get_article_by_pid(pid)
+            article = controllers.get_article_by_scielo_pid(pid)
 
             if not article:
                 article = controllers.get_article_by_oap_pid(pid)
@@ -1107,9 +1107,9 @@ def article_detail_v3(url_seg, article_pid_v3):
         return redirect(
             url_for(
                 'main.article_detail_v3',
-                url_seg=url_seg, 
-                article_pid_v3=article_pid_v3, 
-                format=qs_format, 
+                url_seg=url_seg,
+                article_pid_v3=article_pid_v3,
+                format=qs_format,
                 lang=article.original_language,
             ),
             code=301
@@ -1153,7 +1153,7 @@ def article_detail_v3(url_seg, article_pid_v3):
             abort(404, _('HTML do Artigo não encontrado ou indisponível'))
         except RetryableError:
             abort(500, _('Erro inesperado'))
-        
+
         text_versions = sorted(
                [
                    (


### PR DESCRIPTION
#### O que esse PR faz?

Esse PR adiciona a capacidade de resolver as URLs do legado considerando todas as versões de PID.

#### Onde a revisão poderia começar?

É possível revisar esse PR, verificando as alterações nos seguintes módulo: 

- opac/webapp/controllers.py
- opac/webapp/main/views.py

Ou nos novos testes adicionados no módulo: 

- opac/tests/test_legacy_urls.py


#### Como este poderia ser testado manualmente?

Para testar manualmente é necessária uma instância do OPAC com dados e acessar as seguintes URLs com conteúdo.

https://new.scielo.br/scielo.php?script=sci_arttext&pid={PID} 
https://new.scielo.br/scielo.php?script=sci_pdf&pid={PID}

Sendo que para esse caso, um teste mais fiel seria que o PIDs utilizados estejam no campo `scielo_pids` do **opac_schema**.


#### Algum cenário de contexto que queira dar?
N/A

### Screenshots
N/A

#### Quais são tickets relevantes?

Tíquete referente a esse PR: https://github.com/scieloorg/opac/issues/1684

### Referências
N/A

