### PR TITLE
Corrige configuração de conexão com MongoDB via URI

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -38,7 +38,7 @@ lxml==4.2.4
 Mako==1.1.3
 MarkupSafe==1.1.1
 mock==2.0.0
-mongoengine==0.15.3
+mongoengine==0.16.3
 natsort==7.0.1
 oauthlib==3.1.0
 -e git+https://git@github.com/scieloorg/opac_schema@499062237426fd5597a50ca81c9172852a9e1f81#egg=Opac_Schema
@@ -47,7 +47,7 @@ passlib==1.7.2
 pbr==5.4.5
 picles.plumber==0.11
 Pillow~=6.2
-pymongo==3.11.0
+pymongo==3.11.2
 PySocks==1.7.1
 python-dateutil==2.8.1
 python-editor==1.0.4


### PR DESCRIPTION
#### O que esse PR faz?
Este PR permite que a preferência de leitura seja definida via URI de conexão com o MongoDB, informada na variável `OPAC_MONGODB_HOST`, através do parâmetro `readPreference`.

A versão 0.15.3 do MongoEngine tem um bug que não faz o parser da URI de conexão corretamente, não configurando readPreference informado e mantendo a preferência de leitura para o primário.

#### Onde a revisão poderia começar?
Commit bee3856.

#### Como este poderia ser testado manualmente?
- Configure a variável `OPAC_MONGODB_HOST` com uma URI de conexão com uma lista de nodes MongoDB, passando o parâmetro `readPreference` diferente de `primary`. As opções possíveis estão na [documentação do MongoDB](https://docs.mongodb.com/manual/reference/connection-string/#urioption.readPreference)
- Suba a instância do OPAC
- Acesse o shell do `manager.py` com a linha de comando `cd opac && python manager.py shell`
- No prompt Python, execute os seguintes comandos:
```
>>> from webapp import dbmongo    # instância do MongoEngine da aplicação
>>> dbmongo.connection.read_preference
```
- `read_preference` deve retornar uma instância de classe correspondente ao passado como parâmetro na URI do MongoDB. As classes podem sem conferidas na [documentação do PyMongo](https://pymongo.readthedocs.io/en/stable/api/pymongo/read_preferences.html#module-pymongo.read_preferences)


#### Algum cenário de contexto que queira dar?
.

### Screenshots
.

#### Quais são tickets relevantes?
#1780.

### Referências
- Bug fix no MongoEngine: https://github.com/MongoEngine/mongoengine/pull/1668