### PR TITLE
Remove o filtro para obter os resumos na consulta. Filtra após a consulta

### DIFF
--- a/opac/tests/test_controller.py
+++ b/opac/tests/test_controller.py
@@ -764,14 +764,16 @@ class ArticleControllerTestCase(BaseTestCase):
                 "original_language": "pt",
                 "languages": ["pt", ],
                 "abstract": "texto",
-                "abstract": "resumo", "abstracts": [{"language": "pt", "text": ""}],
+                "abstract": "resumo",
+                "abstracts": [{"language": "pt", "text": "Resumo"}],
                 "abstract_languages": ["pt"],
             },
             {
                 "original_language": "es",
                 "languages": ["es", ],
                 "abstract": "texto",
-                "abstract": "resumo", "abstracts": [{"language": "es", "text": ""}],
+                "abstract": "resumo",
+                "abstracts": [{"language": "es", "text": "Resumo"}],
                 "abstract_languages": ["es"],
             },
         ]
@@ -933,7 +935,8 @@ class ArticleControllerTestCase(BaseTestCase):
         attribs = [
             {
                 "abstract": "texto",
-                "abstract": "resumo", "abstracts": [{"language": "x", "text": ""}]
+                "abstract": "resumo",
+                "abstracts": [{"language": "x", "text": "Resumo"}]
             },
             {},
         ]
@@ -951,7 +954,8 @@ class ArticleControllerTestCase(BaseTestCase):
     def test_goto_article_returns_no_previous_because_previous_has_no_abstract(self):
         attribs = [
             {},
-            {"abstract": "resumo", "abstracts": [{"language": "x", "text": ""}]},
+            {"abstract": "resumo",
+             "abstracts": [{"language": "x", "text": "Resumo"}]},
         ]
         articles = self._make_same_issue_articles(attribs)
         with self.assertRaises(controllers.ArticleNotFoundError):
@@ -960,7 +964,8 @@ class ArticleControllerTestCase(BaseTestCase):
     def test_goto_article_returns_no_previous_because_previous_has_no_abstract(self):
         attribs = [
             {},
-            {"abstract": "resumo", "abstracts": [{"language": "x", "text": ""}]},
+            {"abstract": "resumo",
+             "abstracts": [{"language": "x", "text": "Resumo"}]},
         ]
         articles = self._make_same_issue_articles(attribs)
         with self.assertRaises(ValueError) as exc:
@@ -1538,10 +1543,6 @@ class ArticleControllerTestCase(BaseTestCase):
         with self.assertRaises(controllers.ArticleAbstractNotFoundError) as exc:
             controllers.get_article_by_aid(
                 article.id, article.journal.url_segment, "zz", True)
-        self.assertEqual(
-            str(article.abstract_languages),
-            str(exc.exception)
-        )
 
     def test_get_article_by_aid_returns_article(self):
         """


### PR DESCRIPTION
#### O que esse PR faz?
Remove o filtro para obter os resumos na consulta
Filtra após a consulta, considerando se o campo `abstracts` tem o conteúdo `text` preenchido.

Usar o filtro `abstract` falha quando o documento não tem resumo no idioma original. 
Usar o filtro  para `abstracts` pode trazer documentos campo `abstracts` estão incorretos, como apresentado na imagem:
<img width="780" alt="Captura de Tela 2021-03-29 às 09 48 58" src="https://user-images.githubusercontent.com/505143/112850988-e8bf5900-9080-11eb-9b4c-5ababbfd0916.png">


#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
Acesse um documento e/ou um resumo e navegue pelo anterior e o próximo, verificando se a lista contém os resumos esperados.

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
n/a

#### Quais são tickets relevantes?
https://github.com/scieloorg/opac/issues/1762
https://github.com/scieloorg/opac/pull/1816

### Referências
n/a
