### PR TITLE
Disponibiliza publicamente os XMLs SciELO PS dos documentos

### DIFF
--- a/opac/tests/fixtures/document.xml
+++ b/opac/tests/fixtures/document.xml
@@ -1,0 +1,9 @@
+<!DOCTYPE article PUBLIC "-//NLM//DTD JATS (Z39.96) Journal Publishing DTD v1.1 20151215//EN" "https://jats.nlm.nih.gov/publishing/1.1/JATS-journalpublishing1.dtd">
+<article xmlns:xlink="http://www.w3.org/1999/xlink" specific-use="sps-1.9" dtd-version="1.1" xml:lang="pt" article-type="research-article">
+  <front>
+  </front>
+  <body>
+  </body>
+  <back>
+  </back>
+</article>

--- a/opac/tests/test_main_views.py
+++ b/opac/tests/test_main_views.py
@@ -2274,7 +2274,7 @@ class TestArticleDetailV3Meta(BaseTestCase):
           content="https://website/j/acron/a/pidv3/?format=pdf&amp;lang=idioma_selecionado"/>`
         """
 
-        with current_app.app_context():
+        with current_app.test_request_context() as context:
             utils.makeOneCollection()
             journal = utils.makeOneJournal()
             issue = utils.makeOneIssue({'journal': journal})
@@ -2312,8 +2312,9 @@ class TestArticleDetailV3Meta(BaseTestCase):
                     url_seg=journal.url_segment,
                     article_pid_v3=article.aid,
                     lang="es"
-                    )
                 )
+            )
+            self.assertStatus(response, 200)
             content = response.data.decode('utf-8')
 
             soup = BeautifulSoup(content, 'html.parser')
@@ -2321,8 +2322,10 @@ class TestArticleDetailV3Meta(BaseTestCase):
             self.assertEqual(len(meta_tags), 1)
 
             content_url = urlparse(meta_tags[0].get("content"))
-            self.assertEqual(content_url.scheme, "https")
-            self.assertEqual(content_url.netloc, current_app.config.get('SERVER_NAME'))
+            self.assertEqual(
+                "{}://{}/".format(content_url.scheme, content_url.netloc),
+                context.request.url_root
+            )
             self.assertEqual(
                 content_url.path, "/j/journal_acron/a/{}/".format(article.aid)
             )
@@ -2340,7 +2343,7 @@ class TestArticleDetailV3Meta(BaseTestCase):
           content="https://website/j/acron/a/pidv3/?format=xml"/>`
         """
 
-        with current_app.app_context():
+        with current_app.test_request_context() as context:
             utils.makeOneCollection()
             journal = utils.makeOneJournal()
             issue = utils.makeOneIssue({'journal': journal})
@@ -2368,8 +2371,10 @@ class TestArticleDetailV3Meta(BaseTestCase):
             self.assertEqual(len(meta_tags), 1)
 
             content_url = urlparse(meta_tags[0].get("content"))
-            self.assertEqual(content_url.scheme, "https")
-            self.assertEqual(content_url.netloc, current_app.config.get('SERVER_NAME'))
+            self.assertEqual(
+                "{}://{}/".format(content_url.scheme, content_url.netloc),
+                context.request.url_root
+            )
             self.assertEqual(
                 content_url.path, "/j/journal_acron/a/{}/".format(article.aid)
             )

--- a/opac/webapp/main/views.py
+++ b/opac/webapp/main/views.py
@@ -9,7 +9,20 @@ from urllib.parse import urlparse
 from datetime import datetime
 from collections import OrderedDict
 from flask_babelex import gettext as _
-from flask import render_template, abort, current_app, request, session, redirect, jsonify, url_for, Response, send_from_directory, g
+from flask import (
+    render_template,
+    abort,
+    current_app,
+    request,
+    session,
+    redirect,
+    jsonify,
+    url_for,
+    Response,
+    send_from_directory,
+    g,
+    make_response,
+)
 from werkzeug.contrib.atom import AtomFeed
 from urllib.parse import urljoin
 from legendarium.formatter import descriptive_short_format
@@ -1214,10 +1227,21 @@ def article_detail_v3(url_seg, article_pid_v3):
         else:
             return get_content_from_ssm(pdf_ssm_path)
 
+    def _handle_xml():
+        if current_app.config["SSM_XML_URL_REWRITE"]:
+            result = fetch_data(normalize_ssm_url(article.xml))
+        else:
+            result = fetch_data(article.xml)
+        response = make_response(result)
+        response.headers['Content-Type'] = 'application/xml'
+        return response
+
     if 'html' == qs_format:
         return _handle_html()
     elif 'pdf' == qs_format:
         return _handle_pdf()
+    elif 'xml' == qs_format:
+        return _handle_xml()
     else:
         abort(400, _('Formato não suportado'))
 

--- a/opac/webapp/main/views.py
+++ b/opac/webapp/main/views.py
@@ -1095,13 +1095,16 @@ def article_detail(url_seg, url_seg_issue, url_seg_article, lang_code=''):
 @main.route('/j/<string:url_seg>/a/<string:article_pid_v3>/')
 @cache.cached(key_prefix=cache_key_with_lang)
 def article_detail_v3(url_seg, article_pid_v3):
+    qs_format = request.args.get('format', 'html', type=str)
+    if qs_format == "xml" and request.args.get('lang'):
+        abort(400, _("Idioma não suportado para formato XML"))
+
     article = controllers.get_article_by_aid(article_pid_v3)
 
     if not article or article.journal.url_segment != url_seg:
         abort(404, _('Artigo não encontrado'))
 
     qs_lang = request.args.get('lang', article.original_language, type=str)
-    qs_format = request.args.get('format', 'html', type=str)
 
     if qs_lang not in article.languages + [article.original_language]:
         return redirect(

--- a/opac/webapp/main/views.py
+++ b/opac/webapp/main/views.py
@@ -1160,10 +1160,10 @@ def article_detail_v3(url_seg, article_pid_v3):
                        )
                 break
 
+        website = current_app.config.get('SERVER_NAME')
+        if website:
+            website = "https://{}".format(website)
         if citation_pdf_url:
-            website = current_app.config.get('SERVER_NAME')
-            if website:
-                website = "https://{}".format(website)
             citation_pdf_url = "{}{}".format(website, citation_pdf_url)
         try:
             html, text_languages = render_html(article, qs_lang)
@@ -1187,6 +1187,15 @@ def article_detail_v3(url_seg, article_pid_v3):
                    for lang in text_languages
                ]
            )
+        citation_xml_url = "{}{}".format(
+            website,
+            url_for(
+                'main.article_detail_v3',
+                url_seg=article.journal.url_segment,
+                article_pid_v3=article_pid_v3,
+                format="xml",
+            )
+        )
         context = {
             'next_article': next_article,
             'previous_article': previous_article,
@@ -1195,6 +1204,7 @@ def article_detail_v3(url_seg, article_pid_v3):
             'issue': article.issue,
             'html': html,
             'citation_pdf_url': citation_pdf_url,
+            'citation_xml_url': citation_xml_url,
             'article_lang': qs_lang,
             'text_versions': text_versions,
             'related_links': controllers.related_links(article),

--- a/opac/webapp/main/views.py
+++ b/opac/webapp/main/views.py
@@ -1160,9 +1160,10 @@ def article_detail_v3(url_seg, article_pid_v3):
                        )
                 break
 
-        website = current_app.config.get('SERVER_NAME')
+        website = request.url
         if website:
-            website = "https://{}".format(website)
+            parsed_url = urlparse(request.url)
+            website = "{}://{}".format(parsed_url.scheme, parsed_url.netloc)
         if citation_pdf_url:
             citation_pdf_url = "{}{}".format(website, citation_pdf_url)
         try:

--- a/opac/webapp/templates/article/includes/meta.html
+++ b/opac/webapp/templates/article/includes/meta.html
@@ -32,6 +32,10 @@
     <meta name="citation_pdf_url" content="{{ citation_pdf_url }}"></meta>
 {% endif -%}
 
+{% if citation_xml_url -%}
+    <meta name="citation_xml_url" content="{{ citation_xml_url }}"></meta>
+{% endif -%}
+
 {% if article.elocation -%}
    <meta name="citation_firstpage" content="{{ article.elocation }}"></meta>
 {% else -%}

--- a/opac/webapp/translations/en/LC_MESSAGES/messages.po
+++ b/opac/webapp/translations/en/LC_MESSAGES/messages.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version:  OPAC\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-05-20 11:19-0300\n"
+"POT-Creation-Date: 2020-12-03 11:58-0300\n"
 "PO-Revision-Date: 2018-03-06 19:50+0000\n"
 "Last-Translator: jamil Atta <atta.jamil@gmail.com>\n"
 "Language: en\n"
@@ -41,23 +41,23 @@ msgstr ""
 msgid "Periódico"
 msgstr "Journal"
 
-#: opac/tests/test_controller.py:541 opac/webapp/controllers.py:759
+#: opac/tests/test_controller.py:541 opac/webapp/controllers.py:776
 msgid "Obrigatório um assets_code."
 msgstr " assets_code is mandatory."
 
-#: opac/tests/test_controller.py:550 opac/webapp/controllers.py:762
+#: opac/tests/test_controller.py:550 opac/webapp/controllers.py:779
 msgid "Obrigatório um journal."
 msgstr "Journal is mandatory."
 
-#: opac/tests/test_controller.py:1133 opac/webapp/controllers.py:998
+#: opac/tests/test_controller.py:1144 opac/webapp/controllers.py:1003
 msgid "Obrigatório o acrônimo do periódico."
 msgstr ""
 
-#: opac/tests/test_controller.py:1140 opac/webapp/controllers.py:1000
+#: opac/tests/test_controller.py:1151 opac/webapp/controllers.py:1005
 msgid "Obrigatório o campo issue_info."
 msgstr ""
 
-#: opac/tests/test_controller.py:1147 opac/webapp/controllers.py:1002
+#: opac/tests/test_controller.py:1158 opac/webapp/controllers.py:1007
 msgid "Obrigatório o nome do arquivo PDF."
 msgstr ""
 
@@ -128,6 +128,10 @@ msgstr "About the SciELO Network"
 #: opac/tests/test_main_errors.py:8
 msgid "Mensagem de erro explicativo para o usuário"
 msgstr "Explanatory user error message"
+
+#: opac/tests/test_main_views.py:1336 opac/webapp/main/views.py:1113
+msgid "Idioma não suportado para formato XML"
+msgstr "Lang not supported to XML format"
 
 #: opac/webapp/__init__.py:185 opac/webapp/__init__.py:186
 #: opac/webapp/__init__.py:187 opac/webapp/__init__.py:188
@@ -298,7 +302,7 @@ msgstr "Web of Science List"
 msgid "Lista by Institution"
 msgstr "List by Institution"
 
-#: opac/webapp/controllers.py:437
+#: opac/webapp/controllers.py:437 opac/webapp/controllers.py:658
 msgid "Obrigatório um jid."
 msgstr "A jid is required."
 
@@ -314,99 +318,103 @@ msgstr "A url_seg is required."
 msgid "Obrigatório um issn."
 msgstr "ISSN is required."
 
-#: opac/webapp/controllers.py:500
+#: opac/webapp/controllers.py:502
 msgid "Obrigatório um title."
 msgstr ""
 
-#: opac/webapp/controllers.py:538 opac/webapp/controllers.py:682
-#: opac/webapp/controllers.py:864 opac/webapp/controllers.py:875
+#: opac/webapp/controllers.py:540 opac/webapp/controllers.py:699
+#: opac/webapp/controllers.py:881 opac/webapp/controllers.py:892
 msgid "Obrigatório uma lista de ids."
 msgstr "A list of id's is required."
 
-#: opac/webapp/controllers.py:644 opac/webapp/controllers.py:895
+#: opac/webapp/controllers.py:643 opac/webapp/controllers.py:912
 msgid "Obrigatório um iid."
 msgstr "A iid is required."
 
-#: opac/webapp/controllers.py:701
+#: opac/webapp/controllers.py:661
+msgid "Obrigatório um label do issue."
+msgstr ""
+
+#: opac/webapp/controllers.py:718
 msgid "Obrigatório um jacron e issue_label."
 msgstr "A jacron and issue_label are required."
 
-#: opac/webapp/controllers.py:714
+#: opac/webapp/controllers.py:731
 msgid "Obrigatório um PID."
 msgstr "PID is required."
 
-#: opac/webapp/controllers.py:730
+#: opac/webapp/controllers.py:747
 msgid "Obrigatório um url_seg e url_seg_issue."
 msgstr "A url_seg and url_seg_issue are required."
 
-#: opac/webapp/controllers.py:777
+#: opac/webapp/controllers.py:794
 msgid "Obrigatório um aid."
 msgstr "A aid is required."
 
-#: opac/webapp/controllers.py:791
+#: opac/webapp/controllers.py:808
 msgid "Obrigatório um url_seg_article."
 msgstr "A url_seg_article is required."
 
-#: opac/webapp/controllers.py:806
+#: opac/webapp/controllers.py:823
 msgid "Obrigatório um iid and url_seg_article."
 msgstr "A iid and url_seg_article are required."
 
-#: opac/webapp/controllers.py:822
+#: opac/webapp/controllers.py:839
 msgid "Obrigatório um jid, url_seg_issue and url_seg_article."
 msgstr ""
 
-#: opac/webapp/controllers.py:933 opac/webapp/controllers.py:959
+#: opac/webapp/controllers.py:950 opac/webapp/controllers.py:976
 msgid "Obrigatório um pid."
 msgstr "pid is required."
 
-#: opac/webapp/controllers.py:946
+#: opac/webapp/controllers.py:963
 msgid "Obrigatório um aop_pid."
 msgstr "aop_pid is mandatory."
 
-#: opac/webapp/controllers.py:973
+#: opac/webapp/controllers.py:990
 msgid "Parámetro obrigatório: issue_iid."
 msgstr "issue_iid is mandatory."
 
-#: opac/webapp/controllers.py:1068
+#: opac/webapp/controllers.py:1064
 msgid "Parâmetro email deve ser uma string"
 msgstr "The parameter \"email\" must be a string."
 
-#: opac/webapp/controllers.py:1079
+#: opac/webapp/controllers.py:1075
 msgid "Parâmetro email deve ser uma inteiro"
 msgstr "The parameter \"email\" must be an integer."
 
-#: opac/webapp/controllers.py:1091 opac/webapp/controllers.py:1105
+#: opac/webapp/controllers.py:1087 opac/webapp/controllers.py:1101
 #, python-format
 msgid "Usuário deve ser do tipo %s"
 msgstr "User must be of type %s"
 
-#: opac/webapp/controllers.py:1161
+#: opac/webapp/controllers.py:1157
 msgid "Compartilhamento de link SciELO"
 msgstr "SciELO link sharing"
 
-#: opac/webapp/controllers.py:1162
+#: opac/webapp/controllers.py:1158
 #, python-format
 msgid "O usuário %s compartilha este link: %s, da SciELO"
 msgstr "The user %s share link: %s, of SciELO"
 
-#: opac/webapp/controllers.py:1170 opac/webapp/controllers.py:1206
-#: opac/webapp/controllers.py:1228
+#: opac/webapp/controllers.py:1166 opac/webapp/controllers.py:1202
+#: opac/webapp/controllers.py:1224
 msgid "Mensagem enviada!"
 msgstr "Message sent!"
 
-#: opac/webapp/controllers.py:1187
+#: opac/webapp/controllers.py:1183
 msgid "[Erro] Erro informado pelo usuário no site SciELO"
 msgstr "[Error] Error informed by the user in the SciELO site"
 
-#: opac/webapp/controllers.py:1190
+#: opac/webapp/controllers.py:1186
 msgid "aplicação"
 msgstr ""
 
-#: opac/webapp/controllers.py:1192
+#: opac/webapp/controllers.py:1188
 msgid "conteúdo"
 msgstr ""
 
-#: opac/webapp/controllers.py:1197
+#: opac/webapp/controllers.py:1193
 #, python-format
 msgid ""
 "O usuário <b>%s</b> com e-mail: <b>%s</b>, informa que existe um erro na "
@@ -417,20 +425,20 @@ msgstr ""
 " %s in the website SciELO.<br><br><b>Title of page:</b> "
 "%s<br><br><b>Link:</b> %s"
 
-#: opac/webapp/controllers.py:1218
+#: opac/webapp/controllers.py:1214
 msgid "Contato de usuário via site SciELO"
 msgstr "User contact by SciELO website"
 
-#: opac/webapp/controllers.py:1220
+#: opac/webapp/controllers.py:1216
 #, python-format
 msgid "O usuário %s, com e-mail: %s, entra em contato com a seguinte mensagem:"
 msgstr "User %s, e-mail: %s, contact us with the following message:"
 
-#: opac/webapp/controllers.py:1252
+#: opac/webapp/controllers.py:1248
 msgid "Obrigatório um slug_name."
 msgstr "An slug_name is required"
 
-#: opac/webapp/controllers.py:1288
+#: opac/webapp/controllers.py:1284
 msgid "Obrigatório url_seg para get_aop_issues"
 msgstr ""
 
@@ -938,7 +946,9 @@ msgstr "The full text has been unavailable"
 #: opac/webapp/admin/views.py:646
 #, python-format
 msgid "Ocorreu um erro ao tentar indisponibilizar completo. Erro: %(ex)s"
-msgstr "An error was thrown while trying to make the full text unavailable. Erro: %(ex)s"
+msgstr ""
+"An error was thrown while trying to make the full text unavailable. Erro:"
+" %(ex)s"
 
 #: opac/webapp/admin/views.py:649
 msgid "Disponibilizar texto completo"
@@ -951,7 +961,9 @@ msgstr "The full text has been available"
 #: opac/webapp/admin/views.py:657
 #, python-format
 msgid "Ocorreu um erro ao tentar disponibilizar completo Erro: %(ex)s"
-msgstr "An error was thrown while trying to make the full text unavailable. Erro: %(ex)s"
+msgstr ""
+"An error was thrown while trying to make the full text unavailable. Erro:"
+" %(ex)s"
 
 #: opac/webapp/admin/views.py:666
 msgid "Artigo(s) publicado com sucesso!!"
@@ -993,68 +1005,69 @@ msgstr "Audited Id"
 msgid "Dados dos campos"
 msgstr "Field data"
 
-#: opac/webapp/main/views.py:33
+#: opac/webapp/main/views.py:46
 msgid "O periódico está indisponível por motivo de: "
 msgstr "The journal is unavailable because:"
 
-#: opac/webapp/main/views.py:34
+#: opac/webapp/main/views.py:47
 msgid "O número está indisponível por motivo de: "
 msgstr "The Issue is unavailable because of:"
 
-#: opac/webapp/main/views.py:35
+#: opac/webapp/main/views.py:48
 msgid "O artigo está indisponível por motivo de: "
 msgstr "The article is unavailable because:"
 
-#: opac/webapp/main/views.py:133
+#: opac/webapp/main/views.py:146
 msgid "Código de idioma inválido"
 msgstr "Invalid language code"
 
-#: opac/webapp/main/views.py:248
+#: opac/webapp/main/views.py:261
 msgid "Últimos periódicos inseridos na coleção"
 msgstr "Latest journals added to the collection"
 
-#: opac/webapp/main/views.py:249
+#: opac/webapp/main/views.py:262
 #, python-format
 msgid "10 últimos periódicos inseridos na coleção %s"
 msgstr "10 latest journals added to the collection %s"
 
-#: opac/webapp/main/views.py:308
+#: opac/webapp/main/views.py:321
 msgid "Página não encontrada"
 msgstr ""
 
-#: opac/webapp/main/views.py:333 opac/webapp/main/views.py:435
-#: opac/webapp/main/views.py:1314
+#: opac/webapp/main/views.py:346 opac/webapp/main/views.py:436
+#: opac/webapp/main/views.py:1360
 #, python-format
 msgid "Requsição inválida ao tentar acessar o artigo com pid: %s"
 msgstr ""
 
-#: opac/webapp/main/views.py:341 opac/webapp/main/views.py:403
-#: opac/webapp/main/views.py:454 opac/webapp/main/views.py:523
-#: opac/webapp/main/views.py:571 opac/webapp/main/views.py:725
-#: opac/webapp/main/views.py:747
+#: opac/webapp/main/views.py:354 opac/webapp/main/views.py:407
+#: opac/webapp/main/views.py:455 opac/webapp/main/views.py:514
+#: opac/webapp/main/views.py:561 opac/webapp/main/views.py:703
+#: opac/webapp/main/views.py:725
 msgid "Periódico não encontrado"
 msgstr "Journal not found"
 
-#: opac/webapp/main/views.py:353 opac/webapp/main/views.py:809
-#: opac/webapp/main/views.py:946
+#: opac/webapp/main/views.py:367 opac/webapp/main/views.py:791
+#: opac/webapp/main/views.py:955
 msgid "Número não encontrado"
 msgstr "Issue not found"
 
-#: opac/webapp/main/views.py:381 opac/webapp/main/views.py:418
-#: opac/webapp/main/views.py:998 opac/webapp/main/views.py:1091
-#: opac/webapp/main/views.py:1245 opac/webapp/main/views.py:1318
+#: opac/webapp/main/views.py:395 opac/webapp/main/views.py:423
+#: opac/webapp/main/views.py:1006 opac/webapp/main/views.py:1096
+#: opac/webapp/main/views.py:1118 opac/webapp/main/views.py:1328
+#: opac/webapp/main/views.py:1364
 msgid "Artigo não encontrado"
 msgstr "Article not found"
 
-#: opac/webapp/main/views.py:547
+#: opac/webapp/main/views.py:538
 msgid "Artigo sem título"
 msgstr "Article not found"
 
-#: opac/webapp/main/views.py:622 opac/webapp/main/views.py:643
+#: opac/webapp/main/views.py:600 opac/webapp/main/views.py:621
 msgid "Requisição inválida. Deve ser por ajax"
 msgstr "Invalid request. Must be made via ajax"
 
-#: opac/webapp/main/views.py:659
+#: opac/webapp/main/views.py:637
 msgid ""
 "Parámetro \"filter\" é inválido, deve ser \"areas\", \"wos\" ou "
 "\"publisher\"."
@@ -1062,11 +1075,11 @@ msgstr ""
 "Invalid parameter \"filter\". Should be \"areas\", \"wos\" or "
 "\"publisher\"."
 
-#: opac/webapp/main/views.py:668
+#: opac/webapp/main/views.py:646
 msgid "Parámetro \"extension\" é inválido, deve ser \"csv\" ou \"xls\"."
 msgstr "Invalid parameter \"extension\". Should be \"csv\" or \"xls\"."
 
-#: opac/webapp/main/views.py:670
+#: opac/webapp/main/views.py:648
 msgid ""
 "Parámetro \"list_type\" é inválido, deve ser: \"alpha\", \"areas\", "
 "\"wos\" ou \"publisher\"."
@@ -1074,53 +1087,60 @@ msgstr ""
 "Invalid parameter \"list_type\". Should be: \"alpha\", \"areas\", \"wos\""
 " or \"publisher\"."
 
-#: opac/webapp/main/views.py:691
+#: opac/webapp/main/views.py:669
 msgid "Requisição inválida, deve ser ajax."
 msgstr ""
 
-#: opac/webapp/main/views.py:700
+#: opac/webapp/main/views.py:678
 msgid "Periódico não permite envio de email."
 msgstr ""
 
-#: opac/webapp/main/views.py:718
+#: opac/webapp/main/views.py:696
 msgid "Requisição inválida, captcha inválido."
 msgstr ""
 
-#: opac/webapp/main/views.py:881 opac/webapp/main/views.py:899
+#: opac/webapp/main/views.py:896 opac/webapp/main/views.py:917
 msgid "Artigos ahead of print não encontrados"
 msgstr ""
 
-#: opac/webapp/main/views.py:1082 opac/webapp/main/views.py:1240
+#: opac/webapp/main/views.py:1088 opac/webapp/main/views.py:1324
 msgid "Issue não encontrado"
 msgstr "Issue not found"
 
-#: opac/webapp/main/views.py:1130 opac/webapp/main/views.py:1136
-#: opac/webapp/main/views.py:1277 opac/webapp/main/views.py:1285
-#: opac/webapp/main/views.py:1287
-msgid "PDF do Artigo não encontrado"
-msgstr "Article's PDF not found"
-
-#: opac/webapp/main/views.py:1141
+#: opac/webapp/main/views.py:1171
 msgid "HTML do Artigo não encontrado ou indisponível"
 msgstr "HTML of article not found or unavailable"
 
-#: opac/webapp/main/views.py:1186
-msgid "Parâmetros insuficientes para obter o EPDF do artigo"
-msgstr "Insufficient parameters to obtain article's EPDF"
+#: opac/webapp/main/views.py:1173 opac/webapp/main/views.py:1292
+msgid "Erro inesperado"
+msgstr ""
 
-#: opac/webapp/main/views.py:1207
-msgid "Recruso não encontrado"
-msgstr "Resource not found"
+#: opac/webapp/main/views.py:1223 opac/webapp/main/views.py:1231
+#: opac/webapp/main/views.py:1233
+msgid "PDF do Artigo não encontrado"
+msgstr "Article's PDF not found"
 
-#: opac/webapp/main/views.py:1226 opac/webapp/main/views.py:1290
+#: opac/webapp/main/views.py:1236 opac/webapp/main/views.py:1311
 msgid "Recurso do Artigo não encontrado. Caminho inválido!"
 msgstr "Article resource not found. Invalid path!"
 
-#: opac/webapp/main/views.py:1301
+#: opac/webapp/main/views.py:1256
+msgid "Formato não suportado"
+msgstr ""
+
+#: opac/webapp/main/views.py:1269
+msgid "Parâmetros insuficientes para obter o EPDF do artigo"
+msgstr "Insufficient parameters to obtain article's EPDF"
+
+#: opac/webapp/main/views.py:1290
+msgid "Recurso não encontrado"
+msgstr ""
+
+#: opac/webapp/main/views.py:1347
 msgid "PDF do artigo não foi encontrado"
 msgstr "Article's PDF not found"
 
-#: opac/webapp/main/views.py:1345 opac/webapp/main/views.py:1376
+#: opac/webapp/main/views.py:1384 opac/webapp/main/views.py:1415
 msgid "Requisição inválida."
 msgstr "Invalid request"
 
@@ -1359,7 +1379,9 @@ msgid "sumário"
 msgstr "table of contents"
 
 #: opac/webapp/templates/article/includes/levelMenu.html:30
+#: opac/webapp/templates/issue/includes/alternative_header.html:74
 #: opac/webapp/templates/issue/includes/alternative_header.html:75
+#: opac/webapp/templates/journal/includes/alternative_header.html:70
 #: opac/webapp/templates/journal/includes/alternative_header.html:71
 msgid "anterior"
 msgstr "previous"
@@ -1367,7 +1389,9 @@ msgstr "previous"
 #: opac/webapp/templates/article/includes/levelMenu.html:35
 #: opac/webapp/templates/article/includes/levelMenu.html:88
 #: opac/webapp/templates/article/includes/levelMenu.html:141
+#: opac/webapp/templates/issue/includes/alternative_header.html:81
 #: opac/webapp/templates/issue/includes/alternative_header.html:82
+#: opac/webapp/templates/journal/includes/alternative_header.html:77
 #: opac/webapp/templates/journal/includes/alternative_header.html:78
 msgid "atual"
 msgstr "current"
@@ -1511,7 +1535,7 @@ msgid "números"
 msgstr "issues"
 
 #: opac/webapp/templates/collection/index.html:35
-#: opac/webapp/templates/issue/grid.html:67
+#: opac/webapp/templates/issue/grid.html:71
 msgid "artigos"
 msgstr "articles"
 
@@ -1900,19 +1924,19 @@ msgstr "Issues"
 msgid "Todos os números"
 msgstr "All issues"
 
-#: opac/webapp/templates/issue/grid.html:78
+#: opac/webapp/templates/issue/grid.html:82
 msgid "supl."
 msgstr "suppl."
 
-#: opac/webapp/templates/issue/grid.html:97
+#: opac/webapp/templates/issue/grid.html:101
 msgid "Nenhum número encontrado para esse periódico"
 msgstr "No Issue was found for this Journal"
 
-#: opac/webapp/templates/issue/grid.html:100
+#: opac/webapp/templates/issue/grid.html:104
 msgid "Histórico deste periódico na coleção"
 msgstr "History of the journal in the collection"
 
-#: opac/webapp/templates/issue/grid.html:104
+#: opac/webapp/templates/issue/grid.html:108
 msgid " admitido na coleção da SciELO"
 msgstr "admitted to the SciELO collection"
 
@@ -1991,11 +2015,13 @@ msgstr "Issues"
 
 #: opac/webapp/templates/issue/includes/alternative_header.html:68
 #: opac/webapp/templates/journal/includes/alternative_header.html:64
-#: opac/webapp/templates/journal/includes/levelMenu.html:90
+#: opac/webapp/templates/journal/includes/levelMenu.html:108
 msgid "todos"
 msgstr "all"
 
+#: opac/webapp/templates/issue/includes/alternative_header.html:88
 #: opac/webapp/templates/issue/includes/alternative_header.html:89
+#: opac/webapp/templates/journal/includes/alternative_header.html:84
 #: opac/webapp/templates/journal/includes/alternative_header.html:85
 msgid "próximo"
 msgstr "next"
@@ -2113,32 +2139,48 @@ msgstr "Journal homepage"
 msgid "todos os números"
 msgstr "all issues"
 
+#: opac/webapp/templates/journal/includes/levelMenu.html:24
 #: opac/webapp/templates/journal/includes/levelMenu.html:25
 #: opac/webapp/templates/journal/includes/levelMenu.html:29
+#: opac/webapp/templates/journal/includes/levelMenu.html:30
+#: opac/webapp/templates/journal/includes/levelMenu.html:34
+#: opac/webapp/templates/journal/includes/levelMenu.html:35
+#: opac/webapp/templates/journal/includes/levelMenu.html:115
+#: opac/webapp/templates/journal/includes/levelMenu.html:119
+#: opac/webapp/templates/journal/includes/levelMenu.html:123
 msgid "número anterior"
 msgstr "previous issue"
 
-#: opac/webapp/templates/journal/includes/levelMenu.html:36
-#: opac/webapp/templates/journal/includes/levelMenu.html:40
-#: opac/webapp/templates/journal/includes/levelMenu.html:107
-#: opac/webapp/templates/journal/includes/levelMenu.html:111
+#: opac/webapp/templates/journal/includes/levelMenu.html:41
+#: opac/webapp/templates/journal/includes/levelMenu.html:42
+#: opac/webapp/templates/journal/includes/levelMenu.html:46
+#: opac/webapp/templates/journal/includes/levelMenu.html:47
+#: opac/webapp/templates/journal/includes/levelMenu.html:51
+#: opac/webapp/templates/journal/includes/levelMenu.html:52
+#: opac/webapp/templates/journal/includes/levelMenu.html:130
+#: opac/webapp/templates/journal/includes/levelMenu.html:134
+#: opac/webapp/templates/journal/includes/levelMenu.html:138
 msgid "número atual"
 msgstr "current issue"
 
-#: opac/webapp/templates/journal/includes/levelMenu.html:47
-#: opac/webapp/templates/journal/includes/levelMenu.html:51
+#: opac/webapp/templates/journal/includes/levelMenu.html:58
+#: opac/webapp/templates/journal/includes/levelMenu.html:59
+#: opac/webapp/templates/journal/includes/levelMenu.html:63
+#: opac/webapp/templates/journal/includes/levelMenu.html:64
+#: opac/webapp/templates/journal/includes/levelMenu.html:68
+#: opac/webapp/templates/journal/includes/levelMenu.html:69
 msgid "número seguinte"
 msgstr "next issue"
 
-#: opac/webapp/templates/journal/includes/levelMenu.html:59
-#: opac/webapp/templates/journal/includes/levelMenu.html:130
+#: opac/webapp/templates/journal/includes/levelMenu.html:77
+#: opac/webapp/templates/journal/includes/levelMenu.html:161
 msgid "buscar"
 msgstr "search"
 
-#: opac/webapp/templates/journal/includes/levelMenu.html:65
-#: opac/webapp/templates/journal/includes/levelMenu.html:69
-#: opac/webapp/templates/journal/includes/levelMenu.html:136
-#: opac/webapp/templates/journal/includes/levelMenu.html:140
+#: opac/webapp/templates/journal/includes/levelMenu.html:83
+#: opac/webapp/templates/journal/includes/levelMenu.html:87
+#: opac/webapp/templates/journal/includes/levelMenu.html:167
+#: opac/webapp/templates/journal/includes/levelMenu.html:171
 msgid "métricas"
 msgstr "metrics"
 
@@ -2245,4 +2287,7 @@ msgstr "Open"
 
 #~ msgid "Disponibilizar completo"
 #~ msgstr ""
+
+#~ msgid "Recruso não encontrado"
+#~ msgstr "Resource not found"
 

--- a/opac/webapp/translations/es/LC_MESSAGES/messages.po
+++ b/opac/webapp/translations/es/LC_MESSAGES/messages.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version:  OPAC\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-05-20 11:19-0300\n"
+"POT-Creation-Date: 2020-12-03 11:58-0300\n"
 "PO-Revision-Date: 2018-03-07 00:47+0000\n"
 "Last-Translator: jamil Atta <atta.jamil@gmail.com>\n"
 "Language: es\n"
@@ -42,23 +42,23 @@ msgstr ""
 msgid "Periódico"
 msgstr "Revista"
 
-#: opac/tests/test_controller.py:541 opac/webapp/controllers.py:759
+#: opac/tests/test_controller.py:541 opac/webapp/controllers.py:776
 msgid "Obrigatório um assets_code."
 msgstr "assets_code es obligatório."
 
-#: opac/tests/test_controller.py:550 opac/webapp/controllers.py:762
+#: opac/tests/test_controller.py:550 opac/webapp/controllers.py:779
 msgid "Obrigatório um journal."
 msgstr "journal es obligatorio."
 
-#: opac/tests/test_controller.py:1133 opac/webapp/controllers.py:998
+#: opac/tests/test_controller.py:1144 opac/webapp/controllers.py:1003
 msgid "Obrigatório o acrônimo do periódico."
 msgstr ""
 
-#: opac/tests/test_controller.py:1140 opac/webapp/controllers.py:1000
+#: opac/tests/test_controller.py:1151 opac/webapp/controllers.py:1005
 msgid "Obrigatório o campo issue_info."
 msgstr ""
 
-#: opac/tests/test_controller.py:1147 opac/webapp/controllers.py:1002
+#: opac/tests/test_controller.py:1158 opac/webapp/controllers.py:1007
 msgid "Obrigatório o nome do arquivo PDF."
 msgstr ""
 
@@ -129,6 +129,10 @@ msgstr "Acerca de la Red SciELO"
 #: opac/tests/test_main_errors.py:8
 msgid "Mensagem de erro explicativo para o usuário"
 msgstr "Mensaje de error explicativo para el usuario"
+
+#: opac/tests/test_main_views.py:1336 opac/webapp/main/views.py:1113
+msgid "Idioma não suportado para formato XML"
+msgstr "Lang no disponible para formato XML"
 
 #: opac/webapp/__init__.py:185 opac/webapp/__init__.py:186
 #: opac/webapp/__init__.py:187 opac/webapp/__init__.py:188
@@ -299,7 +303,7 @@ msgstr "Lista Web of Science"
 msgid "Lista by Institution"
 msgstr "Lista por Institución"
 
-#: opac/webapp/controllers.py:437
+#: opac/webapp/controllers.py:437 opac/webapp/controllers.py:658
 msgid "Obrigatório um jid."
 msgstr "Obligatorio un jid."
 
@@ -315,99 +319,103 @@ msgstr "Obligatorio un url_seg."
 msgid "Obrigatório um issn."
 msgstr "ISSN obligatorio."
 
-#: opac/webapp/controllers.py:500
+#: opac/webapp/controllers.py:502
 msgid "Obrigatório um title."
 msgstr ""
 
-#: opac/webapp/controllers.py:538 opac/webapp/controllers.py:682
-#: opac/webapp/controllers.py:864 opac/webapp/controllers.py:875
+#: opac/webapp/controllers.py:540 opac/webapp/controllers.py:699
+#: opac/webapp/controllers.py:881 opac/webapp/controllers.py:892
 msgid "Obrigatório uma lista de ids."
 msgstr "Obligatorio un listado de ids."
 
-#: opac/webapp/controllers.py:644 opac/webapp/controllers.py:895
+#: opac/webapp/controllers.py:643 opac/webapp/controllers.py:912
 msgid "Obrigatório um iid."
 msgstr "Obligatorio un iid."
 
-#: opac/webapp/controllers.py:701
+#: opac/webapp/controllers.py:661
+msgid "Obrigatório um label do issue."
+msgstr ""
+
+#: opac/webapp/controllers.py:718
 msgid "Obrigatório um jacron e issue_label."
 msgstr "Obligatorio un jacron e issue_label."
 
-#: opac/webapp/controllers.py:714
+#: opac/webapp/controllers.py:731
 msgid "Obrigatório um PID."
 msgstr "PID obligatorio."
 
-#: opac/webapp/controllers.py:730
+#: opac/webapp/controllers.py:747
 msgid "Obrigatório um url_seg e url_seg_issue."
 msgstr "Obligatorio un url_seg y url_seg_issue."
 
-#: opac/webapp/controllers.py:777
+#: opac/webapp/controllers.py:794
 msgid "Obrigatório um aid."
 msgstr "Obligatorio un aid."
 
-#: opac/webapp/controllers.py:791
+#: opac/webapp/controllers.py:808
 msgid "Obrigatório um url_seg_article."
 msgstr "Obligatorio un url_seg_article."
 
-#: opac/webapp/controllers.py:806
+#: opac/webapp/controllers.py:823
 msgid "Obrigatório um iid and url_seg_article."
 msgstr "Obligatorio un iid and url_seg_article."
 
-#: opac/webapp/controllers.py:822
+#: opac/webapp/controllers.py:839
 msgid "Obrigatório um jid, url_seg_issue and url_seg_article."
 msgstr ""
 
-#: opac/webapp/controllers.py:933 opac/webapp/controllers.py:959
+#: opac/webapp/controllers.py:950 opac/webapp/controllers.py:976
 msgid "Obrigatório um pid."
 msgstr "PID obligatorio."
 
-#: opac/webapp/controllers.py:946
+#: opac/webapp/controllers.py:963
 msgid "Obrigatório um aop_pid."
 msgstr "Obligatorio un aop_pid."
 
-#: opac/webapp/controllers.py:973
+#: opac/webapp/controllers.py:990
 msgid "Parámetro obrigatório: issue_iid."
 msgstr "Parámetro obligatorio: issue_iid."
 
-#: opac/webapp/controllers.py:1068
+#: opac/webapp/controllers.py:1064
 msgid "Parâmetro email deve ser uma string"
 msgstr "Parámetro email debe ser un string"
 
-#: opac/webapp/controllers.py:1079
+#: opac/webapp/controllers.py:1075
 msgid "Parâmetro email deve ser uma inteiro"
 msgstr "Parámetro email debe ser un entero"
 
-#: opac/webapp/controllers.py:1091 opac/webapp/controllers.py:1105
+#: opac/webapp/controllers.py:1087 opac/webapp/controllers.py:1101
 #, python-format
 msgid "Usuário deve ser do tipo %s"
 msgstr "Usuario debe ser del tipo %s"
 
-#: opac/webapp/controllers.py:1161
+#: opac/webapp/controllers.py:1157
 msgid "Compartilhamento de link SciELO"
 msgstr "Compartir enlace SciELO"
 
-#: opac/webapp/controllers.py:1162
+#: opac/webapp/controllers.py:1158
 #, python-format
 msgid "O usuário %s compartilha este link: %s, da SciELO"
 msgstr "El usuario %s comparte este enlace: %s, de SciELO"
 
-#: opac/webapp/controllers.py:1170 opac/webapp/controllers.py:1206
-#: opac/webapp/controllers.py:1228
+#: opac/webapp/controllers.py:1166 opac/webapp/controllers.py:1202
+#: opac/webapp/controllers.py:1224
 msgid "Mensagem enviada!"
 msgstr "Mensaje enviado!"
 
-#: opac/webapp/controllers.py:1187
+#: opac/webapp/controllers.py:1183
 msgid "[Erro] Erro informado pelo usuário no site SciELO"
 msgstr ""
 
-#: opac/webapp/controllers.py:1190
+#: opac/webapp/controllers.py:1186
 msgid "aplicação"
 msgstr ""
 
-#: opac/webapp/controllers.py:1192
+#: opac/webapp/controllers.py:1188
 msgid "conteúdo"
 msgstr ""
 
-#: opac/webapp/controllers.py:1197
+#: opac/webapp/controllers.py:1193
 #, python-format
 msgid ""
 "O usuário <b>%s</b> com e-mail: <b>%s</b>, informa que existe um erro na "
@@ -418,20 +426,20 @@ msgstr ""
 " en la% s en el sitio SciELO. <br> <br> <b> Título de la página: </ b>% s"
 " <br> <br> <b> Link: </ b% s"
 
-#: opac/webapp/controllers.py:1218
+#: opac/webapp/controllers.py:1214
 msgid "Contato de usuário via site SciELO"
 msgstr "Contacto de usuário por sitio SciELO"
 
-#: opac/webapp/controllers.py:1220
+#: opac/webapp/controllers.py:1216
 #, python-format
 msgid "O usuário %s, com e-mail: %s, entra em contato com a seguinte mensagem:"
 msgstr "El usuario %s, con e-mail: %s, entra en contacto com la siguiente mensaje:"
 
-#: opac/webapp/controllers.py:1252
+#: opac/webapp/controllers.py:1248
 msgid "Obrigatório um slug_name."
 msgstr ""
 
-#: opac/webapp/controllers.py:1288
+#: opac/webapp/controllers.py:1284
 msgid "Obrigatório url_seg para get_aop_issues"
 msgstr ""
 
@@ -941,7 +949,9 @@ msgstr "El texto completo no ha estado disponible"
 #: opac/webapp/admin/views.py:646
 #, python-format
 msgid "Ocorreu um erro ao tentar indisponibilizar completo. Erro: %(ex)s"
-msgstr "Se produjo un error al intentar que el texto completo estuviera disponible. Erro: %(ex)s"
+msgstr ""
+"Se produjo un error al intentar que el texto completo estuviera "
+"disponible. Erro: %(ex)s"
 
 #: opac/webapp/admin/views.py:649
 msgid "Disponibilizar texto completo"
@@ -996,68 +1006,69 @@ msgstr ""
 msgid "Dados dos campos"
 msgstr ""
 
-#: opac/webapp/main/views.py:33
+#: opac/webapp/main/views.py:46
 msgid "O periódico está indisponível por motivo de: "
 msgstr "La revista no está disponible debido a:"
 
-#: opac/webapp/main/views.py:34
+#: opac/webapp/main/views.py:47
 msgid "O número está indisponível por motivo de: "
 msgstr "O fascículo esta indisponible por motivo de:"
 
-#: opac/webapp/main/views.py:35
+#: opac/webapp/main/views.py:48
 msgid "O artigo está indisponível por motivo de: "
 msgstr "El artículo no está disponible debido a:"
 
-#: opac/webapp/main/views.py:133
+#: opac/webapp/main/views.py:146
 msgid "Código de idioma inválido"
 msgstr "Código de idioma inválido"
 
-#: opac/webapp/main/views.py:248
+#: opac/webapp/main/views.py:261
 msgid "Últimos periódicos inseridos na coleção"
 msgstr "Últimas revistas incluidas en la colección"
 
-#: opac/webapp/main/views.py:249
+#: opac/webapp/main/views.py:262
 #, python-format
 msgid "10 últimos periódicos inseridos na coleção %s"
 msgstr "10 últimas revistas incluidas en la colección %s"
 
-#: opac/webapp/main/views.py:308
+#: opac/webapp/main/views.py:321
 msgid "Página não encontrada"
 msgstr "Página no encontrada"
 
-#: opac/webapp/main/views.py:333 opac/webapp/main/views.py:435
-#: opac/webapp/main/views.py:1314
+#: opac/webapp/main/views.py:346 opac/webapp/main/views.py:436
+#: opac/webapp/main/views.py:1360
 #, python-format
 msgid "Requsição inválida ao tentar acessar o artigo com pid: %s"
 msgstr "Requiere no válida al intentar tener acceso al artículo con pid:% s"
 
-#: opac/webapp/main/views.py:341 opac/webapp/main/views.py:403
-#: opac/webapp/main/views.py:454 opac/webapp/main/views.py:523
-#: opac/webapp/main/views.py:571 opac/webapp/main/views.py:725
-#: opac/webapp/main/views.py:747
+#: opac/webapp/main/views.py:354 opac/webapp/main/views.py:407
+#: opac/webapp/main/views.py:455 opac/webapp/main/views.py:514
+#: opac/webapp/main/views.py:561 opac/webapp/main/views.py:703
+#: opac/webapp/main/views.py:725
 msgid "Periódico não encontrado"
 msgstr "Revista no encontrada"
 
-#: opac/webapp/main/views.py:353 opac/webapp/main/views.py:809
-#: opac/webapp/main/views.py:946
+#: opac/webapp/main/views.py:367 opac/webapp/main/views.py:791
+#: opac/webapp/main/views.py:955
 msgid "Número não encontrado"
 msgstr "Fascículo no encontrado"
 
-#: opac/webapp/main/views.py:381 opac/webapp/main/views.py:418
-#: opac/webapp/main/views.py:998 opac/webapp/main/views.py:1091
-#: opac/webapp/main/views.py:1245 opac/webapp/main/views.py:1318
+#: opac/webapp/main/views.py:395 opac/webapp/main/views.py:423
+#: opac/webapp/main/views.py:1006 opac/webapp/main/views.py:1096
+#: opac/webapp/main/views.py:1118 opac/webapp/main/views.py:1328
+#: opac/webapp/main/views.py:1364
 msgid "Artigo não encontrado"
 msgstr "Artículo no encontrado"
 
-#: opac/webapp/main/views.py:547
+#: opac/webapp/main/views.py:538
 msgid "Artigo sem título"
 msgstr "Artículo sin título"
 
-#: opac/webapp/main/views.py:622 opac/webapp/main/views.py:643
+#: opac/webapp/main/views.py:600 opac/webapp/main/views.py:621
 msgid "Requisição inválida. Deve ser por ajax"
 msgstr "Solicitud no válida. Debe ser por ajax"
 
-#: opac/webapp/main/views.py:659
+#: opac/webapp/main/views.py:637
 msgid ""
 "Parámetro \"filter\" é inválido, deve ser \"areas\", \"wos\" ou "
 "\"publisher\"."
@@ -1065,11 +1076,11 @@ msgstr ""
 "Parámetro \"filter\" no es válido, debe ser \"areas\", \"wos\" o "
 "\"publisher\"."
 
-#: opac/webapp/main/views.py:668
+#: opac/webapp/main/views.py:646
 msgid "Parámetro \"extension\" é inválido, deve ser \"csv\" ou \"xls\"."
 msgstr "Parámetro \"extension\" no es válido, debe ser \"csv\" o \"xls\"."
 
-#: opac/webapp/main/views.py:670
+#: opac/webapp/main/views.py:648
 msgid ""
 "Parámetro \"list_type\" é inválido, deve ser: \"alpha\", \"areas\", "
 "\"wos\" ou \"publisher\"."
@@ -1077,53 +1088,60 @@ msgstr ""
 "Parámetro \"list_type\" no es válido, debe ser:  \"alpha\", \"areas\", "
 "\"wos\" o \"publisher\"."
 
-#: opac/webapp/main/views.py:691
+#: opac/webapp/main/views.py:669
 msgid "Requisição inválida, deve ser ajax."
 msgstr ""
 
-#: opac/webapp/main/views.py:700
+#: opac/webapp/main/views.py:678
 msgid "Periódico não permite envio de email."
 msgstr "La revista no permite envío de correo electrónico"
 
-#: opac/webapp/main/views.py:718
+#: opac/webapp/main/views.py:696
 msgid "Requisição inválida, captcha inválido."
 msgstr "Solicitud no válida, captcha inválida."
 
-#: opac/webapp/main/views.py:881 opac/webapp/main/views.py:899
+#: opac/webapp/main/views.py:896 opac/webapp/main/views.py:917
 msgid "Artigos ahead of print não encontrados"
 msgstr ""
 
-#: opac/webapp/main/views.py:1082 opac/webapp/main/views.py:1240
+#: opac/webapp/main/views.py:1088 opac/webapp/main/views.py:1324
 msgid "Issue não encontrado"
 msgstr "Fascículo no encontrado"
 
-#: opac/webapp/main/views.py:1130 opac/webapp/main/views.py:1136
-#: opac/webapp/main/views.py:1277 opac/webapp/main/views.py:1285
-#: opac/webapp/main/views.py:1287
-msgid "PDF do Artigo não encontrado"
-msgstr "PDF del artículo no encontrado"
-
-#: opac/webapp/main/views.py:1141
+#: opac/webapp/main/views.py:1171
 msgid "HTML do Artigo não encontrado ou indisponível"
 msgstr ""
 
-#: opac/webapp/main/views.py:1186
-msgid "Parâmetros insuficientes para obter o EPDF do artigo"
-msgstr "Parámetros insuficientes para obtener el EPDF del artículo"
-
-#: opac/webapp/main/views.py:1207
-msgid "Recruso não encontrado"
+#: opac/webapp/main/views.py:1173 opac/webapp/main/views.py:1292
+msgid "Erro inesperado"
 msgstr ""
 
-#: opac/webapp/main/views.py:1226 opac/webapp/main/views.py:1290
+#: opac/webapp/main/views.py:1223 opac/webapp/main/views.py:1231
+#: opac/webapp/main/views.py:1233
+msgid "PDF do Artigo não encontrado"
+msgstr "PDF del artículo no encontrado"
+
+#: opac/webapp/main/views.py:1236 opac/webapp/main/views.py:1311
 msgid "Recurso do Artigo não encontrado. Caminho inválido!"
 msgstr "Recurso del Artículo no encontrado. Camino inválido!"
 
-#: opac/webapp/main/views.py:1301
+#: opac/webapp/main/views.py:1256
+msgid "Formato não suportado"
+msgstr ""
+
+#: opac/webapp/main/views.py:1269
+msgid "Parâmetros insuficientes para obter o EPDF do artigo"
+msgstr "Parámetros insuficientes para obtener el EPDF del artículo"
+
+#: opac/webapp/main/views.py:1290
+msgid "Recurso não encontrado"
+msgstr ""
+
+#: opac/webapp/main/views.py:1347
 msgid "PDF do artigo não foi encontrado"
 msgstr "PDF del artículo no encontrado"
 
-#: opac/webapp/main/views.py:1345 opac/webapp/main/views.py:1376
+#: opac/webapp/main/views.py:1384 opac/webapp/main/views.py:1415
 msgid "Requisição inválida."
 msgstr "Petición inválida."
 
@@ -1363,7 +1381,9 @@ msgid "sumário"
 msgstr "tabla de contenido"
 
 #: opac/webapp/templates/article/includes/levelMenu.html:30
+#: opac/webapp/templates/issue/includes/alternative_header.html:74
 #: opac/webapp/templates/issue/includes/alternative_header.html:75
+#: opac/webapp/templates/journal/includes/alternative_header.html:70
 #: opac/webapp/templates/journal/includes/alternative_header.html:71
 msgid "anterior"
 msgstr "anterior"
@@ -1371,7 +1391,9 @@ msgstr "anterior"
 #: opac/webapp/templates/article/includes/levelMenu.html:35
 #: opac/webapp/templates/article/includes/levelMenu.html:88
 #: opac/webapp/templates/article/includes/levelMenu.html:141
+#: opac/webapp/templates/issue/includes/alternative_header.html:81
 #: opac/webapp/templates/issue/includes/alternative_header.html:82
+#: opac/webapp/templates/journal/includes/alternative_header.html:77
 #: opac/webapp/templates/journal/includes/alternative_header.html:78
 msgid "atual"
 msgstr "actual"
@@ -1515,7 +1537,7 @@ msgid "números"
 msgstr "números"
 
 #: opac/webapp/templates/collection/index.html:35
-#: opac/webapp/templates/issue/grid.html:67
+#: opac/webapp/templates/issue/grid.html:71
 msgid "artigos"
 msgstr "artículos"
 
@@ -1902,19 +1924,19 @@ msgstr ""
 msgid "Todos os números"
 msgstr "Todos los números"
 
-#: opac/webapp/templates/issue/grid.html:78
+#: opac/webapp/templates/issue/grid.html:82
 msgid "supl."
 msgstr ""
 
-#: opac/webapp/templates/issue/grid.html:97
+#: opac/webapp/templates/issue/grid.html:101
 msgid "Nenhum número encontrado para esse periódico"
 msgstr "Ningún fascículo fue encontrado para esta revista"
 
-#: opac/webapp/templates/issue/grid.html:100
+#: opac/webapp/templates/issue/grid.html:104
 msgid "Histórico deste periódico na coleção"
 msgstr "Historial de esta revista en la colección"
 
-#: opac/webapp/templates/issue/grid.html:104
+#: opac/webapp/templates/issue/grid.html:108
 msgid " admitido na coleção da SciELO"
 msgstr "admitido en la colección de SciELO"
 
@@ -1993,11 +2015,13 @@ msgstr "Números"
 
 #: opac/webapp/templates/issue/includes/alternative_header.html:68
 #: opac/webapp/templates/journal/includes/alternative_header.html:64
-#: opac/webapp/templates/journal/includes/levelMenu.html:90
+#: opac/webapp/templates/journal/includes/levelMenu.html:108
 msgid "todos"
 msgstr "todos"
 
+#: opac/webapp/templates/issue/includes/alternative_header.html:88
 #: opac/webapp/templates/issue/includes/alternative_header.html:89
+#: opac/webapp/templates/journal/includes/alternative_header.html:84
 #: opac/webapp/templates/journal/includes/alternative_header.html:85
 msgid "próximo"
 msgstr "próximo"
@@ -2115,32 +2139,48 @@ msgstr "página de la revista"
 msgid "todos os números"
 msgstr "todos los números"
 
+#: opac/webapp/templates/journal/includes/levelMenu.html:24
 #: opac/webapp/templates/journal/includes/levelMenu.html:25
 #: opac/webapp/templates/journal/includes/levelMenu.html:29
+#: opac/webapp/templates/journal/includes/levelMenu.html:30
+#: opac/webapp/templates/journal/includes/levelMenu.html:34
+#: opac/webapp/templates/journal/includes/levelMenu.html:35
+#: opac/webapp/templates/journal/includes/levelMenu.html:115
+#: opac/webapp/templates/journal/includes/levelMenu.html:119
+#: opac/webapp/templates/journal/includes/levelMenu.html:123
 msgid "número anterior"
 msgstr "número anterior"
 
-#: opac/webapp/templates/journal/includes/levelMenu.html:36
-#: opac/webapp/templates/journal/includes/levelMenu.html:40
-#: opac/webapp/templates/journal/includes/levelMenu.html:107
-#: opac/webapp/templates/journal/includes/levelMenu.html:111
+#: opac/webapp/templates/journal/includes/levelMenu.html:41
+#: opac/webapp/templates/journal/includes/levelMenu.html:42
+#: opac/webapp/templates/journal/includes/levelMenu.html:46
+#: opac/webapp/templates/journal/includes/levelMenu.html:47
+#: opac/webapp/templates/journal/includes/levelMenu.html:51
+#: opac/webapp/templates/journal/includes/levelMenu.html:52
+#: opac/webapp/templates/journal/includes/levelMenu.html:130
+#: opac/webapp/templates/journal/includes/levelMenu.html:134
+#: opac/webapp/templates/journal/includes/levelMenu.html:138
 msgid "número atual"
 msgstr "número actual"
 
-#: opac/webapp/templates/journal/includes/levelMenu.html:47
-#: opac/webapp/templates/journal/includes/levelMenu.html:51
+#: opac/webapp/templates/journal/includes/levelMenu.html:58
+#: opac/webapp/templates/journal/includes/levelMenu.html:59
+#: opac/webapp/templates/journal/includes/levelMenu.html:63
+#: opac/webapp/templates/journal/includes/levelMenu.html:64
+#: opac/webapp/templates/journal/includes/levelMenu.html:68
+#: opac/webapp/templates/journal/includes/levelMenu.html:69
 msgid "número seguinte"
 msgstr "número siguiente"
 
-#: opac/webapp/templates/journal/includes/levelMenu.html:59
-#: opac/webapp/templates/journal/includes/levelMenu.html:130
+#: opac/webapp/templates/journal/includes/levelMenu.html:77
+#: opac/webapp/templates/journal/includes/levelMenu.html:161
 msgid "buscar"
 msgstr "buscar"
 
-#: opac/webapp/templates/journal/includes/levelMenu.html:65
-#: opac/webapp/templates/journal/includes/levelMenu.html:69
-#: opac/webapp/templates/journal/includes/levelMenu.html:136
-#: opac/webapp/templates/journal/includes/levelMenu.html:140
+#: opac/webapp/templates/journal/includes/levelMenu.html:83
+#: opac/webapp/templates/journal/includes/levelMenu.html:87
+#: opac/webapp/templates/journal/includes/levelMenu.html:167
+#: opac/webapp/templates/journal/includes/levelMenu.html:171
 msgid "métricas"
 msgstr "métricas"
 
@@ -2260,5 +2300,8 @@ msgstr "Ver"
 #~ msgstr ""
 
 #~ msgid "Disponibilizar completo"
+#~ msgstr ""
+
+#~ msgid "Recruso não encontrado"
 #~ msgstr ""
 

--- a/opac/webapp/translations/messages.pot
+++ b/opac/webapp/translations/messages.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-05-20 11:19-0300\n"
+"POT-Creation-Date: 2020-12-03 11:58-0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -35,23 +35,23 @@ msgstr ""
 msgid "Periódico"
 msgstr ""
 
-#: opac/tests/test_controller.py:541 opac/webapp/controllers.py:759
+#: opac/tests/test_controller.py:541 opac/webapp/controllers.py:776
 msgid "Obrigatório um assets_code."
 msgstr ""
 
-#: opac/tests/test_controller.py:550 opac/webapp/controllers.py:762
+#: opac/tests/test_controller.py:550 opac/webapp/controllers.py:779
 msgid "Obrigatório um journal."
 msgstr ""
 
-#: opac/tests/test_controller.py:1133 opac/webapp/controllers.py:998
+#: opac/tests/test_controller.py:1144 opac/webapp/controllers.py:1003
 msgid "Obrigatório o acrônimo do periódico."
 msgstr ""
 
-#: opac/tests/test_controller.py:1140 opac/webapp/controllers.py:1000
+#: opac/tests/test_controller.py:1151 opac/webapp/controllers.py:1005
 msgid "Obrigatório o campo issue_info."
 msgstr ""
 
-#: opac/tests/test_controller.py:1147 opac/webapp/controllers.py:1002
+#: opac/tests/test_controller.py:1158 opac/webapp/controllers.py:1007
 msgid "Obrigatório o nome do arquivo PDF."
 msgstr ""
 
@@ -121,6 +121,10 @@ msgstr ""
 
 #: opac/tests/test_main_errors.py:8
 msgid "Mensagem de erro explicativo para o usuário"
+msgstr ""
+
+#: opac/tests/test_main_views.py:1336 opac/webapp/main/views.py:1113
+msgid "Idioma não suportado para formato XML"
 msgstr ""
 
 #: opac/webapp/__init__.py:185 opac/webapp/__init__.py:186
@@ -292,7 +296,7 @@ msgstr ""
 msgid "Lista by Institution"
 msgstr ""
 
-#: opac/webapp/controllers.py:437
+#: opac/webapp/controllers.py:437 opac/webapp/controllers.py:658
 msgid "Obrigatório um jid."
 msgstr ""
 
@@ -308,99 +312,103 @@ msgstr ""
 msgid "Obrigatório um issn."
 msgstr ""
 
-#: opac/webapp/controllers.py:500
+#: opac/webapp/controllers.py:502
 msgid "Obrigatório um title."
 msgstr ""
 
-#: opac/webapp/controllers.py:538 opac/webapp/controllers.py:682
-#: opac/webapp/controllers.py:864 opac/webapp/controllers.py:875
+#: opac/webapp/controllers.py:540 opac/webapp/controllers.py:699
+#: opac/webapp/controllers.py:881 opac/webapp/controllers.py:892
 msgid "Obrigatório uma lista de ids."
 msgstr ""
 
-#: opac/webapp/controllers.py:644 opac/webapp/controllers.py:895
+#: opac/webapp/controllers.py:643 opac/webapp/controllers.py:912
 msgid "Obrigatório um iid."
 msgstr ""
 
-#: opac/webapp/controllers.py:701
+#: opac/webapp/controllers.py:661
+msgid "Obrigatório um label do issue."
+msgstr ""
+
+#: opac/webapp/controllers.py:718
 msgid "Obrigatório um jacron e issue_label."
 msgstr ""
 
-#: opac/webapp/controllers.py:714
+#: opac/webapp/controllers.py:731
 msgid "Obrigatório um PID."
 msgstr ""
 
-#: opac/webapp/controllers.py:730
+#: opac/webapp/controllers.py:747
 msgid "Obrigatório um url_seg e url_seg_issue."
 msgstr ""
 
-#: opac/webapp/controllers.py:777
+#: opac/webapp/controllers.py:794
 msgid "Obrigatório um aid."
 msgstr ""
 
-#: opac/webapp/controllers.py:791
+#: opac/webapp/controllers.py:808
 msgid "Obrigatório um url_seg_article."
 msgstr ""
 
-#: opac/webapp/controllers.py:806
+#: opac/webapp/controllers.py:823
 msgid "Obrigatório um iid and url_seg_article."
 msgstr ""
 
-#: opac/webapp/controllers.py:822
+#: opac/webapp/controllers.py:839
 msgid "Obrigatório um jid, url_seg_issue and url_seg_article."
 msgstr ""
 
-#: opac/webapp/controllers.py:933 opac/webapp/controllers.py:959
+#: opac/webapp/controllers.py:950 opac/webapp/controllers.py:976
 msgid "Obrigatório um pid."
 msgstr ""
 
-#: opac/webapp/controllers.py:946
+#: opac/webapp/controllers.py:963
 msgid "Obrigatório um aop_pid."
 msgstr ""
 
-#: opac/webapp/controllers.py:973
+#: opac/webapp/controllers.py:990
 msgid "Parámetro obrigatório: issue_iid."
 msgstr ""
 
-#: opac/webapp/controllers.py:1068
+#: opac/webapp/controllers.py:1064
 msgid "Parâmetro email deve ser uma string"
 msgstr ""
 
-#: opac/webapp/controllers.py:1079
+#: opac/webapp/controllers.py:1075
 msgid "Parâmetro email deve ser uma inteiro"
 msgstr ""
 
-#: opac/webapp/controllers.py:1091 opac/webapp/controllers.py:1105
+#: opac/webapp/controllers.py:1087 opac/webapp/controllers.py:1101
 #, python-format
 msgid "Usuário deve ser do tipo %s"
 msgstr ""
 
-#: opac/webapp/controllers.py:1161
+#: opac/webapp/controllers.py:1157
 msgid "Compartilhamento de link SciELO"
 msgstr ""
 
-#: opac/webapp/controllers.py:1162
+#: opac/webapp/controllers.py:1158
 #, python-format
 msgid "O usuário %s compartilha este link: %s, da SciELO"
 msgstr ""
 
-#: opac/webapp/controllers.py:1170 opac/webapp/controllers.py:1206
-#: opac/webapp/controllers.py:1228
+#: opac/webapp/controllers.py:1166 opac/webapp/controllers.py:1202
+#: opac/webapp/controllers.py:1224
 msgid "Mensagem enviada!"
 msgstr ""
 
-#: opac/webapp/controllers.py:1187
+#: opac/webapp/controllers.py:1183
 msgid "[Erro] Erro informado pelo usuário no site SciELO"
 msgstr ""
 
-#: opac/webapp/controllers.py:1190
+#: opac/webapp/controllers.py:1186
 msgid "aplicação"
 msgstr ""
 
-#: opac/webapp/controllers.py:1192
+#: opac/webapp/controllers.py:1188
 msgid "conteúdo"
 msgstr ""
 
-#: opac/webapp/controllers.py:1197
+#: opac/webapp/controllers.py:1193
 #, python-format
 msgid ""
 "O usuário <b>%s</b> com e-mail: <b>%s</b>, informa que existe um erro na "
@@ -408,20 +416,20 @@ msgid ""
 " %s"
 msgstr ""
 
-#: opac/webapp/controllers.py:1218
+#: opac/webapp/controllers.py:1214
 msgid "Contato de usuário via site SciELO"
 msgstr ""
 
-#: opac/webapp/controllers.py:1220
+#: opac/webapp/controllers.py:1216
 #, python-format
 msgid "O usuário %s, com e-mail: %s, entra em contato com a seguinte mensagem:"
 msgstr ""
 
-#: opac/webapp/controllers.py:1252
+#: opac/webapp/controllers.py:1248
 msgid "Obrigatório um slug_name."
 msgstr ""
 
-#: opac/webapp/controllers.py:1288
+#: opac/webapp/controllers.py:1284
 msgid "Obrigatório url_seg para get_aop_issues"
 msgstr ""
 
@@ -980,130 +988,138 @@ msgstr ""
 msgid "Dados dos campos"
 msgstr ""
 
-#: opac/webapp/main/views.py:33
+#: opac/webapp/main/views.py:46
 msgid "O periódico está indisponível por motivo de: "
 msgstr ""
 
-#: opac/webapp/main/views.py:34
+#: opac/webapp/main/views.py:47
 msgid "O número está indisponível por motivo de: "
 msgstr ""
 
-#: opac/webapp/main/views.py:35
+#: opac/webapp/main/views.py:48
 msgid "O artigo está indisponível por motivo de: "
 msgstr ""
 
-#: opac/webapp/main/views.py:133
+#: opac/webapp/main/views.py:146
 msgid "Código de idioma inválido"
 msgstr ""
 
-#: opac/webapp/main/views.py:248
+#: opac/webapp/main/views.py:261
 msgid "Últimos periódicos inseridos na coleção"
 msgstr ""
 
-#: opac/webapp/main/views.py:249
+#: opac/webapp/main/views.py:262
 #, python-format
 msgid "10 últimos periódicos inseridos na coleção %s"
 msgstr ""
 
-#: opac/webapp/main/views.py:308
+#: opac/webapp/main/views.py:321
 msgid "Página não encontrada"
 msgstr ""
 
-#: opac/webapp/main/views.py:333 opac/webapp/main/views.py:435
-#: opac/webapp/main/views.py:1314
+#: opac/webapp/main/views.py:346 opac/webapp/main/views.py:436
+#: opac/webapp/main/views.py:1360
 #, python-format
 msgid "Requsição inválida ao tentar acessar o artigo com pid: %s"
 msgstr ""
 
-#: opac/webapp/main/views.py:341 opac/webapp/main/views.py:403
-#: opac/webapp/main/views.py:454 opac/webapp/main/views.py:523
-#: opac/webapp/main/views.py:571 opac/webapp/main/views.py:725
-#: opac/webapp/main/views.py:747
+#: opac/webapp/main/views.py:354 opac/webapp/main/views.py:407
+#: opac/webapp/main/views.py:455 opac/webapp/main/views.py:514
+#: opac/webapp/main/views.py:561 opac/webapp/main/views.py:703
+#: opac/webapp/main/views.py:725
 msgid "Periódico não encontrado"
 msgstr ""
 
-#: opac/webapp/main/views.py:353 opac/webapp/main/views.py:809
-#: opac/webapp/main/views.py:946
+#: opac/webapp/main/views.py:367 opac/webapp/main/views.py:791
+#: opac/webapp/main/views.py:955
 msgid "Número não encontrado"
 msgstr ""
 
-#: opac/webapp/main/views.py:381 opac/webapp/main/views.py:418
-#: opac/webapp/main/views.py:998 opac/webapp/main/views.py:1091
-#: opac/webapp/main/views.py:1245 opac/webapp/main/views.py:1318
+#: opac/webapp/main/views.py:395 opac/webapp/main/views.py:423
+#: opac/webapp/main/views.py:1006 opac/webapp/main/views.py:1096
+#: opac/webapp/main/views.py:1118 opac/webapp/main/views.py:1328
+#: opac/webapp/main/views.py:1364
 msgid "Artigo não encontrado"
 msgstr ""
 
-#: opac/webapp/main/views.py:547
+#: opac/webapp/main/views.py:538
 msgid "Artigo sem título"
 msgstr ""
 
-#: opac/webapp/main/views.py:622 opac/webapp/main/views.py:643
+#: opac/webapp/main/views.py:600 opac/webapp/main/views.py:621
 msgid "Requisição inválida. Deve ser por ajax"
 msgstr ""
 
-#: opac/webapp/main/views.py:659
+#: opac/webapp/main/views.py:637
 msgid ""
 "Parámetro \"filter\" é inválido, deve ser \"areas\", \"wos\" ou "
 "\"publisher\"."
 msgstr ""
 
-#: opac/webapp/main/views.py:668
+#: opac/webapp/main/views.py:646
 msgid "Parámetro \"extension\" é inválido, deve ser \"csv\" ou \"xls\"."
 msgstr ""
 
-#: opac/webapp/main/views.py:670
+#: opac/webapp/main/views.py:648
 msgid ""
 "Parámetro \"list_type\" é inválido, deve ser: \"alpha\", \"areas\", "
 "\"wos\" ou \"publisher\"."
 msgstr ""
 
-#: opac/webapp/main/views.py:691
+#: opac/webapp/main/views.py:669
 msgid "Requisição inválida, deve ser ajax."
 msgstr ""
 
-#: opac/webapp/main/views.py:700
+#: opac/webapp/main/views.py:678
 msgid "Periódico não permite envio de email."
 msgstr ""
 
-#: opac/webapp/main/views.py:718
+#: opac/webapp/main/views.py:696
 msgid "Requisição inválida, captcha inválido."
 msgstr ""
 
-#: opac/webapp/main/views.py:881 opac/webapp/main/views.py:899
+#: opac/webapp/main/views.py:896 opac/webapp/main/views.py:917
 msgid "Artigos ahead of print não encontrados"
 msgstr ""
 
-#: opac/webapp/main/views.py:1082 opac/webapp/main/views.py:1240
+#: opac/webapp/main/views.py:1088 opac/webapp/main/views.py:1324
 msgid "Issue não encontrado"
 msgstr ""
 
-#: opac/webapp/main/views.py:1130 opac/webapp/main/views.py:1136
-#: opac/webapp/main/views.py:1277 opac/webapp/main/views.py:1285
-#: opac/webapp/main/views.py:1287
-msgid "PDF do Artigo não encontrado"
-msgstr ""
-
-#: opac/webapp/main/views.py:1141
+#: opac/webapp/main/views.py:1171
 msgid "HTML do Artigo não encontrado ou indisponível"
 msgstr ""
 
-#: opac/webapp/main/views.py:1186
-msgid "Parâmetros insuficientes para obter o EPDF do artigo"
+#: opac/webapp/main/views.py:1173 opac/webapp/main/views.py:1292
+msgid "Erro inesperado"
 msgstr ""
 
-#: opac/webapp/main/views.py:1207
-msgid "Recruso não encontrado"
+#: opac/webapp/main/views.py:1223 opac/webapp/main/views.py:1231
+#: opac/webapp/main/views.py:1233
+msgid "PDF do Artigo não encontrado"
 msgstr ""
 
-#: opac/webapp/main/views.py:1226 opac/webapp/main/views.py:1290
+#: opac/webapp/main/views.py:1236 opac/webapp/main/views.py:1311
 msgid "Recurso do Artigo não encontrado. Caminho inválido!"
 msgstr ""
 
-#: opac/webapp/main/views.py:1301
+#: opac/webapp/main/views.py:1256
+msgid "Formato não suportado"
+msgstr ""
+
+#: opac/webapp/main/views.py:1269
+msgid "Parâmetros insuficientes para obter o EPDF do artigo"
+msgstr ""
+
+#: opac/webapp/main/views.py:1290
+msgid "Recurso não encontrado"
+msgstr ""
+
+#: opac/webapp/main/views.py:1347
 msgid "PDF do artigo não foi encontrado"
 msgstr ""
 
-#: opac/webapp/main/views.py:1345 opac/webapp/main/views.py:1376
+#: opac/webapp/main/views.py:1384 opac/webapp/main/views.py:1415
 msgid "Requisição inválida."
 msgstr ""
 
@@ -1336,7 +1352,9 @@ msgid "sumário"
 msgstr ""
 
 #: opac/webapp/templates/article/includes/levelMenu.html:30
+#: opac/webapp/templates/issue/includes/alternative_header.html:74
 #: opac/webapp/templates/issue/includes/alternative_header.html:75
+#: opac/webapp/templates/journal/includes/alternative_header.html:70
 #: opac/webapp/templates/journal/includes/alternative_header.html:71
 msgid "anterior"
 msgstr ""
@@ -1344,7 +1362,9 @@ msgstr ""
 #: opac/webapp/templates/article/includes/levelMenu.html:35
 #: opac/webapp/templates/article/includes/levelMenu.html:88
 #: opac/webapp/templates/article/includes/levelMenu.html:141
+#: opac/webapp/templates/issue/includes/alternative_header.html:81
 #: opac/webapp/templates/issue/includes/alternative_header.html:82
+#: opac/webapp/templates/journal/includes/alternative_header.html:77
 #: opac/webapp/templates/journal/includes/alternative_header.html:78
 msgid "atual"
 msgstr ""
@@ -1488,7 +1508,7 @@ msgid "números"
 msgstr ""
 
 #: opac/webapp/templates/collection/index.html:35
-#: opac/webapp/templates/issue/grid.html:67
+#: opac/webapp/templates/issue/grid.html:71
 msgid "artigos"
 msgstr ""
 
@@ -1871,19 +1891,19 @@ msgstr ""
 msgid "Todos os números"
 msgstr ""
 
-#: opac/webapp/templates/issue/grid.html:78
+#: opac/webapp/templates/issue/grid.html:82
 msgid "supl."
 msgstr ""
 
-#: opac/webapp/templates/issue/grid.html:97
+#: opac/webapp/templates/issue/grid.html:101
 msgid "Nenhum número encontrado para esse periódico"
 msgstr ""
 
-#: opac/webapp/templates/issue/grid.html:100
+#: opac/webapp/templates/issue/grid.html:104
 msgid "Histórico deste periódico na coleção"
 msgstr ""
 
-#: opac/webapp/templates/issue/grid.html:104
+#: opac/webapp/templates/issue/grid.html:108
 msgid " admitido na coleção da SciELO"
 msgstr ""
 
@@ -1962,11 +1982,13 @@ msgstr ""
 
 #: opac/webapp/templates/issue/includes/alternative_header.html:68
 #: opac/webapp/templates/journal/includes/alternative_header.html:64
-#: opac/webapp/templates/journal/includes/levelMenu.html:90
+#: opac/webapp/templates/journal/includes/levelMenu.html:108
 msgid "todos"
 msgstr ""
 
+#: opac/webapp/templates/issue/includes/alternative_header.html:88
 #: opac/webapp/templates/issue/includes/alternative_header.html:89
+#: opac/webapp/templates/journal/includes/alternative_header.html:84
 #: opac/webapp/templates/journal/includes/alternative_header.html:85
 msgid "próximo"
 msgstr ""
@@ -2084,32 +2106,48 @@ msgstr ""
 msgid "todos os números"
 msgstr ""
 
+#: opac/webapp/templates/journal/includes/levelMenu.html:24
 #: opac/webapp/templates/journal/includes/levelMenu.html:25
 #: opac/webapp/templates/journal/includes/levelMenu.html:29
+#: opac/webapp/templates/journal/includes/levelMenu.html:30
+#: opac/webapp/templates/journal/includes/levelMenu.html:34
+#: opac/webapp/templates/journal/includes/levelMenu.html:35
+#: opac/webapp/templates/journal/includes/levelMenu.html:115
+#: opac/webapp/templates/journal/includes/levelMenu.html:119
+#: opac/webapp/templates/journal/includes/levelMenu.html:123
 msgid "número anterior"
 msgstr ""
 
-#: opac/webapp/templates/journal/includes/levelMenu.html:36
-#: opac/webapp/templates/journal/includes/levelMenu.html:40
-#: opac/webapp/templates/journal/includes/levelMenu.html:107
-#: opac/webapp/templates/journal/includes/levelMenu.html:111
+#: opac/webapp/templates/journal/includes/levelMenu.html:41
+#: opac/webapp/templates/journal/includes/levelMenu.html:42
+#: opac/webapp/templates/journal/includes/levelMenu.html:46
+#: opac/webapp/templates/journal/includes/levelMenu.html:47
+#: opac/webapp/templates/journal/includes/levelMenu.html:51
+#: opac/webapp/templates/journal/includes/levelMenu.html:52
+#: opac/webapp/templates/journal/includes/levelMenu.html:130
+#: opac/webapp/templates/journal/includes/levelMenu.html:134
+#: opac/webapp/templates/journal/includes/levelMenu.html:138
 msgid "número atual"
 msgstr ""
 
-#: opac/webapp/templates/journal/includes/levelMenu.html:47
-#: opac/webapp/templates/journal/includes/levelMenu.html:51
+#: opac/webapp/templates/journal/includes/levelMenu.html:58
+#: opac/webapp/templates/journal/includes/levelMenu.html:59
+#: opac/webapp/templates/journal/includes/levelMenu.html:63
+#: opac/webapp/templates/journal/includes/levelMenu.html:64
+#: opac/webapp/templates/journal/includes/levelMenu.html:68
+#: opac/webapp/templates/journal/includes/levelMenu.html:69
 msgid "número seguinte"
 msgstr ""
 
-#: opac/webapp/templates/journal/includes/levelMenu.html:59
-#: opac/webapp/templates/journal/includes/levelMenu.html:130
+#: opac/webapp/templates/journal/includes/levelMenu.html:77
+#: opac/webapp/templates/journal/includes/levelMenu.html:161
 msgid "buscar"
 msgstr ""
 
-#: opac/webapp/templates/journal/includes/levelMenu.html:65
-#: opac/webapp/templates/journal/includes/levelMenu.html:69
-#: opac/webapp/templates/journal/includes/levelMenu.html:136
-#: opac/webapp/templates/journal/includes/levelMenu.html:140
+#: opac/webapp/templates/journal/includes/levelMenu.html:83
+#: opac/webapp/templates/journal/includes/levelMenu.html:87
+#: opac/webapp/templates/journal/includes/levelMenu.html:167
+#: opac/webapp/templates/journal/includes/levelMenu.html:171
 msgid "métricas"
 msgstr ""
 


### PR DESCRIPTION
#### O que esse PR faz?
Este PR disponibiliza os documentos em XMLs SciELO PS retornados pelo Kernel, acessando URLs com formato `/j/<acron>/a/<PID v3>/?format=xml`. Também adiciona esta URL nos metadados do documento em formato HTML.

#### Onde a revisão poderia começar?
Commit 2488edc.

#### Como este poderia ser testado manualmente?
1. Obtenha o PID v3 de um documento presente em instância do novo site
2. Acesse a URL `<endereço do site>/j/<acrônimo do periódico>/a/<PID v3>/?format=xml`
3. Verifique se o XML do documento é renderizado
3. Acesse a URL `<endereço do site>/j/<acrônimo do periódico>/a/<PID v3>`. Caso o acesso seja feito via navegador, abra o código fonte da página.
4. Verifique a presença da tag:
```<meta content="https://enderecodosite/j/acron/a/pid-v3-do-documento/?format=xml" name="citation_xml_url">```

#### Algum cenário de contexto que queira dar?
.

### Screenshots
.

#### Quais são tickets relevantes?
Closes #1667.

### Referências
.