### PR TITLE
Apresenta `s/v` para ausência de volume no _grid_

### DIFF
--- a/opac/webapp/templates/issue/grid.html
+++ b/opac/webapp/templates/issue/grid.html
@@ -58,7 +58,11 @@
                   <tr>
                     <td>{{ year }}</td>
                     <th>
-                      {{ volume }}
+                      {% if volume %}
+                        {{ volume }}
+                      {% else %}
+                          s/v
+                      {% endif %}
                     </th>
                     <td class="left">
                       {# Verificando se é um número de volume #}


### PR DESCRIPTION
#### O que esse PR faz?
Apresenta `s/v` para ausência de volume no _grid_

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
Veja o #1327

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
<img width="649" alt="Captura de Tela 2020-11-25 às 10 38 32" src="https://user-images.githubusercontent.com/505143/100235006-9e7b6f00-2f0a-11eb-931a-ce9565bfc206.png">

#### Quais são tickets relevantes?
#1327

### Referências
n/a
