### PR TITLE
Atualiza a versão do packtools para 2.6.12

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -42,7 +42,7 @@ mongoengine==0.16.3
 natsort==7.0.1
 oauthlib==3.1.0
 -e git+https://git@github.com/scieloorg/opac_schema@499062237426fd5597a50ca81c9172852a9e1f81#egg=Opac_Schema
--e git+https://github.com/scieloorg/packtools/@2.6.11#egg=packtools
+-e git+https://github.com/scieloorg/packtools/@2.6.12#egg=packtools
 passlib==1.7.2
 pbr==5.4.5
 picles.plumber==0.11


### PR DESCRIPTION
#### O que esse PR faz?
Atualiza a versão do packtools para 2.6.12 que
- corrige transformações de `graphic` e `inline-graphic`

#### Onde a revisão poderia começar?
.
#### Como este poderia ser testado manualmente?
Veja a seção `como reproduzir o problema`
https://github.com/scieloorg/packtools/issues/248
https://github.com/scieloorg/packtools/issues/250

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
n/a

#### Quais são tickets relevantes?
https://github.com/scieloorg/packtools/issues/248
https://github.com/scieloorg/packtools/issues/250

### Referências
n/a
