### PR TITLE
Remove a necessidade de avaliar o HTML com BeautifulSoup no acesso a página do artigo.

### DIFF
--- a/opac/webapp/main/views.py
+++ b/opac/webapp/main/views.py
@@ -4,7 +4,6 @@ import logging
 import requests
 import mimetypes
 from io import BytesIO
-from bs4 import BeautifulSoup
 from urllib.parse import urlparse
 from datetime import datetime
 from collections import OrderedDict
@@ -46,7 +45,6 @@ logger = logging.getLogger(__name__)
 JOURNAL_UNPUBLISH = _("O periódico está indisponível por motivo de: ")
 ISSUE_UNPUBLISH = _("O número está indisponível por motivo de: ")
 ARTICLE_UNPUBLISH = _("O artigo está indisponível por motivo de: ")
-
 
 
 def url_external(endpoint, **kwargs):
@@ -252,6 +250,7 @@ def collection_list_thematic():
         "collection/list_thematic.html",
         **{"objects": objects, "query_filter": query_filter, "filter": thematic_filter}
     )
+
 
 @main.route('/journals/feed/')
 @cache.cached(key_prefix=cache_key_with_lang)
@@ -1028,13 +1027,9 @@ def render_html_from_xml(article, lang, gs_abstract=False):
     xml = etree.parse(BytesIO(result))
 
     generator = HTMLGenerator.parse(
-        xml, valid_only=False, gs_abstract=gs_abstract)
+        xml, valid_only=False, gs_abstract=gs_abstract, output_style="website")
 
-    # Criamos um objeto do tip soup
-    soup = BeautifulSoup(etree.tostring(generator.generate(lang), encoding="UTF-8", method="html"), 'html.parser')
-
-    # Fatiamos o HTML pelo div com class: articleTxt
-    return soup.find('div', {'id': 'standalonearticle'}), generator.languages
+    return generator.generate(lang), generator.languages
 
 
 def render_html_from_html(article, lang):
@@ -1136,7 +1131,6 @@ def article_detail_v3(url_seg, article_pid_v3, part=None):
     try:
         qs_lang, article = controllers.get_article(
             article_pid_v3, url_seg, qs_lang, gs_abstract, qs_goto)
-
         if qs_goto:
             return redirect(
                 url_for(
@@ -1179,6 +1173,7 @@ def article_detail_v3(url_seg, article_pid_v3, part=None):
         abort(404, str(e))
 
     def _handle_html():
+
         citation_pdf_url = None
         for pdf_data in article.pdfs:
             if pdf_data.get("lang") == qs_lang:

--- a/requirements.txt
+++ b/requirements.txt
@@ -42,7 +42,7 @@ mongoengine==0.16.3
 natsort==7.0.1
 oauthlib==3.1.0
 -e git+https://git@github.com/scieloorg/opac_schema@499062237426fd5597a50ca81c9172852a9e1f81#egg=Opac_Schema
--e git+https://github.com/scieloorg/packtools/@2.6.12#egg=packtools
+-e git+https://github.com/scieloorg/packtools/@2.7.0#egg=packtools
 passlib==1.7.2
 pbr==5.4.5
 picles.plumber==0.11


### PR DESCRIPTION
#### O que esse PR faz?

Remove a necessidade de avaliar o **HTML** com **BeautifulSoup**, para que tenhamos ganho de performe no acesso à página do artigo.

#### Onde a revisão poderia começar?

Verifique a **view.py** a partir da linha: **1030**

#### Como este poderia ser testado manualmente?

Para teste manual da alteração sugiro utilizar o utilitário desenvolvido pelo @joffilyfe no seguinte link: https://github.com/joffilyfe/scielo-replay-http-traffic

Ofereço para esse teste alguns insumos que segue:

- **Commando para execução**: time python main.py log_apache/apache.log http://0.0.0.0:5000 --connections 10 --dont-wait-until-request-time --output-file "resultado_stress/10-conexoes.csv"
- Em anexo contém a pasta log_apache com os arquivos necessários para execução do comando anterior

[log_apache.zip](https://github.com/scieloorg/opac/files/6244859/log_apache.zip)

#### Quais são tickets relevantes?
#1812



