### PR TITLE
Adiciona rota para gerar dicionário de PIDs e outros atributos para aplicação COUNTER

### DIFF
--- a/opac/webapp/controllers.py
+++ b/opac/webapp/controllers.py
@@ -1189,8 +1189,8 @@ def get_articles_by_date_range(start_date, end_date):
     """
     Retorna artigos criados ou atualizados durante o período entre start_date e end_date.
     """
-    return Article.objects(Q(created__gte=start_date) | Q(updated__gte=start_date),
-                           Q(created__lte=end_date) | Q(updated__lte=end_date))
+    return Article.objects((Q(created__gte=start_date) & Q(created__lte=end_date)) |
+                           (Q(updated__gte=start_date) & Q(updated__lte=end_date)))
 
 
 # -------- NEWS --------

--- a/opac/webapp/controllers.py
+++ b/opac/webapp/controllers.py
@@ -1184,6 +1184,15 @@ def get_article_by_pdf_filename(journal_acron, issue_info, pdf_filename):
             if pdf["filename"] == pdf_filename:
                 return pdf["url"]
 
+
+def get_articles_by_date_range(start_date, end_date):
+    """
+    Retorna artigos criados ou atualizados durante o período entre start_date e end_date.
+    """
+    return Article.objects(Q(created__gte=start_date) | Q(updated__gte=start_date),
+                           Q(created__lte=end_date) | Q(updated__lte=end_date))
+
+
 # -------- NEWS --------
 
 

--- a/opac/webapp/controllers.py
+++ b/opac/webapp/controllers.py
@@ -1185,12 +1185,12 @@ def get_article_by_pdf_filename(journal_acron, issue_info, pdf_filename):
                 return pdf["url"]
 
 
-def get_articles_by_date_range(start_date, end_date):
+def get_articles_by_date_range(begin_date, end_date):
     """
     Retorna artigos criados ou atualizados durante o período entre start_date e end_date.
     """
-    return Article.objects((Q(created__gte=start_date) & Q(created__lte=end_date)) |
-                           (Q(updated__gte=start_date) & Q(updated__lte=end_date)))
+    return Article.objects((Q(created__gte=begin_date) & Q(created__lte=end_date)) |
+                           (Q(updated__gte=begin_date) & Q(updated__lte=end_date)))
 
 
 # -------- NEWS --------

--- a/opac/webapp/main/views.py
+++ b/opac/webapp/main/views.py
@@ -1563,3 +1563,18 @@ def router_counter_dicts(end_date=''):
     return jsonify(results)
 
 
+def get_article_counter_data(article):
+    return {
+        article.aid: {
+            "journal_acronym": article.journal.acronym,
+            "pid": article.pid if article.pid else '',
+            "aop_pid": article.aop_pid if article.aop_pid else '',
+            "pid_v1": article.scielo_pids.get('v1', ''),
+            "pid_v2": article.scielo_pids.get('v2', ''),
+            "pid_v3": article.scielo_pids.get('v3', ''),
+            "publication_date": article.publication_date,
+            "default_language": article.original_language,
+            "create": article.created,
+            "update": article.updated
+        }
+    }

--- a/opac/webapp/main/views.py
+++ b/opac/webapp/main/views.py
@@ -5,7 +5,7 @@ import requests
 import mimetypes
 from io import BytesIO
 from urllib.parse import urlparse
-from datetime import datetime
+from datetime import datetime, timedelta
 from collections import OrderedDict
 from flask_babelex import gettext as _
 from flask import (

--- a/opac/webapp/main/views.py
+++ b/opac/webapp/main/views.py
@@ -1533,3 +1533,33 @@ def router_legacy_info_pages(journal_seg, page):
         }
     return redirect('%s%s' % (url_for('main.about_journal',
                                       url_seg=journal_seg), page_anchor.get(page, '')), code=301)
+
+
+@main.route("/api/v1/counter", methods=['GET'])
+@main.route("/api/v1/counter/<string:end_date>", methods=['GET'])
+def router_counter_dicts(end_date=''):
+    """
+    Essa view function retorna um dicionário, em formato JSON, que mapeia PIDs a insumos
+    necessários para o funcionamento das aplicações Matomo & COUNTER & SUSHI.
+    """
+
+    try:
+        end_date = datetime.strptime(end_date, '%Y-%m-%d')
+    except:
+        end_date = datetime.now()
+    start_date = end_date - timedelta(days=30)
+
+    results = {'dictionary_date': end_date,
+               'documents_last_create_date': end_date.strftime('%Y-%m-%d %H-%M-%S'),
+               'documents_first_create_date': start_date.strftime('%Y-%m-%d %H-%M-%S'),
+               'documents': {},
+               'collection': current_app.config['OPAC_COLLECTION']}
+
+    for a in controllers.get_articles_by_date_range(start_date, end_date):
+        results['documents'].update(get_article_counter_data(a))
+
+    results['total'] = len(results['documents'])
+
+    return jsonify(results)
+
+

--- a/opac/webapp/main/views.py
+++ b/opac/webapp/main/views.py
@@ -1546,15 +1546,15 @@ def router_counter_dicts():
         end_date = datetime.strptime(end_date, '%Y-%m-%d')
     except ValueError:
         end_date = datetime.now()
-    start_date = end_date - timedelta(days=30)
+    begin_date = end_date - timedelta(days=30)
 
     results = {'dictionary_date': end_date,
-               'documents_last_create_date': end_date.strftime('%Y-%m-%d %H-%M-%S'),
-               'documents_first_create_date': start_date.strftime('%Y-%m-%d %H-%M-%S'),
+               'end_date': end_date.strftime('%Y-%m-%d %H-%M-%S'),
+               'begin_date': begin_date.strftime('%Y-%m-%d %H-%M-%S'),
                'documents': {},
                'collection': current_app.config['OPAC_COLLECTION']}
 
-    for a in controllers.get_articles_by_date_range(start_date, end_date):
+    for a in controllers.get_articles_by_date_range(begin_date, end_date):
         results['documents'].update(get_article_counter_data(a))
 
     results['total'] = len(results['documents'])

--- a/opac/webapp/main/views.py
+++ b/opac/webapp/main/views.py
@@ -1544,7 +1544,7 @@ def router_counter_dicts():
     end_date = request.args.get('end_date', '', type=str)
     try:
         end_date = datetime.strptime(end_date, '%Y-%m-%d')
-    except:
+    except ValueError:
         end_date = datetime.now()
     start_date = end_date - timedelta(days=30)
 

--- a/opac/webapp/main/views.py
+++ b/opac/webapp/main/views.py
@@ -1536,13 +1536,12 @@ def router_legacy_info_pages(journal_seg, page):
 
 
 @main.route("/api/v1/counter_dict", methods=['GET'])
-@main.route("/api/v1/counter_dict/<string:end_date>", methods=['GET'])
-def router_counter_dicts(end_date=''):
+def router_counter_dicts():
     """
     Essa view function retorna um dicionário, em formato JSON, que mapeia PIDs a insumos
     necessários para o funcionamento das aplicações Matomo & COUNTER & SUSHI.
     """
-
+    end_date = request.args.get('end_date', '', type=str)
     try:
         end_date = datetime.strptime(end_date, '%Y-%m-%d')
     except:

--- a/opac/webapp/main/views.py
+++ b/opac/webapp/main/views.py
@@ -1535,8 +1535,8 @@ def router_legacy_info_pages(journal_seg, page):
                                       url_seg=journal_seg), page_anchor.get(page, '')), code=301)
 
 
-@main.route("/api/v1/counter", methods=['GET'])
-@main.route("/api/v1/counter/<string:end_date>", methods=['GET'])
+@main.route("/api/v1/counter_dict", methods=['GET'])
+@main.route("/api/v1/counter_dict/<string:end_date>", methods=['GET'])
 def router_counter_dicts(end_date=''):
     """
     Essa view function retorna um dicionário, em formato JSON, que mapeia PIDs a insumos


### PR DESCRIPTION
#### O que esse PR faz?
Adiciona rota /api/v1/counter_dict/ para gerar dicionário de PIDs e outros atributos para aplicação COUNTER.

#### Onde a revisão poderia começar?
Apenas dois arquivos foram modificados. Um controlador foi adicionado para obter artigos com base nos campos created e updated de objetos Article. Uma rota (/api/v1/counter_dict ou /api/v1/counter_dict/YYYY-MM-DD) foi adicionada para obter dados obtidos por meio do controlador.

A quantidade de dados é limitada a 30 dias, a partir da data indicada e percorrendo o tempo no sentido do passado. É importante averiguar se a obtenção de dados, por meio do método adicionado ao controlador, é ótima (otimizada, eficiente, eficaz, etc). 


#### Como este poderia ser testado manualmente?
É preciso ter uma base mongodb com dados do OPAC São necessários, pelo menos, registros das coleções collection, journal, issue e article. Deve-se subir uma instância do OPAC e acessar a rota impĺementada. Seguem exemplos de acesso:

- `0.0.0.0:5000/api/v1/counter_dict` (irá obter dados do período entre hoje e trinta dias atrás)
- `0.0.0.0:5000/api/v1/counter_dict/2021-04-01` (irá obter dados do período entre 2021-03-01 e 2020-04-01)


#### Algum cenário de contexto que queira dar?
Esta funcionalidade é necessária para permitir que as aplicações Matomo & COUNTER & SUSHI contabilizem de forma correta o ano de publicação dos artigos acessos por meio do site novo. Um dos relatórios COUNTER considera o ano de publicação dos artigos, parâmetro que não existe nas URLs acessadas. Por isso, é necessário gerar um dicionário que mapeie o ano de publicação dos artigos (entre outros atributos) a seus respectivos PIDs.


### Screenshots
Seguem figuras que exemplificam acessos a rota implementada:

![image](https://user-images.githubusercontent.com/2096125/114235794-16e14a80-9957-11eb-8c1e-ab92d2db5853.png)

e

![image](https://user-images.githubusercontent.com/2096125/114236361-e221c300-9957-11eb-8c1e-e38918184b19.png)


#### Quais são tickets relevantes?
#1814 

### Referências
N/A

