### PR TITLE
Apresenta os links dos resumos no padrão `/j/<acron>/a/<docid>/abstract/?lang=<lang>` no sumário

### DIFF
--- a/opac/tests/test_controller.py
+++ b/opac/tests/test_controller.py
@@ -704,32 +704,6 @@ class ArticleControllerTestCase(BaseTestCase):
         """
         return utils.makeAnyArticle(issue=issue, items=items)
 
-    def test_get_article_by_aid(self):
-        """
-        Teste da função controllers.get_article_by_aid para retornar um objeto:
-        ``Article``.
-        """
-
-        article = self._make_one()
-
-        self.assertEqual(controllers.get_article_by_aid(article.id).id,
-                         article.id)
-
-    def test_get_article_by_aid_without_aid(self):
-        """
-        Teste da função controllers.get_article_by_aid com uma lista vazia,
-        deve retorna um exceção ValueError.
-        """
-
-        self.assertRaises(ValueError, controllers.get_article_by_aid, [])
-
-    def test_get_article_by_aid_without_article(self):
-        """
-        Testando controllers.get_article_by_aid() sem article, deve retornar
-        None.
-        """
-        self.assertIsNone(controllers.get_article_by_aid('anyjid'))
-
     def test_get_articles_by_aid(self):
         """
         Testando a função controllers.get_articles_by_aid() deve retornar uma
@@ -1194,6 +1168,90 @@ class ArticleControllerTestCase(BaseTestCase):
 
         for article in articles.values():
             self.assertTrue(article.display_full_text)
+
+    def test_get_article_by_aid_raises_missing_aid_parameter_error(self):
+        with self.assertRaises(ValueError) as exc:
+            controllers.get_article_by_aid(None, None)
+        self.assertIn("aid", str(exc.exception))
+
+    def test_get_article_by_aid_raises_article_not_found_error(self):
+        with self.assertRaises(controllers.ArticleNotFoundError) as exc:
+            controllers.get_article_by_aid("notid", None)
+        self.assertIn("notid", str(exc.exception))
+
+    def test_get_article_by_aid_raises_missing_journal_url_seg_parameter_error(
+            self):
+        article = self._make_one()
+        with self.assertRaises(ValueError) as exc:
+            controllers.get_article_by_aid(article.id, None)
+        self.assertIn("journal_url_seg", str(exc.exception))
+
+    def test_get_article_by_aid_raises_not_found_article_journal_error(
+            self):
+        article = self._make_one({'journal': 'JOURNALID02'})
+        with self.assertRaises(controllers.ArticleJournalNotFoundError) as exc:
+            controllers.get_article_by_aid(article.id, "JOURNALID01")
+        self.assertIn(article.journal.acronym, str(exc.exception))
+
+    def test_get_article_by_aid_raises_article_is_not_published_error(
+            self):
+        article = self._make_one({"is_public": False})
+        with self.assertRaises(controllers.ArticleIsNotPublishedError):
+            controllers.get_article_by_aid(
+                article.id, article.journal.url_segment)
+
+    def test_get_article_by_aid_raises_issue_is_not_published_error(
+            self):
+        issue = utils.makeOneIssue({"is_public": False})
+        article = self._make_one({"issue": issue})
+
+        with self.assertRaises(controllers.IssueIsNotPublishedError):
+            controllers.get_article_by_aid(
+                article.id, article.journal.url_segment)
+
+    def test_get_article_by_aid_raises_journal_is_not_published_error(
+            self):
+        journal = utils.makeOneJournal({"is_public": False})
+        article = self._make_one({"journal": journal})
+        with self.assertRaises(controllers.JournalIsNotPublishedError):
+            controllers.get_article_by_aid(
+                article.id, article.journal.url_segment)
+
+    def test_get_article_by_aid_raises_article_lang_not_found_error(
+            self):
+        article = self._make_one()
+        with self.assertRaises(controllers.ArticleLangNotFoundError) as exc:
+            controllers.get_article_by_aid(
+                article.id, article.journal.url_segment, "xx")
+        self.assertEqual(
+            str([article.original_language] + article.languages),
+            str(exc.exception)
+        )
+
+    def test_get_article_by_aid_raises_article_abstract_not_found_error(
+            self):
+        article = self._make_one()
+        with self.assertRaises(controllers.ArticleAbstractNotFoundError) as exc:
+            controllers.get_article_by_aid(
+                article.id, article.journal.url_segment, "zz", True)
+        self.assertEqual(
+            str(article.abstract_languages),
+            str(exc.exception)
+        )
+
+    def test_get_article_by_aid_returns_article(self):
+        """
+        Teste da função controllers.get_article_by_aid para retornar um objeto:
+        ``Article``.
+        """
+
+        article = self._make_one()
+        id, url_seg = article.id, article.journal.url_segment
+        self.assertEqual(
+            controllers.get_article_by_aid(id, url_seg).id,
+            article.id
+        )
+
 
 
 class UserControllerTestCase(BaseTestCase):

--- a/opac/tests/test_legacy_urls.py
+++ b/opac/tests/test_legacy_urls.py
@@ -451,7 +451,11 @@ class LegacyURLTestCase(BaseTestCase):
 
             article = utils.makeOneArticle({
                 'journal': journal.id, 'issue': issue.id,
-                'pid': '0000-00002016000100251'
+                'pid': '0000-00002016000100251',
+                'abstracts':
+                    [
+                        {"language": "pt", "text": "Texto do abstract"},
+                    ],
             })
 
             with self.client as c:

--- a/opac/tests/test_main_views.py
+++ b/opac/tests/test_main_views.py
@@ -558,7 +558,6 @@ class MainTestCase(BaseTestCase):
                     url_seg=journal.url_segment, 
                     article_pid_v3=article.aid, 
                     format='html',
-                    lang='en', 
                 )
             )
 

--- a/opac/tests/test_main_views.py
+++ b/opac/tests/test_main_views.py
@@ -557,8 +557,8 @@ class MainTestCase(BaseTestCase):
                     'main.article_detail_v3',
                     url_seg=journal.url_segment, 
                     article_pid_v3=article.aid, 
+                    format='html',
                     lang='en', 
-                    format='html'
                 )
             )
 

--- a/opac/tests/test_main_views_abstract.py
+++ b/opac/tests/test_main_views_abstract.py
@@ -1,0 +1,89 @@
+# coding: utf-8
+# import unittest
+# from unittest.mock import patch, Mock
+from unittest.mock import patch
+
+import flask
+from flask import url_for, g, current_app
+# from flask import render_template
+# from flask_babelex import gettext as _
+
+from .base import BaseTestCase
+
+from . import utils
+
+
+class TestArticleDetailV3Abstract(BaseTestCase):
+    def _get_response(self, article_data=None, part='abstract'):
+        with current_app.test_request_context():
+            utils.makeOneCollection()
+            journal = utils.makeOneJournal()
+            issue = utils.makeOneIssue({'journal': journal})
+
+            _article_data = {
+                'title': 'Article Y',
+                'original_language': 'en',
+                'languages': ['es', 'pt', 'en'],
+                'issue': issue,
+                'journal': journal,
+                'url_segment': '10-11',
+                'translated_titles': [
+                    {'language': 'es', 'name': u'Artículo en español'},
+                    {'language': 'pt', 'name': u'Artigo en Português'},
+                ],
+            }
+            _article_data.update(article_data or {})
+            self.article = utils.makeOneArticle(_article_data)
+
+            response = self.client.get(
+                url_for(
+                    'main.article_detail_v3',
+                    url_seg=journal.url_segment,
+                    article_pid_v3=self.article.aid,
+                    part=part,
+                )
+            )
+            return response
+
+    def test_abstract_pid_v3_returns_404_and_displays_invalid_part_value_message(self):
+        expected = "Não existe 'abst'. No seu lugar use 'abstract'"
+        response = self._get_response(part='abst')
+        self.assertStatus(response, 404)
+        result = response.data.decode('utf-8')
+        self.assertIn(expected, result)
+
+    def test_abstract_pid_v3_returns_status_code_200(self):
+        article_data = {}
+        response = self._get_response(article_data)
+        self.assertStatus(response, 200)
+
+    @patch("webapp.main.views.render_html")
+    def test_abstract_pid_v3(self, mock_render_html):
+        mock_render_html.return_value = (
+            "abstract do documento",
+            ['en', 'es', 'pt'],
+        )
+        expected = "abstract do documento"
+        response = self._get_response()
+        result = response.data.decode('utf-8')
+        mock_render_html.assert_called_once_with(self.article, "en", True)
+        self.assertIn(expected, result)
+
+    @patch("webapp.main.views.render_html")
+    def test_abstract_pid_v3_does_not_return_abstract_but_fulltext_if_part_is_None(self, mock_render_html):
+        mock_render_html.return_value = (
+            "texto do documento",
+            ['en', 'es', 'pt'],
+        )
+        expected = "texto do documento"
+        response = self._get_response(part=None)
+        result = response.data.decode('utf-8')
+        mock_render_html.assert_called_once_with(self.article, "en", False)
+        self.assertIn(expected, result)
+
+    def test_abstract_pid_v3_returns_404_and_displays_invalid_part_value_message_if_part_is_False(self):
+        expected = "Não existe 'False'. No seu lugar use 'abstract'"
+        response = self._get_response(part=False)
+        self.assertStatus(response, 404)
+        result = response.data.decode('utf-8')
+        self.assertIn(expected, result)

--- a/opac/webapp/main/views.py
+++ b/opac/webapp/main/views.py
@@ -1150,7 +1150,7 @@ def article_detail_v3(url_seg, article_pid_v3, part=None):
         abort(404, "{}{}".format(ISSUE_UNPUBLISH, e))
     except controllers.JournalIsNotPublishedError as e:
         abort(404, "{}{}".format(JOURNAL_UNPUBLISH, e))
-    except Value as e:
+    except ValueError as e:
         abort(404, str(e))
 
     qs_lang = qs_lang or article.original_language

--- a/opac/webapp/main/views.py
+++ b/opac/webapp/main/views.py
@@ -394,9 +394,13 @@ def router_legacy():
             if not article:
                 abort(404, _('Artigo não encontrado'))
 
+            # 'abstract' or None (not False, porque False converterá a string 'False')
+            part = (script_php == 'sci_abstract' and 'abstract') or None
+
             return redirect(url_for('main.article_detail_v3',
                                     url_seg=article.journal.url_segment,
                                     article_pid_v3=article.aid,
+                                    part=part,
                                     lang=tlng), code=301)
 
         elif script_php == 'sci_issues':
@@ -1110,12 +1114,11 @@ def article_detail(url_seg, url_seg_issue, url_seg_article, lang_code=''):
 @main.route('/j/<string:url_seg>/a/<string:article_pid_v3>/<string:part>/')
 @cache.cached(key_prefix=cache_key_with_lang)
 def article_detail_v3(url_seg, article_pid_v3, part=None):
-
     qs_format = request.args.get('format', 'html', type=str)
     if qs_format == "xml" and request.args.get('lang'):
         abort(400, _("Idioma não suportado para formato XML"))
 
-    gs_abstract = part and part == "abstract"
+    gs_abstract = bool(part and part == "abstract")
     if part and not gs_abstract:
         abort(404,
               _("Não existe '{}'. No seu lugar use '{}'"

--- a/opac/webapp/templates/issue/toc.html
+++ b/opac/webapp/templates/issue/toc.html
@@ -160,7 +160,9 @@
                             <li>
                               {% trans %}Resumo{% endtrans %}:
                               {% for lang in article.abstract_languages|sort %}
-                                <a class="collapseAbstractBlock" href="#" data-id="{{article.id}}_{{lang}}" data-toggle="tooltip" data-placement="bottom" title="{{lang|trans_alpha2}}">
+                                <a href="{{ url_for('.article_detail_v3', url_seg=journal.url_segment, article_pid_v3=article.aid, 
+                                part='abstract',
+                                lang=lang) }}" data-toggle="tooltip" data-placement="bottom" title="{{lang|trans_alpha2}}">
                                   {{ lang }}
                                 </a>
                               {% endfor %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -42,7 +42,7 @@ mongoengine==0.16.3
 natsort==7.0.1
 oauthlib==3.1.0
 -e git+https://git@github.com/scieloorg/opac_schema@499062237426fd5597a50ca81c9172852a9e1f81#egg=Opac_Schema
--e git+https://github.com/scieloorg/packtools/@2.6.10#egg=packtools
+-e git+https://github.com/scieloorg/packtools/@2.6.11#egg=packtools
 passlib==1.7.2
 pbr==5.4.5
 picles.plumber==0.11


### PR DESCRIPTION
#### O que esse PR faz?
Apresenta os links dos resumos no padrão `/j/<acron>/a/<docid>/abstract/?lang=<lang>` no sumário

#### Onde a revisão poderia começar?
pelo commit https://github.com/scieloorg/opac/commit/c0cd3c25fcddbb1de4468e371374cb95d95ad295

#### Como este poderia ser testado manualmente?
Acesse o sumário qualquer e confira os links para os resumos

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
n/a

#### Quais são tickets relevantes?
#1762, #1730

### Referências
n/a
