### PR TITLE
Altera consulta de artigo no banco de dados p/ melhorar a performance

### DIFF
--- a/opac/webapp/controllers.py
+++ b/opac/webapp/controllers.py
@@ -819,9 +819,14 @@ def get_article_by_aid(aid, journal_url_seg, lang=None, gs_abstract=False, **kwa
     if not aid:
         raise ValueError(__('Obrigatório um aid.'))
 
-    article = Article.objects(aid=aid, **kwargs).first()
-    if not article:
+    try:
+        article = Article.objects.get(pk=aid, **kwargs)
+    except Article.DoesNotExist as e:
         raise ArticleNotFoundError(aid)
+    except Article.MultipleObjectsReturned as e:
+        article = Article.objects(aid=aid, **kwargs).first()
+        if not article:
+            raise ArticleNotFoundError(aid)
 
     if not article.is_public:
         raise ArticleIsNotPublishedError(article.unpublish_reason)

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -2,3 +2,4 @@ Flask-DebugToolbar==0.10.1
 Flask-Testing==0.6.2
 mock==2.0.0
 coverage==4.5.1
+pyinstrument==3.2.0


### PR DESCRIPTION
#### O que esse PR faz?
Este PR altera a busca de `Article` no MongoDB na consulta a um documento, feita ao acessar um artigo.

Usando o [pyinstrument](https://github.com/joerick/pyinstrument#pyinstrument), foi possível observar uma diferença de até 400ms a menos com a consulta, conforme mostram as imagens [1] e [2]. O teste foi feito acessando o PDF de um artigo, com e sem a alteração.

#### Onde a revisão poderia começar?
Commit 9b68cab.

#### Como este poderia ser testado manualmente?
- Para visualizar o resultado, é necessário garantir que a instância foco do teste não esteja usando o Redis ou que o cache seja limpo para cada requisição
- Execute `pip install -r requirements.dev.txt` ou recompile o contêiner do opac_webapp.
- Adicione o seguinte código em `opac/webapp/main/views.py`:
```
from pyinstrument import Profiler

@main.before_app_request
def before_request():
    if "profile" in request.args:
        g.profiler = Profiler()
        g.profiler.start()


@main.after_request
def after_request(response):
    if not hasattr(g, "profiler"):
        return response
    g.profiler.stop()
    output_html = g.profiler.output_html()
    return make_response(output_html)
```
- Acesse a página de um artigo, HTML ou PDF, incluindo no final da URL `&profile`
- Visualize o resultado produzido pelo PyIntrument, especialmente o `article_detail_v3` > `get_article` > `get_article_by_aid`
- Baixe o código deste PR, limpe o cache do Redis e reexecute o teste, comparando o resultado

#### Algum cenário de contexto que queira dar?
Este é um teste básico e que tem características de análise descritas [aqui](https://github.com/joerick/pyinstrument#how-is-it-different-to-profile-or-cprofile). Para uma análise mais completa, é necessário que façamos testes de performance mais robustos.

### Screenshots
[1] - Resultado antes da alteração
![article-detail-v3_2021-03-30 3 618s - full_dispatch_request - pyinstrument](https://user-images.githubusercontent.com/18053487/113159219-cfe6ad00-9212-11eb-97f0-588b0929f8df.png)

[2] - Resultado depois da alteração
![article_detail_v3_2021-03-31 0 875s - full_dispatch_request - pyinstrument](https://user-images.githubusercontent.com/18053487/113159243-d5dc8e00-9212-11eb-8c8d-0e93f44b91c6.png)


#### Quais são tickets relevantes?
#1812 e #1813.

### Referências
- Documentação do Python Profile built-in: https://docs.python.org/3/library/profile.html
- Documentação do PyInstrument: https://github.com/joerick/pyinstrument#pyinstrument.
