### PR TITLE
Permite a configuração do nível de log da aplicação e suas dependências

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -48,6 +48,7 @@ services:
             - "8000:8000"
         environment:
             - OPAC_DEBUG_MODE=True
+            - OPAC_LOG_LEVEL=DEBUG
             - OPAC_MONGODB_NAME=opac
             - OPAC_MONGODB_HOST=opac_mongo
             - OPAC_MONGODB_PORT=27017

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,6 +39,7 @@ services:
             - "8000:8000"
         environment:
             - OPAC_DEBUG_MODE=True
+            - OPAC_LOG_LEVEL=WARNING
             - OPAC_MONGODB_NAME=opac_mongo
             - OPAC_DATABASE_DIR=/app/data
             - OPAC_SECRET_KEY=s3kr3tk3y

--- a/opac/webapp/__init__.py
+++ b/opac/webapp/__init__.py
@@ -129,6 +129,7 @@ def create_app():
     app.config.from_object(rq_scheduler_dashboard.default_settings)
     app.config.from_object('webapp.config.default')  # Configuração basica
     app.config.from_envvar('OPAC_CONFIG', silent=True)  # configuração do ambiente
+    app.logger.root.setLevel(app.config.get("LOG_LEVEL"))
 
     configure_apm_agent(app)
 

--- a/opac/webapp/config/default.py
+++ b/opac/webapp/config/default.py
@@ -179,6 +179,8 @@ DEBUG = os.environ.get('OPAC_DEBUG_MODE', 'False') == 'True'
 # NUNCA deixar TESTING = True em produção
 TESTING = False
 
+# Define o nível do log para toda a aplicação e suas dependências
+LOG_LEVEL = os.environ.get('OPAC_LOG_LEVEL', 'DEBUG' if DEBUG else 'WARNING')
 
 # ativa/desativa o modo Debug dos assets
 # NUNCA deixar ASSETS_DEBUG = True em produção


### PR DESCRIPTION
#### O que esse PR faz?

Este _pull request_ torna possível a configuração do nível de log da aplicação a partir da variável de ambiente `OPAC_LOG_LEVEL`. Melhora leitura de logs para a aplicação em produção.

#### Onde a revisão poderia começar?
- Pelo arquivo `opac/webapp/config/default.py`
- Depois `opac/webapp/__init__.py`

#### Como este poderia ser testado manualmente?
- Configure a variável `OPAC_LOG_LEVEL` no arquivo de `docker-compose`;
- Acesse páginas como as de artigos;
- Habilite o `APM`;
- Mude o nível de log para `DEBUG` e verifique que o `APM` imprime mensagens de `DEBUG`;
- Mude o nível de log para `ERROR` e verifique que o `APM` não imprime as mensagens de `DEBUG`;
- Desconecte da VPN;
- Verifique que o `APM` imprime mensagens de erro de conexão;

#### Algum cenário de contexto que queira dar?
N/A

### Screenshots
N/A

#### Quais são tickets relevantes?
close #1781 

### Referências
N/A

