### PR TITLE
Atualiza a versão do Pillow para ficar compatível com packtools==2.6.8

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -46,7 +46,7 @@ https://github.com/scieloorg/packtools/archive/2.6.8.tar.gz#egg=packtools
 passlib==1.7.2
 pbr==5.4.5
 picles.plumber==0.11
-Pillow==5.2.0
+Pillow~=6.2
 pymongo==3.11.0
 PySocks==1.7.1
 python-dateutil==2.8.1


### PR DESCRIPTION
#### O que esse PR faz?
Atualiza a versão do Pillow para ficar compatível com packtools==2.6.8
https://travis-ci.org/github/scieloorg/opac/builds/746844320

```
ERROR: Cannot install -r /app/requirements.txt (line 45) and Pillow==5.2.0 because these package versions have conflicting dependencies.

The conflict is caused by:

    The user requested Pillow==5.2.0

    packtools 2.6.8rc20201201 depends on Pillow~=6.2

To fix this you could try to:

1. loosen the range of package versions you've specified

2. remove package versions to allow pip attempt to solve the dependency conflict
```