### PR TITLE
Adiciona no README o procedimento para rodar uma instância do OPAC com dados populado a partir de fixtures disponibilizadas pelo SciELO no minio.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -89,26 +89,35 @@ Simplesmente executar:
 Fixtures
 ======================
 
-Procedimento para popular a instância de desenvolvimento, a partir de fixtures disponibilizadas pelo SciELO.
+Procedimento para popular a instância de desenvolvimento a partir de fixtures disponibilizadas pelo SciELO.
 
 1. Baixar a fixture de desenvolvimento, execute: ``wget https://minio.scielo.br/dev/fixtures/opac_br.zip``
 2. Extraia o conteúdo, execute: ``unzip opac_br.zip`
 3. Repare que contém uma pasta chamado **opac_br**, nessa pasta temos os arquivo **.bson .json .sqlite** e outra pasta chamado **media** contento os ativos dos periódico e da coleção.
 4. Acesse a pasta **opac_br**, execute: ``cd opac_br``
-5. Utilizando **mongorestore** realize o recuperação do banco de dados apontando para o endereço que está rodando o seu mongo local, exemplo: ``mongorestore --host=localhost --port=27017 --db=opac_br -d``
-6. Realize a cópia da pasta **media** para {APP}/data
-7. Realize a cópia do **opac.sqlite** para {APP}/data
+5. Utilizando **mongorestore** realize a recuperação do banco de dados apontando para o endereço que está rodando o seu mongo local, exemplo: ``mongorestore --host=localhost --port=27017 --db=opac --dir .``
+6. Realize a cópia da pasta **media** para a pasta data. A pasta data está na raiz deste repositório e é, por padrão, mapeada à aplicação OPAC.
+7. Realize a cópia da pasta **opac.sqlite** para a pasta data. A pasta data está na raiz deste repositório e é, por padrão, mapeada à aplicação OPAC.
+8. Os seguintes parâmetros devem está configurados no arquivo no ``docker-compose-dev.yml``:
+
+- OPAC_SSM_DOMAIN=minio.scielo.br
+- OPAC_SSM_PORT=443
+- OPAC_SSM_SCHEME=https
+- OPAC_SSM_XML_URL_REWRITE=False
+
 8. Para ambiente utilizando **Docker** é necessário reiniciar os containers: ``make dev_compose_stop`` && ``make dev_compose_up``
 
 Caso não tenha o **mongorestore** localmente é necessário a instalação **MONGODB DATABASE TOOLS**: https://docs.mongodb.com/database-tools/installation/installation/
 
-Para utilizar o ambiente de desenvolvimento com os dados populado a partir dos passos indicado acima é necessário que esteja conectado com a **VPN da SciELO**
+Para utilizar o ambiente de desenvolvimento com os dados populado a partir dos passos indicado acima é necessário que esteja conectado com a **VPN da SciELO**, caso não esteja conectado a página do artigo estará indisponível.
 
-Usuário e senha para a área administrativa:
+A área administrativa conta com um usuário cadastrado, em http://0.0.0.0:8000/admin, utilize as seguintes credenciais:
 
-**Ususário:** admin@admin.com
+**Usuário:** admin@admin.com
+
 **Senha:** admin
 
+Caso queira alterar para um mongodb local do hospedeiro, é necessário alterar o parâmetro: ``OPAC_MONGODB_HOST`` no ``docker-compose-dev.yml``.
 
 =========================================
 Reportar problemas, ou solicitar mudanças

--- a/README.rst
+++ b/README.rst
@@ -104,6 +104,12 @@ Caso não tenha o **mongorestore** localmente é necessário a instalação **MO
 
 Para utilizar o ambiente de desenvolvimento com os dados populado a partir dos passos indicado acima é necessário que esteja conectado com a **VPN da SciELO**
 
+Usuário e senha para a área administrativa:
+
+**Ususário:** admin@admin.com
+**Senha:** admin
+
+
 =========================================
 Reportar problemas, ou solicitar mudanças
 =========================================

--- a/README.rst
+++ b/README.rst
@@ -85,6 +85,24 @@ Simplesmente executar:
 5. para parar os containers, executar: ``make dev_compose_stop``
 6. para abrir uma terminal dentro do container, executar: ``make dev_compose_exec_shell_webapp``
 
+======================
+Fixtures
+======================
+
+Procedimento para popular a instância de desenvolvimento, a partir de fixtures disponibilizadas pelo SciELO.
+
+1. Baixar a fixture de desenvolvimento, execute: ``wget https://minio.scielo.br/dev/fixtures/opac_br.zip``
+2. Extraia o conteúdo, execute: ``unzip opac_br.zip`
+3. Repare que contém uma pasta chamado **opac_br**, nessa pasta temos os arquivo **.bson .json .sqlite** e outra pasta chamado **media** contento os ativos dos periódico e da coleção.
+4. Acesse a pasta **opac_br**, execute: ``cd opac_br``
+5. Utilizando **mongorestore** realize o recuperação do banco de dados apontando para o endereço que está rodando o seu mongo local, exemplo: ``mongorestore --host=localhost --port=27017 --db=opac_br -d``
+6. Realize a cópia da pasta **media** para {APP}/data
+7. Realize a cópia do **opac.sqlite** para {APP}/data
+8. Para ambiente utilizando **Docker** é necessário reiniciar os containers: ``make dev_compose_stop`` && ``make dev_compose_up``
+
+Caso não tenha o **mongorestore** localmente é necessário a instalação **MONGODB DATABASE TOOLS**: https://docs.mongodb.com/database-tools/installation/installation/
+
+Para utilizar o ambiente de desenvolvimento com os dados populado a partir dos passos indicado acima é necessário que esteja conectado com a **VPN da SciELO**
 
 =========================================
 Reportar problemas, ou solicitar mudanças


### PR DESCRIPTION
#### O que esse PR faz?
Adiciona a capacidade do desenvolvedor popular o banco de dados local com 4 periódicos. 

#### Onde a revisão poderia começar?

Lendo as alterações no **README.rst** 

#### Como este poderia ser testado manualmente?
Realizando de fato os novos passos para popular o banco de dados.

#### Algum cenário de contexto que queira dar?

Ainda é necessário o uso da **VPN SciELO** para visualizar a página do artigo.


Referente a atividade: #1864 