### PR TITLE
Ajusta exibição do índice e a mediana H5 do Google Scholar na home do periódico

### DIFF
--- a/opac/tests/test_controller.py
+++ b/opac/tests/test_controller.py
@@ -456,6 +456,59 @@ class JournalControllerTestCase(BaseTestCase):
         for journal in journals.values():
             self.assertTrue(journal.is_public)
 
+    def test_get_journal_metrics_no_issn_found(self):
+        journal = self._make_one({"eletronic_issn": "0101-XXXX", "print_issn" : "0101-0202"})
+        self.assertEqual(
+            controllers.get_journal_metrics(journal),
+            {
+                "total_h5_index" : 0,
+                "total_h5_median" : 0,
+                "h5_metric_year" : 0
+            },
+        )
+
+    def test_get_journal_metrics_electronic_issn(self):
+        journal = self._make_one({"eletronic_issn": "0101-XXXX", "print_issn" : "0101-0202"})
+        self.assertEqual(
+            controllers.get_journal_metrics(journal),
+            {
+                "total_h5_index" : 0,
+                "total_h5_median" : 0,
+                "h5_metric_year" : 0
+            },
+        )
+
+    def test_get_journal_metrics_print_issn(self):
+        journal = self._make_one({"print_issn" : "0101-0202"})
+        self.assertEqual(
+            controllers.get_journal_metrics(journal),
+            {
+                "total_h5_index" : 0,
+                "total_h5_median" : 0,
+                "h5_metric_year" : 0
+            },
+        )
+
+    @patch("webapp.controllers.h5m5.get_current_metrics")
+    def test_get_journal_metrics_returns_int_metrics_and_year(self, mk_get_current_metrics):
+        mk_get_current_metrics.return_value = {
+            "h5": "58",
+            "m5": "42",
+            "url": "https://scholar.google.com/citations?view_op=list_hcore&venue=xxxxxxxxxxxx.2020&hl=pt-BR",
+            "year": "2020"
+        }
+        journal = self._make_one(
+            {"eletronic_issn": "1518-8787", "print_issn" : "0034-8910"}
+        )
+        self.assertEqual(
+            controllers.get_journal_metrics(journal),
+            {
+                "total_h5_index" : 58,
+                "total_h5_median" : 42,
+                "h5_metric_year" : 2020
+            },
+        )
+
 
 class IssueControllerTestCase(BaseTestCase):
 

--- a/opac/webapp/controllers.py
+++ b/opac/webapp/controllers.py
@@ -37,6 +37,7 @@ from uuid import uuid4
 
 from mongoengine import Q
 from mongoengine.errors import InvalidQueryError
+from scieloh5m5 import h5m5
 
 
 HIGHLIGHTED_TYPES = (
@@ -1285,3 +1286,30 @@ def get_aop_issues(url_seg, is_public=True):
     else:
         order_by = ["-year"]
         return Issue.objects(journal=journal, type='ahead', is_public=is_public).order_by(*order_by)
+
+
+def get_journal_metrics(journal):
+    """
+    Obtém métricas do Google Scholar para o periódico
+
+    @params:
+    - ``journal``: instância de opac_schema.models.Journal
+
+    @return:
+    - Dict com métricas do Google Scholar:
+        - ``total_h5_index``: Índice h5
+        - ``total_h5_median``: Mediana h5
+        - ``h5_metric_year``: Ano de referência das métricas
+    """
+    scielo_metrics = None
+    for issn in [journal.scielo_issn, journal.eletronic_issn, journal.print_issn]:
+        scielo_metrics = h5m5.get_current_metrics(issn)
+        if scielo_metrics:
+            break
+
+    metrics = {
+        "total_h5_index" : int(scielo_metrics.get("h5", 0)) if scielo_metrics else 0,
+        "total_h5_median" : int(scielo_metrics.get("m5", 0)) if scielo_metrics else 0,
+        "h5_metric_year" : int(scielo_metrics.get("year", 0)) if scielo_metrics else 0,
+    }
+    return metrics

--- a/opac/webapp/main/views.py
+++ b/opac/webapp/main/views.py
@@ -487,6 +487,8 @@ def journal_detail(url_seg):
     else:
         latest_issue_legend = ''
 
+    journal_metrics = controllers.get_journal_metrics(journal)
+
     context = {
         'journal': journal,
         'press_releases': press_releases,
@@ -499,7 +501,8 @@ def journal_detail(url_seg):
         'last_issue': latest_issue,
         'latest_issue_legend': latest_issue_legend,
         'sections': sections if sections else None,
-        'news': news
+        'news': news,
+        'journal_metrics': journal_metrics
     }
 
     return render_template("journal/detail.html", **context)

--- a/opac/webapp/templates/journal/detail.html
+++ b/opac/webapp/templates/journal/detail.html
@@ -50,24 +50,24 @@
                 <div>
                   <small>
                     {% trans %}Índice h5{% endtrans %}:
-                    {% if journal.metrics.total_h5_index and journal.metrics.h5_metric_year %}
-                      ({% trans %}ano{% endtrans %}: {{ journal.metrics.h5_metric_year }})
+                    {% if journal_metrics.total_h5_index and journal_metrics.h5_metric_year %}
+                      ({% trans %}ano{% endtrans %}: {{ journal_metrics.h5_metric_year }})
                     {% endif %}
                   </small>
                   <strong>
-                    {{ journal.metrics.total_h5_index|default(_("Não possui"), True) }}
+                    {{ journal_metrics.total_h5_index|default(_("Não possui"), True) }}
                   </strong>
                 </div>
                 <div>
                   <small>
                     {% trans %}Mediana h5{% endtrans %}:
-                    {% if journal.metrics.total_h5_median and journal.metrics.h5_metric_year %}
+                    {% if journal_metrics.total_h5_median and journal_metrics.h5_metric_year %}
                       {# a mediana é obtida sempre para o ano atual #}
-                      ({% trans %}ano{% endtrans %}: {{ journal.metrics.h5_metric_year }})
+                      ({% trans %}ano{% endtrans %}: {{ journal_metrics.h5_metric_year }})
                     {% endif %}
                   </small>
                   <strong>
-                    {{ journal.metrics.total_h5_median|default(_("Não possui"), True)  }}
+                    {{ journal_metrics.total_h5_median|default(_("Não possui"), True)  }}
                   </strong>
                 </div>
               </li>

--- a/requirements.txt
+++ b/requirements.txt
@@ -61,6 +61,7 @@ rq==0.12.0
 rq-dashboard==0.3.10
 rq-scheduler==0.8.2
 rq-scheduler-dashboard==0.0.2
+-e git+https://github.com/scieloorg/scieloh5m5.git@1.9.5#egg=scieloh5m5
 six==1.15.0
 speaklater==1.3
 SQLAlchemy==1.3.18


### PR DESCRIPTION
#### O que esse PR faz?
Este PR exibe o índice e a mediana H5 do Google Scholar,  utilizando a lib https://github.com/scieloorg/scieloh5m5.

#### Onde a revisão poderia começar?
Commit 028011b.

#### Como este poderia ser testado manualmente?
1. Suba uma instância do projeto, conectando-a a uma base de dados MongoDB contendo periódicos da coleção BR
2. Acesse a home de periódicos
3. Observe que as métricas do Google Scholar são exibidas, como no print de tela em anexo [1]

#### Algum cenário de contexto que queira dar?
Indique um contexto onde as modificações se fazem necessárias ou passe informações que contextualizam
o revisor a fim de facilitar o entendimento da funcionalidade.

### Screenshots
[1] - Home do periódico com as métricas do Google Scholar

<img width="1234" alt="opac-gscholar-metrics" src="https://user-images.githubusercontent.com/18053487/110999827-c11d8080-835f-11eb-8544-0285e230a302.png">

#### Quais são tickets relevantes?
Fix #1796 

### Referências
.