### PR TITLE
Trata da navegação entre os resumos (próximo e anterior)

### DIFF
--- a/opac/tests/test_controller.py
+++ b/opac/tests/test_controller.py
@@ -963,14 +963,20 @@ class ArticleControllerTestCase(BaseTestCase):
         self.assertIn("Expected: next or previous", str(exc.exception))
 
     def test__articles_or_abstracts_sorted_by_order_or_date_returns_empty_list(self):
-        abstracts = []
-        a = self._make_one({"abstracts": abstracts})
+        a = self._make_one({"abstracts": []})
         articles = controllers._articles_or_abstracts_sorted_by_order_or_date(
             a.issue.id, gs_abstract=True)
         self.assertEqual(articles, [])
 
     def test__articles_or_abstracts_sorted_by_order_or_date_returns_empty_list2(self):
         a = self._make_one({"abstracts": None})
+        articles = controllers._articles_or_abstracts_sorted_by_order_or_date(
+            a.issue.id, gs_abstract=True)
+        self.assertEqual(articles, [])
+
+    def test__articles_or_abstracts_sorted_by_order_or_date_returns_empty_list3(self):
+        # nao existe nem o campo `abstracts`
+        a = self._make_one()
         articles = controllers._articles_or_abstracts_sorted_by_order_or_date(
             a.issue.id, gs_abstract=True)
         self.assertEqual(articles, [])

--- a/opac/tests/test_controller.py
+++ b/opac/tests/test_controller.py
@@ -760,8 +760,18 @@ class ArticleControllerTestCase(BaseTestCase):
     def _make_same_issue_articles(self, articles_attribs=None):
         issue = utils.makeOneIssue()
         default_attribs = [
-            {"abstracts": [{"language": "en", "text": ""}]},
-            {"abstracts": [{"language": "en", "text": ""}]},
+            {
+                "original_language": "pt",
+                "languages": ["pt", ],
+                "abstracts": [{"language": "pt", "text": ""}],
+                "abstract_languages": ["pt"],
+            },
+            {
+                "original_language": "es",
+                "languages": ["es", ],
+                "abstracts": [{"language": "es", "text": ""}],
+                "abstract_languages": ["es"],
+            },
         ]
         articles_attribs = articles_attribs or default_attribs
         articles = []
@@ -769,6 +779,122 @@ class ArticleControllerTestCase(BaseTestCase):
             article_attribs.update({"issue": issue})
             articles.append(self._make_one(article_attribs))
         return articles
+
+    def test_get_article_returns_next_article(self):
+        """
+        Teste da função controllers.get_article para retornar um objeto:
+        ``Article``.
+        """
+        articles = self._make_same_issue_articles()
+        article = articles[1]
+        lang, result = controllers.get_article(
+            articles[0].id,
+            articles[0].journal.url_segment,
+            articles[0].original_language,
+            gs_abstract=False,
+            goto="next",
+        )
+        self.assertEqual(article.id, result.id)
+        self.assertEqual(lang, "es")
+
+    def test_get_article_returns_previous_article(self):
+        """
+        Teste da função controllers.get_article para retornar um objeto:
+        ``Article``.
+        """
+        articles = self._make_same_issue_articles()
+        article = articles[0]
+        lang, result = controllers.get_article(
+            articles[1].id,
+            articles[1].journal.url_segment,
+            articles[1].original_language,
+            gs_abstract=False,
+            goto="previous",
+        )
+        self.assertEqual(article.id, result.id)
+        self.assertEqual(lang, "pt")
+
+    def test_get_article_returns_article(self):
+        """
+        Teste da função controllers.get_article para retornar um objeto:
+        ``Article``.
+        """
+        articles = self._make_same_issue_articles()
+        article = articles[0]
+        lang, result = controllers.get_article(
+            articles[0].id,
+            articles[0].journal.url_segment,
+            "pt",
+            gs_abstract=False,
+        )
+        self.assertEqual(article.id, result.id)
+        self.assertEqual(lang, "pt")
+
+    def test_get_article_returns_article_and_original_lang(self):
+        """
+        Teste da função controllers.get_article para retornar um objeto:
+        ``Article``.
+        """
+        articles = self._make_same_issue_articles()
+        article = articles[0]
+        lang, result = controllers.get_article(
+            articles[0].id,
+            articles[0].journal.url_segment,
+            None,
+            gs_abstract=False,
+        )
+        self.assertEqual(article.id, result.id)
+        self.assertEqual(lang, "pt")
+
+    def test_get_article_returns_next_article_which_has_abstract(self):
+        """
+        Teste da função controllers.get_article para retornar um objeto:
+        ``Article``.
+        """
+        articles = self._make_same_issue_articles()
+        article = articles[1]
+        lang, result = controllers.get_article(
+            articles[0].id,
+            articles[0].journal.url_segment,
+            "en",
+            gs_abstract=True,
+            goto="next",
+        )
+        self.assertEqual(article.id, result.id)
+        self.assertEqual(lang, "es")
+
+    def test_get_article_returns_previous_article_which_has_abstract(self):
+        """
+        Teste da função controllers.get_article para retornar um objeto:
+        ``Article``.
+        """
+        articles = self._make_same_issue_articles()
+        article = articles[0]
+        lang, result = controllers.get_article(
+            articles[1].id,
+            articles[1].journal.url_segment,
+            "en",
+            gs_abstract=True,
+            goto="previous",
+        )
+        self.assertEqual(article.id, result.id)
+        self.assertEqual(lang, "pt")
+
+    def test_get_article_returns_article_which_has_abstract(self):
+        """
+        Teste da função controllers.get_article para retornar um objeto:
+        ``Article``.
+        """
+        articles = self._make_same_issue_articles()
+        article = articles[0]
+        lang, result = controllers.get_article(
+            articles[0].id,
+            articles[0].journal.url_segment,
+            "pt",
+            gs_abstract=True,
+        )
+        self.assertEqual(article.id, result.id)
+        self.assertEqual(lang, "pt")
 
     def test_goto_article_returns_next_article(self):
         articles = self._make_same_issue_articles()

--- a/opac/tests/test_controller.py
+++ b/opac/tests/test_controller.py
@@ -757,6 +757,40 @@ class ArticleControllerTestCase(BaseTestCase):
         """
         return utils.makeAnyArticle(issue=issue, items=items)
 
+    def test__articles_or_abstracts_sorted_by_order_or_date_returns_empty_list(self):
+        abstracts = []
+        a = self._make_one({"abstracts": abstracts})
+        articles = controllers._articles_or_abstracts_sorted_by_order_or_date(
+            a.issue.id, gs_abstract=True)
+        self.assertEqual(articles, [])
+
+    def test__articles_or_abstracts_sorted_by_order_or_date_returns_empty_list2(self):
+        a = self._make_one({"abstracts": None})
+        articles = controllers._articles_or_abstracts_sorted_by_order_or_date(
+            a.issue.id, gs_abstract=True)
+        self.assertEqual(articles, [])
+
+    def test__articles_or_abstracts_sorted_by_order_or_date_returns_empty_list3(self):
+        a = self._make_one()
+        articles = controllers._articles_or_abstracts_sorted_by_order_or_date(
+            a.issue.id, gs_abstract=True)
+        self.assertEqual(articles, [])
+
+    def test__articles_or_abstracts_sorted_by_order_or_date_returns_one(self):
+        abstracts = [
+            {"language": "en", "text": "Texto"}
+        ]
+        abstract_languages = ["en"]
+        a = self._make_one(
+            {
+                "abstracts": abstracts,
+                "abstract_languages": abstract_languages
+            }
+        )
+        articles = controllers._articles_or_abstracts_sorted_by_order_or_date(
+            a.issue.id, gs_abstract=True)
+        self.assertEqual(len(articles), 1)
+
     def test_get_articles_by_aid(self):
         """
         Testando a função controllers.get_articles_by_aid() deve retornar uma

--- a/opac/tests/test_controller.py
+++ b/opac/tests/test_controller.py
@@ -763,13 +763,15 @@ class ArticleControllerTestCase(BaseTestCase):
             {
                 "original_language": "pt",
                 "languages": ["pt", ],
-                "abstracts": [{"language": "pt", "text": ""}],
+                "abstract": "texto",
+                "abstract": "resumo", "abstracts": [{"language": "pt", "text": ""}],
                 "abstract_languages": ["pt"],
             },
             {
                 "original_language": "es",
                 "languages": ["es", ],
-                "abstracts": [{"language": "es", "text": ""}],
+                "abstract": "texto",
+                "abstract": "resumo", "abstracts": [{"language": "es", "text": ""}],
                 "abstract_languages": ["es"],
             },
         ]
@@ -929,7 +931,10 @@ class ArticleControllerTestCase(BaseTestCase):
 
     def test_goto_article_returns_no_next_because_next_has_no_abstract(self):
         attribs = [
-            {"abstracts": [{"language": "x", "text": ""}]},
+            {
+                "abstract": "texto",
+                "abstract": "resumo", "abstracts": [{"language": "x", "text": ""}]
+            },
             {},
         ]
         articles = self._make_same_issue_articles(attribs)
@@ -946,7 +951,7 @@ class ArticleControllerTestCase(BaseTestCase):
     def test_goto_article_returns_no_previous_because_previous_has_no_abstract(self):
         attribs = [
             {},
-            {"abstracts": [{"language": "x", "text": ""}]},
+            {"abstract": "resumo", "abstracts": [{"language": "x", "text": ""}]},
         ]
         articles = self._make_same_issue_articles(attribs)
         with self.assertRaises(controllers.ArticleNotFoundError):
@@ -955,7 +960,7 @@ class ArticleControllerTestCase(BaseTestCase):
     def test_goto_article_returns_no_previous_because_previous_has_no_abstract(self):
         attribs = [
             {},
-            {"abstracts": [{"language": "x", "text": ""}]},
+            {"abstract": "resumo", "abstracts": [{"language": "x", "text": ""}]},
         ]
         articles = self._make_same_issue_articles(attribs)
         with self.assertRaises(ValueError) as exc:
@@ -994,7 +999,8 @@ class ArticleControllerTestCase(BaseTestCase):
         abstract_languages = ["en"]
         a = self._make_one(
             {
-                "abstracts": abstracts,
+                "abstract": "Texto",
+                "abstract": "resumo", "abstracts": abstracts,
                 "abstract_languages": abstract_languages
             }
         )

--- a/opac/tests/test_controller.py
+++ b/opac/tests/test_controller.py
@@ -905,7 +905,7 @@ class ArticleControllerTestCase(BaseTestCase):
 
     def test_goto_article_returns_no_next(self):
         articles = self._make_same_issue_articles()
-        with self.assertRaises(controllers.ArticleNotFoundError):
+        with self.assertRaises(controllers.PreviousOrNextArticleNotFoundError):
             controllers.goto_article(articles[-1], "next")
 
     def test_goto_article_returns_previous_article(self):
@@ -917,7 +917,7 @@ class ArticleControllerTestCase(BaseTestCase):
 
     def test_goto_article_returns_no_previous(self):
         articles = self._make_same_issue_articles()
-        with self.assertRaises(controllers.ArticleNotFoundError):
+        with self.assertRaises(controllers.PreviousOrNextArticleNotFoundError):
             controllers.goto_article(articles[0], "previous")
 
     def test_goto_article_returns_next_article_with_abstract(self):
@@ -933,7 +933,7 @@ class ArticleControllerTestCase(BaseTestCase):
             {},
         ]
         articles = self._make_same_issue_articles(attribs)
-        with self.assertRaises(controllers.ArticleNotFoundError):
+        with self.assertRaises(controllers.PreviousOrNextArticleNotFoundError):
             controllers.goto_article(articles[0], "next", True)
 
     def test_goto_article_returns_previous_article_with_abstract(self):

--- a/opac/tests/test_interface_menu.py
+++ b/opac/tests/test_interface_menu.py
@@ -535,7 +535,8 @@ class MenuTestCase(BaseTestCase):
             article_detail_url = url_for(
                 'main.article_detail_v3',
                 url_seg=journal.url_segment,
-                article_pid_v3=article2.aid)
+                article_pid_v3=article2.aid,
+                lang=article2.original_language)
 
             response = self.client.get(article_detail_url)
 
@@ -546,6 +547,7 @@ class MenuTestCase(BaseTestCase):
                 '.article_detail_v3',
                 url_seg=journal.url_segment,
                 article_pid_v3=article2.aid,
+                lang=article2.original_language,
                 goto='previous'
                 )  # artigo anterior
 
@@ -555,6 +557,7 @@ class MenuTestCase(BaseTestCase):
                 '.article_detail_v3',
                 url_seg=journal.url_segment,
                 article_pid_v3=article2.aid,
+                lang=article2.original_language,
                 goto='next'
                 )  # artigo seguinte
 
@@ -562,7 +565,9 @@ class MenuTestCase(BaseTestCase):
 
             # Verificar se todos os btns do menu estão presentes no HTML da resposta
             for btn in expected_btns:
-                self.assertIn(btn, response.data.decode('utf-8'))
+                self.assertIn(
+                    btn.replace('&', '&amp;'),
+                    response.data.decode('utf-8'))
 
     def test_article_detail_v3_menu_when_last_article(self):
         """
@@ -606,7 +611,9 @@ class MenuTestCase(BaseTestCase):
             article_detail_url = url_for(
                 'main.article_detail_v3',
                 url_seg=journal.url_segment,
-                article_pid_v3=article3.aid)
+                article_pid_v3=article3.aid,
+                lang=article3.original_language,
+            )
 
             response = self.client.get(article_detail_url)
 
@@ -617,6 +624,7 @@ class MenuTestCase(BaseTestCase):
                 '.article_detail_v3',
                 url_seg=journal.url_segment,
                 article_pid_v3=article3.aid,
+                lang=article3.original_language,
                 goto='previous',
                 )  # artigo anterior
 
@@ -628,7 +636,9 @@ class MenuTestCase(BaseTestCase):
             # Verificar se todos os btns do menu estão presentes no HTML da resposta
             for btn in expected_btns:
                 with self.subTest(btn):
-                    self.assertIn(btn, response.data.decode('utf-8'))
+                    self.assertIn(
+                        btn.replace("&", "&amp;"),
+                        response.data.decode('utf-8'))
 
     def test_article_detail_v3_menu_when_first_article(self):
         """
@@ -670,7 +680,9 @@ class MenuTestCase(BaseTestCase):
             article_detail_url = url_for(
                 'main.article_detail_v3',
                 url_seg=journal.url_segment,
-                article_pid_v3=article1.aid)
+                article_pid_v3=article1.aid,
+                lang=article1.original_language,
+                )
 
             response = self.client.get(article_detail_url)
 
@@ -685,6 +697,7 @@ class MenuTestCase(BaseTestCase):
                 '.article_detail_v3',
                 url_seg=journal.url_segment,
                 article_pid_v3=article1.aid,
+                lang=article1.original_language,
                 goto='next')  # artigo seguinte
 
             expected_btns = [
@@ -695,7 +708,9 @@ class MenuTestCase(BaseTestCase):
 
             # Verificar se todos os btns do menu estão presentes no HTML da resposta
             for btn in expected_btns:
-                self.assertIn(btn, response.data.decode('utf-8'))
+                self.assertIn(
+                    btn.replace("&", "&amp;"),
+                    response.data.decode('utf-8'))
 
     # Article Menu
     def test_article_detail_v3_abstract_menu(self):
@@ -769,6 +784,7 @@ class MenuTestCase(BaseTestCase):
                 url_seg=journal.url_segment,
                 article_pid_v3=article2.aid,
                 part='abstract',
+                lang="pt",
                 goto='previous'
                 )  # artigo anterior
 
@@ -779,6 +795,7 @@ class MenuTestCase(BaseTestCase):
                 url_seg=journal.url_segment,
                 article_pid_v3=article2.aid,
                 part='abstract',
+                lang="pt",
                 goto='next'
                 )  # artigo seguinte
 
@@ -786,7 +803,9 @@ class MenuTestCase(BaseTestCase):
 
             # Verificar se todos os btns do menu estão presentes no HTML da resposta
             for btn in expected_btns:
-                self.assertIn(btn, response.data.decode('utf-8'))
+                self.assertIn(
+                    btn.replace('&', '&amp;'),
+                    response.data.decode('utf-8'))
 
     def test_article_detail_v3_abstract_menu_when_last_article(self):
         """
@@ -860,6 +879,7 @@ class MenuTestCase(BaseTestCase):
                 url_seg=journal.url_segment,
                 article_pid_v3=article3.aid,
                 part='abstract',
+                lang='pt',
                 goto='previous',
                 )  # artigo anterior
 
@@ -871,7 +891,9 @@ class MenuTestCase(BaseTestCase):
             # Verificar se todos os btns do menu estão presentes no HTML da resposta
             for btn in expected_btns:
                 with self.subTest(btn):
-                    self.assertIn(btn, response.data.decode('utf-8'))
+                    self.assertIn(
+                        btn.replace('&', '&amp;'),
+                        response.data.decode('utf-8'))
 
     def test_article_detail_v3_abstract_menu_when_first_article(self):
         """
@@ -947,6 +969,7 @@ class MenuTestCase(BaseTestCase):
                 url_seg=journal.url_segment,
                 article_pid_v3=article1.aid,
                 part='abstract',
+                lang='pt',
                 goto='next')  # artigo seguinte
 
             expected_btns = [
@@ -957,4 +980,7 @@ class MenuTestCase(BaseTestCase):
 
             # Verificar se todos os btns do menu estão presentes no HTML da resposta
             for btn in expected_btns:
-                self.assertIn(btn, response.data.decode('utf-8'))
+                self.assertIn(
+                    btn.replace('&', '&amp;'),
+                    response.data.decode('utf-8')
+                )

--- a/opac/tests/test_interface_menu.py
+++ b/opac/tests/test_interface_menu.py
@@ -697,3 +697,264 @@ class MenuTestCase(BaseTestCase):
             for btn in expected_btns:
                 self.assertIn(btn, response.data.decode('utf-8'))
 
+    # Article Menu
+    def test_article_detail_v3_abstract_menu(self):
+        """
+        Teste para verificar se os botões estão ``anterior``, ``atual``,
+        ``próximo`` estão disponíveis no ``article/detail.html``.
+        """
+
+        with current_app.app_context():
+            # Criando uma coleção para termos o objeto ``g`` na interface
+            utils.makeOneCollection()
+
+            journal = utils.makeOneJournal()
+
+            issue = utils.makeOneIssue({
+                'journal': journal,
+                'year': '2016',
+                'volume': '1',
+                'number': '1',
+                'order': '1',
+            })
+
+            article1 = utils.makeOneArticle({
+                'issue': issue,
+                'order': 1,
+                'elocation': 'e1234560',
+                'abstracts': [
+                    {"language": "pt", "text": "Resumo"},
+                    {"language": "es", "text": "Resumen"},
+                ],
+                'abstract_languages': ["pt", "es"],
+            })
+
+            article2 = utils.makeOneArticle({
+                'issue': issue,
+                'order': 2,
+                'elocation': 'e1234561',
+                'abstracts': [
+                    {"language": "pt", "text": "Resumo"},
+                    {"language": "es", "text": "Resumen"},
+                ],
+                'abstract_languages': ["pt", "es"],
+            })
+
+            article3 = utils.makeOneArticle({
+                'issue': issue,
+                'order': 3,
+                'elocation': 'e1234562',
+                'abstracts': [
+                    {"language": "pt", "text": "Resumo"},
+                    {"language": "es", "text": "Resumen"},
+                ],
+                'abstract_languages': ["pt", "es"],
+            })
+
+            article_detail_url = url_for(
+                'main.article_detail_v3',
+                url_seg=journal.url_segment,
+                article_pid_v3=article2.aid,
+                part='abstract',
+                lang='pt',
+            )
+
+            response = self.client.get(article_detail_url)
+
+            self.assertStatus(response, 200)
+            self.assertTemplateUsed('article/detail.html')
+
+            expect_btn_anterior = '<a href="%s" class="btn group">' % url_for(
+                '.article_detail_v3',
+                url_seg=journal.url_segment,
+                article_pid_v3=article2.aid,
+                part='abstract',
+                goto='previous'
+                )  # artigo anterior
+
+            expect_btn_atual = '<a href="#" class="btn group disabled">'  # número atual
+
+            expect_btn_proximo = '<a href="%s" class="btn group">' % url_for(
+                '.article_detail_v3',
+                url_seg=journal.url_segment,
+                article_pid_v3=article2.aid,
+                part='abstract',
+                goto='next'
+                )  # artigo seguinte
+
+            expected_btns = [expect_btn_anterior, expect_btn_atual, expect_btn_proximo]
+
+            # Verificar se todos os btns do menu estão presentes no HTML da resposta
+            for btn in expected_btns:
+                self.assertIn(btn, response.data.decode('utf-8'))
+
+    def test_article_detail_v3_abstract_menu_when_last_article(self):
+        """
+        Teste para verificar se os botões estão ``anterior``, ``atual``,
+        ``próximo`` estão disponíveis no ``article/detail.html`` quando é o
+        último artigo. O botão próximo deve esta desativado.
+        """
+
+        journal = utils.makeOneJournal()
+
+        with current_app.app_context():
+            # Criando uma coleção para termos o objeto ``g`` na interface
+            utils.makeOneCollection()
+
+            issue = utils.makeOneIssue({
+                'journal': journal,
+                'year': '2016',
+                'volume': '1',
+                'number': '1',
+                'order': '1'
+            })
+
+            utils.makeOneArticle({
+                'issue': issue,
+                'order': 1,
+                'elocation': 'e1234562',
+                'abstracts': [
+                    {"language": "pt", "text": "Resumo"},
+                    {"language": "es", "text": "Resumen"},
+                ],
+                'abstract_languages': ["pt", "es"],
+            })
+
+            article2 = utils.makeOneArticle({
+                'issue': issue,
+                'order': 2,
+                'elocation': 'e1234562',
+                'abstracts': [
+                    {"language": "pt", "text": "Resumo"},
+                    {"language": "es", "text": "Resumen"},
+                ],
+                'abstract_languages': ["pt", "es"],
+            })
+
+            article3 = utils.makeOneArticle({
+                'issue': issue,
+                'order': 3,
+                'elocation': 'e1234562',
+                'abstracts': [
+                    {"language": "pt", "text": "Resumo"},
+                    {"language": "es", "text": "Resumen"},
+                ],
+                'abstract_languages': ["pt", "es"],
+            })
+
+            article_detail_url = url_for(
+                'main.article_detail_v3',
+                url_seg=journal.url_segment,
+                article_pid_v3=article3.aid,
+                part='abstract',
+                lang='pt',
+            )
+
+            response = self.client.get(article_detail_url)
+
+            self.assertStatus(response, 200)
+            self.assertTemplateUsed('article/detail.html')
+
+            expect_btn_anterior = '<a href="%s" class="btn group">' % url_for(
+                '.article_detail_v3',
+                url_seg=journal.url_segment,
+                article_pid_v3=article3.aid,
+                part='abstract',
+                goto='previous',
+                )  # artigo anterior
+
+            expect_btn_atual = '<a href="#" class="btn group disabled">'  # número atual
+            expect_btn_proximo = '<a href="#" class="btn group disabled">'  # artigo anterior
+
+            expected_btns = [expect_btn_anterior, expect_btn_atual, expect_btn_proximo]
+
+            # Verificar se todos os btns do menu estão presentes no HTML da resposta
+            for btn in expected_btns:
+                with self.subTest(btn):
+                    self.assertIn(btn, response.data.decode('utf-8'))
+
+    def test_article_detail_v3_abstract_menu_when_first_article(self):
+        """
+        Teste para verificar se os botões estão ``anterior``, ``atual``,
+        ``próximo`` estão disponíveis no ``article/detail.html`` quando é o
+        primeiro artigo. O botão anterior deve esta desativado.
+        """
+
+        journal = utils.makeOneJournal()
+
+        with current_app.app_context():
+            # Criando uma coleção para termos o objeto ``g`` na interface
+            utils.makeOneCollection()
+
+            issue = utils.makeOneIssue({
+                'journal': journal,
+                'year': '2016', 'volume': '1',
+                'number': '1', 'order': '1'
+            })
+
+            article1 = utils.makeOneArticle({
+                'issue': issue,
+                'order': 1,
+                'elocation': 'e1234562',
+                'abstracts': [
+                    {"language": "pt", "text": "Resumo"},
+                    {"language": "es", "text": "Resumen"},
+                ],
+                'abstract_languages': ["pt", "es"],
+            })
+
+            article2 = utils.makeOneArticle({
+                'issue': issue,
+                'order': 2,
+                'elocation': 'e1234562',
+                'abstracts': [
+                    {"language": "pt", "text": "Resumo"},
+                    {"language": "es", "text": "Resumen"},
+                ],
+                'abstract_languages': ["pt", "es"],
+            })
+
+            utils.makeOneArticle({
+                'issue': issue,
+                'order': 3,
+                'elocation': 'e1234562',
+                'abstracts': [
+                    {"language": "pt", "text": "Resumo"},
+                    {"language": "es", "text": "Resumen"},
+                ],
+                'abstract_languages': ["pt", "es"],
+            })
+
+            article_detail_url = url_for(
+                'main.article_detail_v3',
+                url_seg=journal.url_segment,
+                article_pid_v3=article1.aid,
+                part='abstract',
+                lang='pt',
+            )
+
+            response = self.client.get(article_detail_url)
+
+            self.assertStatus(response, 200)
+            self.assertTemplateUsed('article/detail.html')
+
+            expect_btn_anterior = '<a href="#" class="btn group disabled">'  # artigo anterior
+
+            expect_btn_atual = '<a href="#" class="btn group disabled">'  # número atual
+
+            expect_btn_proximo = '<a href="%s" class="btn group">' % url_for(
+                '.article_detail_v3',
+                url_seg=journal.url_segment,
+                article_pid_v3=article1.aid,
+                part='abstract',
+                goto='next')  # artigo seguinte
+
+            expected_btns = [
+                expect_btn_anterior,
+                expect_btn_atual,
+                expect_btn_proximo
+            ]
+
+            # Verificar se todos os btns do menu estão presentes no HTML da resposta
+            for btn in expected_btns:
+                self.assertIn(btn, response.data.decode('utf-8'))

--- a/opac/tests/test_interface_menu.py
+++ b/opac/tests/test_interface_menu.py
@@ -784,8 +784,8 @@ class MenuTestCase(BaseTestCase):
                 url_seg=journal.url_segment,
                 article_pid_v3=article2.aid,
                 part='abstract',
+                goto='previous',
                 lang="pt",
-                goto='previous'
                 )  # artigo anterior
 
             expect_btn_atual = '<a href="#" class="btn group disabled">'  # número atual
@@ -795,8 +795,8 @@ class MenuTestCase(BaseTestCase):
                 url_seg=journal.url_segment,
                 article_pid_v3=article2.aid,
                 part='abstract',
+                goto='next',
                 lang="pt",
-                goto='next'
                 )  # artigo seguinte
 
             expected_btns = [expect_btn_anterior, expect_btn_atual, expect_btn_proximo]
@@ -879,8 +879,8 @@ class MenuTestCase(BaseTestCase):
                 url_seg=journal.url_segment,
                 article_pid_v3=article3.aid,
                 part='abstract',
-                lang='pt',
                 goto='previous',
+                lang='pt',
                 )  # artigo anterior
 
             expect_btn_atual = '<a href="#" class="btn group disabled">'  # número atual
@@ -969,8 +969,9 @@ class MenuTestCase(BaseTestCase):
                 url_seg=journal.url_segment,
                 article_pid_v3=article1.aid,
                 part='abstract',
+                goto='next',
                 lang='pt',
-                goto='next')  # artigo seguinte
+                )  # artigo seguinte
 
             expected_btns = [
                 expect_btn_anterior,

--- a/opac/tests/test_interface_menu.py
+++ b/opac/tests/test_interface_menu.py
@@ -545,14 +545,18 @@ class MenuTestCase(BaseTestCase):
             expect_btn_anterior = '<a href="%s" class="btn group">' % url_for(
                 '.article_detail_v3',
                 url_seg=journal.url_segment,
-                article_pid_v3=article1.aid)  # artigo anterior
+                article_pid_v3=article2.aid,
+                goto='previous'
+                )  # artigo anterior
 
             expect_btn_atual = '<a href="#" class="btn group disabled">'  # número atual
 
             expect_btn_proximo = '<a href="%s" class="btn group">' % url_for(
                 '.article_detail_v3',
                 url_seg=journal.url_segment,
-                article_pid_v3=article3.aid)  # artigo seguinte
+                article_pid_v3=article2.aid,
+                goto='next'
+                )  # artigo seguinte
 
             expected_btns = [expect_btn_anterior, expect_btn_atual, expect_btn_proximo]
 
@@ -609,20 +613,22 @@ class MenuTestCase(BaseTestCase):
             self.assertStatus(response, 200)
             self.assertTemplateUsed('article/detail.html')
 
-            expect_btn_anterior = '<a href="#" class="btn group disabled">'  # artigo anterior
-
-            expect_btn_atual = '<a href="#" class="btn group disabled">'  # número atual
-
-            expect_btn_proximo = '<a href="%s" class="btn group">' % url_for(
+            expect_btn_anterior = '<a href="%s" class="btn group">' % url_for(
                 '.article_detail_v3',
                 url_seg=journal.url_segment,
-                article_pid_v3=article2.aid)  # artigo seguinte
+                article_pid_v3=article3.aid,
+                goto='previous',
+                )  # artigo anterior
+
+            expect_btn_atual = '<a href="#" class="btn group disabled">'  # número atual
+            expect_btn_proximo = '<a href="#" class="btn group disabled">'  # artigo anterior
 
             expected_btns = [expect_btn_anterior, expect_btn_atual, expect_btn_proximo]
 
             # Verificar se todos os btns do menu estão presentes no HTML da resposta
             for btn in expected_btns:
-                self.assertIn(btn, response.data.decode('utf-8'))
+                with self.subTest(btn):
+                    self.assertIn(btn, response.data.decode('utf-8'))
 
     def test_article_detail_v3_menu_when_first_article(self):
         """
@@ -678,7 +684,8 @@ class MenuTestCase(BaseTestCase):
             expect_btn_proximo = '<a href="%s" class="btn group">' % url_for(
                 '.article_detail_v3',
                 url_seg=journal.url_segment,
-                article_pid_v3=article2.aid)  # artigo seguinte
+                article_pid_v3=article1.aid,
+                goto='next')  # artigo seguinte
 
             expected_btns = [
                 expect_btn_anterior,
@@ -689,3 +696,4 @@ class MenuTestCase(BaseTestCase):
             # Verificar se todos os btns do menu estão presentes no HTML da resposta
             for btn in expected_btns:
                 self.assertIn(btn, response.data.decode('utf-8'))
+

--- a/opac/tests/utils.py
+++ b/opac/tests/utils.py
@@ -318,12 +318,7 @@ def makeOneArticle(attrib=None):  # noqa
         'translated_titles': attrib.get('translated_titles', []),
         'languages': attrib.get('languages', ['pt', ]),
     }
-    if attrib.get('htmls'):
-        article['htmls'] = attrib.get('htmls')
-
-    for k, v in attrib.items():
-        if k not in list(article.keys()):
-            article[k] = v
+    article.update(attrib)
 
     return models.Article(**article).save()
 

--- a/opac/webapp/controllers.py
+++ b/opac/webapp/controllers.py
@@ -869,6 +869,48 @@ def _articles_or_abstracts_sorted_by_order_or_date(iid, gs_abstract=False):
     return articles
 
 
+def _prev_item(items, item):
+    """
+    Retorna os item anterior a `item` na lista `items`
+    Considera `items` em ordem crescente
+    """
+    index = items.index(item)
+    if index == -1:
+        raise ValueError("{} not found in {}".format(item, items))
+    if index > 0:
+        return items[index - 1]
+
+
+def _next_item(items, item):
+    """
+    Retorna os item posterior a `item` na lista `items`
+    Considera `items` em ordem crescente
+    """
+    index = items.index(item)
+    if index == -1:
+        raise ValueError("{} not found in {}".format(item, items))
+    try:
+        return items[index + 1]
+    except (ValueError, IndexError):
+        return None
+
+
+def goto_article(doc, goto, gs_abstract=False):
+    if goto not in ("next", "previous"):
+        raise ValueError(
+            "Invalid value: goto={}. Expected: next or previous)".format(goto)
+        )
+    docs = list(_articles_or_abstracts_sorted_by_order_or_date(
+        doc.issue.iid, gs_abstract))
+    if goto == "next":
+        article = _next_item(docs, doc)
+    if goto == "previous":
+        article = _prev_item(docs, doc)
+    if article:
+        return article
+    raise ArticleNotFoundError(goto)
+
+
 def get_article_by_url_seg(url_seg_article, **kwargs):
     """
     Retorna um artigo considerando os parâmetros ``url_seg_article`` e ``kwargs``.

--- a/opac/webapp/controllers.py
+++ b/opac/webapp/controllers.py
@@ -911,6 +911,41 @@ def goto_article(doc, goto, gs_abstract=False):
     raise ArticleNotFoundError(goto)
 
 
+def get_article(aid, journal_url_seg, lang=None, gs_abstract=False, goto=None):
+    # obtém o artigo
+    if goto:
+        # obtém o artigo, não importa o idioma, nem se tem abstract
+        # pois será redirecionado para o próximo ou anterior
+        article = get_article_by_aid(aid, journal_url_seg)
+
+        # obtém o próximo ou anterior?
+        article = goto_article(article, goto, gs_abstract)
+
+        # precisa obter um idioma válido
+        lang = get_existing_lang(article, lang, gs_abstract)
+    else:
+        # obtém o artigo
+        article = get_article_by_aid(aid, journal_url_seg, lang, gs_abstract)
+        if lang is None and not gs_abstract:
+            lang = article.original_language
+    return lang, article
+
+
+def get_existing_lang(article, lang, gs_abstract):
+    """
+    Evita falha de recurso não encontrado,
+    quando se navega entre os documentos e/ou resumos,
+    """
+    # ajusta o idioma
+    if gs_abstract:
+        langs = article.abstract_languages
+    else:
+        langs = [article.original_language] + article.languages
+    if lang not in langs:
+        lang = langs[0]
+    return lang
+
+
 def get_article_by_url_seg(url_seg_article, **kwargs):
     """
     Retorna um artigo considerando os parâmetros ``url_seg_article`` e ``kwargs``.

--- a/opac/webapp/controllers.py
+++ b/opac/webapp/controllers.py
@@ -869,7 +869,7 @@ def _articles_or_abstracts_sorted_by_order_or_date(iid, gs_abstract=False):
     query = dict(is_public=True)
 
     if gs_abstract:
-        query.update({'abstracts__not__size': 0})
+        query.update({'abstract__ne': "", 'abstract__exists': True})
 
     return list(get_articles_by_iid(iid, **query))
 

--- a/opac/webapp/controllers.py
+++ b/opac/webapp/controllers.py
@@ -853,6 +853,22 @@ def get_article_by_aid(aid, journal_url_seg, lang=None, gs_abstract=False, **kwa
     return article
 
 
+def _articles_or_abstracts_sorted_by_order_or_date(iid, gs_abstract=False):
+    """
+    Retorna uma lista de artigos de um _fascículo_ ou de um _bundle_
+
+    - ``iid``: chave primaria de número para escolher os artigos.
+    - ``kwargs``: parâmetros de filtragem.
+
+    Em caso de não existir itens retorna {}.
+
+    """
+    articles = get_articles_by_iid(iid, is_public=True)
+    if gs_abstract:
+        return [a for a in list(articles) if a.abstracts]
+    return articles
+
+
 def get_article_by_url_seg(url_seg_article, **kwargs):
     """
     Retorna um artigo considerando os parâmetros ``url_seg_article`` e ``kwargs``.

--- a/opac/webapp/controllers.py
+++ b/opac/webapp/controllers.py
@@ -866,13 +866,12 @@ def _articles_or_abstracts_sorted_by_order_or_date(iid, gs_abstract=False):
     Em caso de não existir itens retorna {}.
 
     """
-    articles = get_articles_by_iid(iid, is_public=True)
+    query = dict(is_public=True)
+
     if gs_abstract:
-        # FIXME - Melhorar esta consulta
-        # conseguir em um único comando
-        # obter só os documentos que contenham resumo
-        return [a for a in list(articles) if a.abstracts]
-    return articles
+        query.update({'abstracts__not__size': 0})
+
+    return list(get_articles_by_iid(iid, **query))
 
 
 def _prev_item(items, item):

--- a/opac/webapp/main/views.py
+++ b/opac/webapp/main/views.py
@@ -1151,6 +1151,8 @@ def article_detail_v3(url_seg, article_pid_v3, part=None):
                 code=301
             )
     except (controllers.PreviousOrNextArticleNotFoundError) as e:
+        if gs_abstract:
+            abort(404, _('Resumo inexistente'))
         abort(404, _('Artigo inexistente'))
     except (controllers.ArticleNotFoundError,
             controllers.ArticleJournalNotFoundError):

--- a/opac/webapp/main/views.py
+++ b/opac/webapp/main/views.py
@@ -1151,7 +1151,7 @@ def article_detail_v3(url_seg, article_pid_v3, part=None):
                 code=301
             )
     except (controllers.PreviousOrNextArticleNotFoundError) as e:
-        abort(404, _('Artigo {} não existe').format(e))
+        abort(404, _('Artigo inexistente'))
     except (controllers.ArticleNotFoundError,
             controllers.ArticleJournalNotFoundError):
         abort(404, _('Artigo não encontrado'))

--- a/opac/webapp/main/views.py
+++ b/opac/webapp/main/views.py
@@ -1162,9 +1162,20 @@ def article_detail_v3(url_seg, article_pid_v3, part=None):
         article_list = list(
             controllers.get_articles_by_iid(article.issue.iid, is_public=True)
         )
+        prev_lang = next_lang = None
+
+        if gs_abstract:
+            article_list = [a for a in article_list if a.abstracts]
 
         previous_article = utils.get_prev_article(article_list, article)
         next_article = utils.get_next_article(article_list, article)
+
+        if gs_abstract:
+            prev_lang = next_lang = qs_lang
+            if previous_article and (qs_lang not in previous_article.abstract_languages):
+                prev_lang = previous_article.abstract_languages[0]
+            if next_article and (qs_lang not in next_article.abstract_languages):
+                next_lang = next_article.abstract_languages[0]
 
         citation_pdf_url = None
         for pdf_data in article.pdfs:
@@ -1228,6 +1239,10 @@ def article_detail_v3(url_seg, article_pid_v3, part=None):
             'text_versions': text_versions,
             'related_links': controllers.related_links(article),
             'gs_abstract': gs_abstract,
+            'part': part,
+            'next_lang': next_lang,
+            'prev_lang': prev_lang,
+
         }
         return render_template("article/detail.html", **context)
 

--- a/opac/webapp/main/views.py
+++ b/opac/webapp/main/views.py
@@ -48,6 +48,7 @@ ISSUE_UNPUBLISH = _("O número está indisponível por motivo de: ")
 ARTICLE_UNPUBLISH = _("O artigo está indisponível por motivo de: ")
 
 
+
 def url_external(endpoint, **kwargs):
     url = url_for(endpoint, **kwargs)
     return urljoin(request.url_root, url)
@@ -1170,24 +1171,6 @@ def article_detail_v3(url_seg, article_pid_v3, part=None):
         abort(404, str(e))
 
     def _handle_html():
-        article_list = list(
-            controllers.get_articles_by_iid(article.issue.iid, is_public=True)
-        )
-        prev_lang = next_lang = None
-
-        if gs_abstract:
-            article_list = [a for a in article_list if a.abstracts]
-
-        previous_article = utils.get_prev_article(article_list, article)
-        next_article = utils.get_next_article(article_list, article)
-
-        if gs_abstract:
-            prev_lang = next_lang = qs_lang
-            if previous_article and (qs_lang not in previous_article.abstract_languages):
-                prev_lang = previous_article.abstract_languages[0]
-            if next_article and (qs_lang not in next_article.abstract_languages):
-                next_lang = next_article.abstract_languages[0]
-
         citation_pdf_url = None
         for pdf_data in article.pdfs:
             if pdf_data.get("lang") == qs_lang:
@@ -1238,8 +1221,9 @@ def article_detail_v3(url_seg, article_pid_v3, part=None):
             )
         )
         context = {
-            'next_article': next_article,
-            'previous_article': previous_article,
+            # mostra os botões 'next' e 'previous' sempre, por enquanto
+            'next_article': True,
+            'previous_article': True,
             'article': article,
             'journal': article.journal,
             'issue': article.issue,
@@ -1251,9 +1235,6 @@ def article_detail_v3(url_seg, article_pid_v3, part=None):
             'related_links': controllers.related_links(article),
             'gs_abstract': gs_abstract,
             'part': part,
-            'next_lang': next_lang,
-            'prev_lang': prev_lang,
-
         }
         return render_template("article/detail.html", **context)
 

--- a/opac/webapp/templates/article/includes/levelMenu.html
+++ b/opac/webapp/templates/article/includes/levelMenu.html
@@ -179,7 +179,7 @@
               {% if is_pdf_page -%}
                 <a target='_blank' href="{{ url_for('.article_detail_v3', url_seg=journal.url_segment, article_pid_v3=article.aid, goto='previous', format='pdf') }}" class="btn group">
               {%- else -%}
-                <a href="{{ url_for('.article_detail_v3', url_seg=journal.url_segment, article_pid_v3=article.aid, part=part, goto='previous') }}" class="btn group">
+                <a href="{{ url_for('.article_detail_v3', url_seg=journal.url_segment, article_pid_v3=article.aid, part=part, lang=article_lang, goto='previous') }}" class="btn group">
               {% endif %}
             {%- endif %}
               <span class="sci-ico-arrowLeft"></span>
@@ -197,7 +197,7 @@
               {%- if is_pdf_page -%}
                 <a target='_blank' href="{{ url_for('.article_detail_v3', url_seg=journal.url_segment, article_pid_v3=article.aid, goto='next', format='pdf') }}" class="btn group">
               {%- else -%}
-                <a href="{{ url_for('.article_detail_v3', url_seg=journal.url_segment, article_pid_v3=article.aid, part=part, goto='next') }}" class="btn group">
+                <a href="{{ url_for('.article_detail_v3', url_seg=journal.url_segment, article_pid_v3=article.aid, part=part, lang=article_lang, goto='next') }}" class="btn group">
               {%- endif %}
             {%- endif %}
                 <span class="sci-ico-arrowRight"></span>

--- a/opac/webapp/templates/article/includes/levelMenu.html
+++ b/opac/webapp/templates/article/includes/levelMenu.html
@@ -177,9 +177,9 @@
                 <a href="#" class="btn group disabled">
             {% else %}
               {% if is_pdf_page -%}
-                <a target='_blank' href="{{ url_for('.article_detail_v3', url_seg=journal.url_segment, article_pid_v3=previous_article.aid, format='pdf') }}" class="btn group">
+                <a target='_blank' href="{{ url_for('.article_detail_v3', url_seg=journal.url_segment, article_pid_v3=article.aid, goto='previous', format='pdf') }}" class="btn group">
               {%- else -%}
-                <a href="{{ url_for('.article_detail_v3', url_seg=journal.url_segment, article_pid_v3=previous_article.aid, part=part, lang=prev_lang) }}" class="btn group">
+                <a href="{{ url_for('.article_detail_v3', url_seg=journal.url_segment, article_pid_v3=article.aid, part=part, goto='previous') }}" class="btn group">
               {% endif %}
             {%- endif %}
               <span class="sci-ico-arrowLeft"></span>
@@ -195,9 +195,9 @@
                 <a href="#" class="btn group disabled">
             {% else %}
               {%- if is_pdf_page -%}
-                <a target='_blank' href="{{ url_for('.article_detail_v3', url_seg=journal.url_segment, article_pid_v3=next_article.aid, format='pdf') }}" class="btn group">
+                <a target='_blank' href="{{ url_for('.article_detail_v3', url_seg=journal.url_segment, article_pid_v3=article.aid, goto='next', format='pdf') }}" class="btn group">
               {%- else -%}
-                <a href="{{ url_for('.article_detail_v3', url_seg=journal.url_segment, article_pid_v3=next_article.aid, part=part, lang=next_lang) }}" class="btn group">
+                <a href="{{ url_for('.article_detail_v3', url_seg=journal.url_segment, article_pid_v3=article.aid, part=part, goto='next') }}" class="btn group">
               {%- endif %}
             {%- endif %}
                 <span class="sci-ico-arrowRight"></span>

--- a/opac/webapp/templates/article/includes/levelMenu.html
+++ b/opac/webapp/templates/article/includes/levelMenu.html
@@ -179,7 +179,7 @@
               {% if is_pdf_page -%}
                 <a target='_blank' href="{{ url_for('.article_detail_v3', url_seg=journal.url_segment, article_pid_v3=previous_article.aid, format='pdf') }}" class="btn group">
               {%- else -%}
-                <a href="{{ url_for('.article_detail_v3', url_seg=journal.url_segment, article_pid_v3=previous_article.aid) }}" class="btn group">
+                <a href="{{ url_for('.article_detail_v3', url_seg=journal.url_segment, article_pid_v3=previous_article.aid, part=part, lang=prev_lang) }}" class="btn group">
               {% endif %}
             {%- endif %}
               <span class="sci-ico-arrowLeft"></span>
@@ -197,7 +197,7 @@
               {%- if is_pdf_page -%}
                 <a target='_blank' href="{{ url_for('.article_detail_v3', url_seg=journal.url_segment, article_pid_v3=next_article.aid, format='pdf') }}" class="btn group">
               {%- else -%}
-                <a href="{{ url_for('.article_detail_v3', url_seg=journal.url_segment, article_pid_v3=next_article.aid) }}" class="btn group">
+                <a href="{{ url_for('.article_detail_v3', url_seg=journal.url_segment, article_pid_v3=next_article.aid, part=part, lang=next_lang) }}" class="btn group">
               {%- endif %}
             {%- endif %}
                 <span class="sci-ico-arrowRight"></span>

--- a/opac/webapp/templates/article/includes/levelMenu_layout_lg.html
+++ b/opac/webapp/templates/article/includes/levelMenu_layout_lg.html
@@ -21,7 +21,7 @@
                   {% if is_pdf_page -%}
                     <a target='_blank' href="{{ url_for('.article_detail_v3', url_seg=journal.url_segment, article_pid_v3=previous_article.aid, format='pdf') }}" class="btn group">
                   {%- else -%}
-                    <a href="{{ url_for('.article_detail_v3', url_seg=journal.url_segment, article_pid_v3=previous_article.aid) }}" class="btn group">
+                    <a href="{{ url_for('.article_detail_v3', url_seg=journal.url_segment, article_pid_v3=previous_article.aid, part=part, lang=prev_lang) }}" class="btn group">
                   {% endif %}
                 {%- endif %}
                   &laquo; {% trans %}anterior{% endtrans %}
@@ -39,7 +39,7 @@
                 {%- if is_pdf_page -%}
                   <a target='_blank' href="{{ url_for('.article_detail_v3', url_seg=journal.url_segment, article_pid_v3=next_article.aid, format='pdf') }}" class="btn group">
                 {%- else -%}
-                  <a href="{{ url_for('.article_detail_v3', url_seg=journal.url_segment, article_pid_v3=next_article.aid) }}" class="btn group">
+                  <a href="{{ url_for('.article_detail_v3', url_seg=journal.url_segment, article_pid_v3=next_article.aid, part=part, lang=next_lang) }}" class="btn group">
                 {%- endif %}
               {%- endif %}
                   {% trans %}seguinte{% endtrans %} &raquo;

--- a/opac/webapp/templates/article/includes/levelMenu_layout_lg.html
+++ b/opac/webapp/templates/article/includes/levelMenu_layout_lg.html
@@ -21,7 +21,7 @@
                   {% if is_pdf_page -%}
                     <a target='_blank' href="{{ url_for('.article_detail_v3', url_seg=journal.url_segment, article_pid_v3=article.aid, goto='previous', format='pdf') }}" class="btn group">
                   {%- else -%}
-                    <a href="{{ url_for('.article_detail_v3', url_seg=journal.url_segment, article_pid_v3=article.aid, part=part, goto='previous') }}" class="btn group">
+                    <a href="{{ url_for('.article_detail_v3', url_seg=journal.url_segment, article_pid_v3=article.aid, part=part, lang=article_lang, goto='previous') }}" class="btn group">
                   {% endif %}
                 {%- endif %}
                   &laquo; {% trans %}anterior{% endtrans %}
@@ -39,7 +39,7 @@
                 {%- if is_pdf_page -%}
                   <a target='_blank' href="{{ url_for('.article_detail_v3', url_seg=journal.url_segment, article_pid_v3=article.aid, goto='next', format='pdf') }}" class="btn group">
                 {%- else -%}
-                  <a href="{{ url_for('.article_detail_v3', url_seg=journal.url_segment, article_pid_v3=article.aid, part=part, goto='next') }}" class="btn group">
+                  <a href="{{ url_for('.article_detail_v3', url_seg=journal.url_segment, article_pid_v3=article.aid, part=part, lang=article_lang, goto='next') }}" class="btn group">
                 {%- endif %}
               {%- endif %}
                   {% trans %}seguinte{% endtrans %} &raquo;

--- a/opac/webapp/templates/article/includes/levelMenu_layout_lg.html
+++ b/opac/webapp/templates/article/includes/levelMenu_layout_lg.html
@@ -19,9 +19,9 @@
                     <a href="#" class="btn group disabled">
                 {% else %}
                   {% if is_pdf_page -%}
-                    <a target='_blank' href="{{ url_for('.article_detail_v3', url_seg=journal.url_segment, article_pid_v3=previous_article.aid, format='pdf') }}" class="btn group">
+                    <a target='_blank' href="{{ url_for('.article_detail_v3', url_seg=journal.url_segment, article_pid_v3=article.aid, goto='previous', format='pdf') }}" class="btn group">
                   {%- else -%}
-                    <a href="{{ url_for('.article_detail_v3', url_seg=journal.url_segment, article_pid_v3=previous_article.aid, part=part, lang=prev_lang) }}" class="btn group">
+                    <a href="{{ url_for('.article_detail_v3', url_seg=journal.url_segment, article_pid_v3=article.aid, part=part, goto='previous') }}" class="btn group">
                   {% endif %}
                 {%- endif %}
                   &laquo; {% trans %}anterior{% endtrans %}
@@ -37,9 +37,9 @@
                   <a href="#" class="btn group disabled">
               {% else %}
                 {%- if is_pdf_page -%}
-                  <a target='_blank' href="{{ url_for('.article_detail_v3', url_seg=journal.url_segment, article_pid_v3=next_article.aid, format='pdf') }}" class="btn group">
+                  <a target='_blank' href="{{ url_for('.article_detail_v3', url_seg=journal.url_segment, article_pid_v3=article.aid, goto='next', format='pdf') }}" class="btn group">
                 {%- else -%}
-                  <a href="{{ url_for('.article_detail_v3', url_seg=journal.url_segment, article_pid_v3=next_article.aid, part=part, lang=next_lang) }}" class="btn group">
+                  <a href="{{ url_for('.article_detail_v3', url_seg=journal.url_segment, article_pid_v3=article.aid, part=part, goto='next') }}" class="btn group">
                 {%- endif %}
               {%- endif %}
                   {% trans %}seguinte{% endtrans %} &raquo;

--- a/opac/webapp/templates/article/includes/levelMenu_layout_md.html
+++ b/opac/webapp/templates/article/includes/levelMenu_layout_md.html
@@ -21,7 +21,7 @@
                   {% if is_pdf_page -%}
                     <a target='_blank' href="{{ url_for('.article_detail_v3', url_seg=journal.url_segment, article_pid_v3=previous_article.aid, format='pdf') }}" class="btn group ">
                   {%- else -%}
-                    <a href="{{ url_for('.article_detail_v3', url_seg=journal.url_segment, article_pid_v3=previous_article.aid) }}" class="btn group">
+                    <a href="{{ url_for('.article_detail_v3', url_seg=journal.url_segment, article_pid_v3=previous_article.aid, part=part, lang=prev_lang) }}" class="btn group">
                   {% endif %}
                 {%- endif %}
                   <span class="sci-ico-arrowLeft">
@@ -39,7 +39,7 @@
                 {%- if is_pdf_page -%}
                   <a target='_blank' href="{{ url_for('.article_detail_v3', url_seg=journal.url_segment, article_pid_v3=next_article.aid, format='pdf') }}" class="btn group">
                 {%- else -%}
-                  <a href="{{ url_for('.article_detail_v3', url_seg=journal.url_segment, article_pid_v3=next_article.aid) }}" class="btn group">
+                  <a href="{{ url_for('.article_detail_v3', url_seg=journal.url_segment, article_pid_v3=next_article.aid, part=part, lang=next_lang) }}" class="btn group">
                 {%- endif %}
               {%- endif %}
                   <span class="sci-ico-arrowRight">

--- a/opac/webapp/templates/article/includes/levelMenu_layout_md.html
+++ b/opac/webapp/templates/article/includes/levelMenu_layout_md.html
@@ -19,9 +19,9 @@
                     <a href="#" class="btn group disabled">
                 {% else %}
                   {% if is_pdf_page -%}
-                    <a target='_blank' href="{{ url_for('.article_detail_v3', url_seg=journal.url_segment, article_pid_v3=previous_article.aid, format='pdf') }}" class="btn group ">
+                    <a target='_blank' href="{{ url_for('.article_detail_v3', url_seg=journal.url_segment, article_pid_v3=article.aid, goto='previous', format='pdf') }}" class="btn group ">
                   {%- else -%}
-                    <a href="{{ url_for('.article_detail_v3', url_seg=journal.url_segment, article_pid_v3=previous_article.aid, part=part, lang=prev_lang) }}" class="btn group">
+                    <a href="{{ url_for('.article_detail_v3', url_seg=journal.url_segment, article_pid_v3=article.aid, part=part, goto='previous') }}" class="btn group">
                   {% endif %}
                 {%- endif %}
                   <span class="sci-ico-arrowLeft">
@@ -37,9 +37,9 @@
                   <a href="#" class="btn group disabled">
               {% else %}
                 {%- if is_pdf_page -%}
-                  <a target='_blank' href="{{ url_for('.article_detail_v3', url_seg=journal.url_segment, article_pid_v3=next_article.aid, format='pdf') }}" class="btn group">
+                  <a target='_blank' href="{{ url_for('.article_detail_v3', url_seg=journal.url_segment, article_pid_v3=article.aid, goto='next', format='pdf') }}" class="btn group">
                 {%- else -%}
-                  <a href="{{ url_for('.article_detail_v3', url_seg=journal.url_segment, article_pid_v3=next_article.aid, part=part, lang=next_lang) }}" class="btn group">
+                  <a href="{{ url_for('.article_detail_v3', url_seg=journal.url_segment, article_pid_v3=article.aid, part=part, goto='next') }}" class="btn group">
                 {%- endif %}
               {%- endif %}
                   <span class="sci-ico-arrowRight">

--- a/opac/webapp/templates/article/includes/levelMenu_layout_md.html
+++ b/opac/webapp/templates/article/includes/levelMenu_layout_md.html
@@ -21,7 +21,7 @@
                   {% if is_pdf_page -%}
                     <a target='_blank' href="{{ url_for('.article_detail_v3', url_seg=journal.url_segment, article_pid_v3=article.aid, goto='previous', format='pdf') }}" class="btn group ">
                   {%- else -%}
-                    <a href="{{ url_for('.article_detail_v3', url_seg=journal.url_segment, article_pid_v3=article.aid, part=part, goto='previous') }}" class="btn group">
+                    <a href="{{ url_for('.article_detail_v3', url_seg=journal.url_segment, article_pid_v3=article.aid, part=part, lang=article_lang, goto='previous') }}" class="btn group">
                   {% endif %}
                 {%- endif %}
                   <span class="sci-ico-arrowLeft">
@@ -39,7 +39,7 @@
                 {%- if is_pdf_page -%}
                   <a target='_blank' href="{{ url_for('.article_detail_v3', url_seg=journal.url_segment, article_pid_v3=article.aid, goto='next', format='pdf') }}" class="btn group">
                 {%- else -%}
-                  <a href="{{ url_for('.article_detail_v3', url_seg=journal.url_segment, article_pid_v3=article.aid, part=part, goto='next') }}" class="btn group">
+                  <a href="{{ url_for('.article_detail_v3', url_seg=journal.url_segment, article_pid_v3=article.aid, part=part, lang=article_lang, goto='next') }}" class="btn group">
                 {%- endif %}
               {%- endif %}
                   <span class="sci-ico-arrowRight">

--- a/opac/webapp/templates/article/includes/levelMenu_layout_sm.html
+++ b/opac/webapp/templates/article/includes/levelMenu_layout_sm.html
@@ -21,7 +21,7 @@
                   {% if is_pdf_page -%}
                     <a target='_blank' href="{{ url_for('.article_detail_v3', url_seg=journal.url_segment, article_pid_v3=previous_article.aid, format='pdf') }}" class="btn group ">
                   {%- else -%}
-                    <a href="{{ url_for('.article_detail_v3', url_seg=journal.url_segment, article_pid_v3=previous_article.aid) }}" class="btn group">
+                    <a href="{{ url_for('.article_detail_v3', url_seg=journal.url_segment, article_pid_v3=previous_article.aid, part=part, lang=prev_lang) }}" class="btn group">
                   {% endif %}
                 {%- endif %}
                   <span class="sci-ico-arrowLeft">
@@ -39,7 +39,7 @@
                 {%- if is_pdf_page -%}
                   <a target='_blank' href="{{ url_for('.article_detail_v3', url_seg=journal.url_segment, article_pid_v3=next_article.aid, format='pdf') }}" class="btn group">
                 {%- else -%}
-                  <a href="{{ url_for('.article_detail_v3', url_seg=journal.url_segment, article_pid_v3=next_article.aid) }}" class="btn group">
+                  <a href="{{ url_for('.article_detail_v3', url_seg=journal.url_segment, article_pid_v3=next_article.aid, part=part, lang=next_lang) }}" class="btn group">
                 {%- endif %}
               {%- endif %}
                   <span class="sci-ico-arrowRight">

--- a/opac/webapp/templates/article/includes/levelMenu_layout_sm.html
+++ b/opac/webapp/templates/article/includes/levelMenu_layout_sm.html
@@ -19,9 +19,9 @@
                     <a href="#" class="btn group disabled">
                 {% else %}
                   {% if is_pdf_page -%}
-                    <a target='_blank' href="{{ url_for('.article_detail_v3', url_seg=journal.url_segment, article_pid_v3=previous_article.aid, format='pdf') }}" class="btn group ">
+                    <a target='_blank' href="{{ url_for('.article_detail_v3', url_seg=journal.url_segment, article_pid_v3=article.aid, goto='previous', format='pdf') }}" class="btn group ">
                   {%- else -%}
-                    <a href="{{ url_for('.article_detail_v3', url_seg=journal.url_segment, article_pid_v3=previous_article.aid, part=part, lang=prev_lang) }}" class="btn group">
+                    <a href="{{ url_for('.article_detail_v3', url_seg=journal.url_segment, article_pid_v3=article.aid, part=part, goto='previous') }}" class="btn group">
                   {% endif %}
                 {%- endif %}
                   <span class="sci-ico-arrowLeft">
@@ -37,9 +37,9 @@
                   <a href="#" class="btn group disabled">
               {% else %}
                 {%- if is_pdf_page -%}
-                  <a target='_blank' href="{{ url_for('.article_detail_v3', url_seg=journal.url_segment, article_pid_v3=next_article.aid, format='pdf') }}" class="btn group">
+                  <a target='_blank' href="{{ url_for('.article_detail_v3', url_seg=journal.url_segment, article_pid_v3=article.aid, goto='next', format='pdf') }}" class="btn group">
                 {%- else -%}
-                  <a href="{{ url_for('.article_detail_v3', url_seg=journal.url_segment, article_pid_v3=next_article.aid, part=part, lang=next_lang) }}" class="btn group">
+                  <a href="{{ url_for('.article_detail_v3', url_seg=journal.url_segment, article_pid_v3=article.aid, part=part, goto='next') }}" class="btn group">
                 {%- endif %}
               {%- endif %}
                   <span class="sci-ico-arrowRight">

--- a/opac/webapp/templates/article/includes/levelMenu_layout_sm.html
+++ b/opac/webapp/templates/article/includes/levelMenu_layout_sm.html
@@ -21,7 +21,7 @@
                   {% if is_pdf_page -%}
                     <a target='_blank' href="{{ url_for('.article_detail_v3', url_seg=journal.url_segment, article_pid_v3=article.aid, goto='previous', format='pdf') }}" class="btn group ">
                   {%- else -%}
-                    <a href="{{ url_for('.article_detail_v3', url_seg=journal.url_segment, article_pid_v3=article.aid, part=part, goto='previous') }}" class="btn group">
+                    <a href="{{ url_for('.article_detail_v3', url_seg=journal.url_segment, article_pid_v3=article.aid, part=part, lang=article_lang, goto='previous') }}" class="btn group">
                   {% endif %}
                 {%- endif %}
                   <span class="sci-ico-arrowLeft">
@@ -39,7 +39,7 @@
                 {%- if is_pdf_page -%}
                   <a target='_blank' href="{{ url_for('.article_detail_v3', url_seg=journal.url_segment, article_pid_v3=article.aid, goto='next', format='pdf') }}" class="btn group">
                 {%- else -%}
-                  <a href="{{ url_for('.article_detail_v3', url_seg=journal.url_segment, article_pid_v3=article.aid, part=part, goto='next') }}" class="btn group">
+                  <a href="{{ url_for('.article_detail_v3', url_seg=journal.url_segment, article_pid_v3=article.aid, part=part, lang=article_lang, goto='next') }}" class="btn group">
                 {%- endif %}
               {%- endif %}
                   <span class="sci-ico-arrowRight">


### PR DESCRIPTION
#### O que esse PR faz?
Trata da navegação entre os resumos (próximo e anterior). Levando em consideração:
- Nem todos os documentos tem resumos, então a lista a ser navegada, tem que conter somente os documentos com resumos
- Foi refatorado a identificação de "previous" e "next" para obter melhor desempenho. O código anterior sempre identificava o anterior e o próximo fazendo uma consulta ao banco. No código novo, a consulta não é feita sempre. Só é feita caso o usuário comece a navegar pelo próximo ou anterior (parâmetro `goto`).  É uma aborgadem parecida com o que foi feita com `issue_toc`. 


#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
Acesse um documento e/ou um resumo e navegue pelo anterior e o próximo

#### Algum cenário de contexto que queira dar?
A aplicação tenta evitar que o usuário navegue por próximo e anterior e receba uma mensagem de erro de recurso não encontrado. Mas a mensagem ainda vai acontecer se ele estiver na **_primeira navegação_** (ou seja, for começar a navegar) e:
    a) estiver no primeiro documento e clicar no anterior
    b) estiver no último documento e clicar no próximo
Isso porque a aplicação só passa a descobrir se tem o próximo ou anterior após o primeiro clique em anterior ou próximo. Ou seja, se ele chegou a um artigo sem ser pelo anterior ou pelo próximo, a aplicação não sabe se haverá um anterior ou próximo


### Screenshots
n/a

#### Quais são tickets relevantes?
#1762 

### Referências
n/a
