### PR TITLE
Atualiza versão do packtools p/ resolver exibição de resumos do artigo

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -42,7 +42,7 @@ mongoengine==0.15.3
 natsort==7.0.1
 oauthlib==3.1.0
 -e git+https://git@github.com/scieloorg/opac_schema@499062237426fd5597a50ca81c9172852a9e1f81#egg=Opac_Schema
--e git+https://github.com/scieloorg/packtools/@2.6.9#egg=packtools
+-e git+https://github.com/scieloorg/packtools/@2.6.10#egg=packtools
 passlib==1.7.2
 pbr==5.4.5
 picles.plumber==0.11


### PR DESCRIPTION
#### O que esse PR faz?
Este PR atualiza a versão do Packtools para `2.6.10` e renderizar os artigos HTML com todos os resumos do documento, independente de idioma.

#### Onde a revisão poderia começar?
Em `requirements.txt`.

#### Como este poderia ser testado manualmente?
1. Instale as dependências da app com `pip install -r requirements.txt`, caso esteja usando uma Virtualenv, ou execute o `make dev_compose_build && make dev_compose_up` para testar no Docker.
2. Acesse a página de um artigo na instância do site
3. Verifique se todos os resumos são exibidos, independente do idioma do texto atual.

#### Algum cenário de contexto que queira dar?
.

### Screenshots
.

#### Quais são tickets relevantes?
https://github.com/scieloorg/packtools/issues/215

### Referências
.
