### PR TITLE
Atualiza versão do packtools para exibir imagem em tamanho original com tag fig sem id

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -42,7 +42,7 @@ mongoengine==0.15.3
 natsort==7.0.1
 oauthlib==3.1.0
 -e git+https://git@github.com/scieloorg/opac_schema@499062237426fd5597a50ca81c9172852a9e1f81#egg=Opac_Schema
-https://github.com/scieloorg/packtools/archive/2.6.8.tar.gz#egg=packtools
+-e git+https://github.com/scieloorg/packtools/@2.6.9#egg=packtools
 passlib==1.7.2
 pbr==5.4.5
 picles.plumber==0.11


### PR DESCRIPTION
#### O que esse PR faz?
Este PR atualiza a versão do Packtools que gera o modal das tags `fig` mesmo sem o atributo `id`, possibilitando visualizar a versão em tamanho original das imagens.

#### Onde a revisão poderia começar?
Em `requirements.txt`

#### Como este poderia ser testado manualmente?
1. Obtenha um documento em que o XML contenha a tag `fig` sem atributo `id`, como o exemplo abaixo:
<img width="1565" alt="Screen Shot 2020-09-16 at 20 19 21" src="https://user-images.githubusercontent.com/4604104/93402003-ef5f4f00-f859-11ea-9b97-2fc1251c2dd0.png">
2. Acesse a página do artigo
3. Verifique se a imagem do thumbnail é exibida no modal ao clicar nela.

#### Algum cenário de contexto que queira dar?
.

### Screenshots
.

#### Quais são tickets relevantes?
#1654.

### Referências
.
