### PR TITLE
Alinhamento dos botões resumo, texto e pdf na tela do artigo

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -9,6 +9,8 @@ const gutil = require('gulp-util');
 const rename = require('gulp-rename');
 const concat = require('gulp-concat');
 const minifyCSS = require('gulp-minify-css');
+const stripDebug = require('gulp-strip-debug');
+
 
 
 // caminho da pasta 'node_modules/bootstrap'
@@ -37,8 +39,8 @@ let paths = {
 };
 
 console.info('[INFO] [gulpfile.js] path da pasta bootstrap/js:\t', paths['bootstrap_js']);
-console.info('[INFO] [gulpfile.js] path da pasta bootstrap/less:\t', paths['bootstrap_less']);
-console.info('[INFO] [gulpfile.js] path da pasta bootstrap/css:\t', paths['bootstrap_css']);
+//console.info('[INFO] [gulpfile.js] path da pasta bootstrap/less:\t', paths['bootstrap_less']);
+//console.info('[INFO] [gulpfile.js] path da pasta bootstrap/css:\t', paths['bootstrap_css']);
 
 console.info('[INFO] [gulpfile.js] path da pasta static/js:\t', paths['static_js']);
 console.info('[INFO] [gulpfile.js] path da pasta static/less:\t', paths['static_less']);
@@ -53,7 +55,7 @@ let target_src = {
             path.join(paths['jquery-typeahead_js'], 'jquery.typeahead.min.js'),
             path.join(paths['static_js'], 'plugins.js'),
             path.join(paths['static_js'], 'main.js'),
-            
+           
             // instruções JS (equipe scielo)
             path.join(paths['static_js'], 'common.js'),
             path.join(paths['static_js'], 'moment.js'),
@@ -109,6 +111,58 @@ let output = {
         'scielo-bundle-print': 'scielo-bundle-print.css',
     }
 };
+
+// Task para gerar o scielo-article-standalone.js
+function processScieloArticleStandaloneJs(){
+    return src(target_src['js']['scielo-article-standalone'])
+    .pipe(concat(output['js']['scielo-article-standalone']))
+    .pipe(sourceMaps.init())
+    .pipe(stripDebug())
+    .pipe(uglify())
+    .pipe(sourceMaps.write('../maps'))
+    .pipe(dest(output['js']['folder']));
+}
+
+// Task para gerar o scielo-article.js
+function processScieloArticleJs(){
+    return src(target_src['js']['scielo-article'])
+    .pipe(concat(output['js']['scielo-article']))
+    .pipe(sourceMaps.init())
+    .pipe(stripDebug())
+    .pipe(uglify())
+    .pipe(sourceMaps.write('../maps'))
+    .pipe(dest(output['js']['folder']));
+}
+
+// Task para gerar o scielo-bundle.js
+function processScieloBundleJs(){
+    return src(target_src['js']['scielo-bundle'])
+    .pipe(concat(output['js']['scielo-bundle']))
+    .pipe(sourceMaps.init())
+    .pipe(stripDebug())
+    .pipe(uglify())
+    .pipe(sourceMaps.write('../maps'))
+    .pipe(dest(output['js']['folder']));
+}
+
+
+// Task para gerar o scielo-bundle-print.less
+function processScieloBundlePrintLess(){
+    return src(target_src['less']['scielo-bundle-print'])
+    .pipe(concat(output['css']['scielo-bundle-print']))
+    .pipe(less(output['css']['scielo-bundle-print']))
+    .pipe(minifyCSS())
+    .pipe(dest(output['css']['folder']));
+}
+
+// Task para gerar o scielo-article-standalone.less
+function processScieloArticleStandaloneLess(){
+    return src(target_src['less']['scielo-article-standalone'])
+    .pipe(concat(output['css']['scielo-article-standalone']))
+    .pipe(less(output['css']['scielo-article-standalone']))
+    .pipe(minifyCSS())
+    .pipe(dest(output['css']['folder']));
+}
 
 function processScieloBundleLess(){
     return src(target_src['less']['scielo-bundle'])
@@ -169,15 +223,19 @@ function watchProcessScieloArticleLess() {
 exports.watch = series(
     processScieloBundleLess,
     processScieloArticleLess,
-    
+   
     parallel(
         watchProcessScieloBundleLess,
         watchProcessScieloArticleLess
     )
 )
 
-
 exports.default = series(
-    processScieloArticleLess
+    processScieloBundleLess,
+    processScieloArticleLess,
+    processScieloArticleStandaloneLess,
+    processScieloBundlePrintLess,
+    processScieloBundleJs,
+    processScieloArticleJs,
+    processScieloArticleStandaloneJs
 );
-

--- a/opac/webapp/static/less/article.less
+++ b/opac/webapp/static/less/article.less
@@ -2501,6 +2501,15 @@ Ajustes para mobile
 				padding-right: 32px !important;
 			}
 		}
+
+		&:hover{
+			background: @Blue !important;
+			color: #fff;
+
+			[class^="sci-ico-"] {
+				color: #fff;
+			}
+		}
 	}
 	.dropdown-menu{
 		a.current{
@@ -2521,6 +2530,8 @@ Ajustes para mobile
 				left: auto;
 			}
 		}
+
+		
 	}
 }
 
@@ -2549,6 +2560,15 @@ Ajustes para mobile
 					display: inline-block;
 					width: 70%;
 				}
+
+				@media @onlyMobile {
+					.caret{
+						position: absolute;
+						right: 10px;
+						top: 17px;
+					}
+				}
+				
 			}
 		}
 		&.btn-group-nav-mobile-content{
@@ -2577,6 +2597,7 @@ Ajustes para mobile
 
 				.btn{
 					width: 100%;
+					position: relative;
 
 					span{
 
@@ -2585,6 +2606,12 @@ Ajustes para mobile
 
 						&:last-child{
 							width: auto;
+						}
+
+						&.caret{
+							position: absolute;
+							right: 10px;
+							top: 17px;
 						}
 						
 					}

--- a/opac/webapp/templates/article/includes/levelMenu_pdf.html
+++ b/opac/webapp/templates/article/includes/levelMenu_pdf.html
@@ -1,7 +1,33 @@
           {% if article and article.pdfs|length == 1 %}
+            <!--
             <a target='_blank' href="{{ url_for('.article_detail_v3', url_seg=article.journal.url_segment, article_pid_v3=article.aid, format='pdf', lang=article.pdfs[0].lang) }}" class="btn">
               <span class="sci-ico-filePDF"></span> PDF
             </a>
+            -->
+
+            <div class="dropdown">
+              <button class="btn dropdown-toggle" type="button" data-toggle="dropdown">
+              <span class="sci-ico-filePDF"></span>
+              <span>PDF</span>
+              <span class="caret"></span></button>
+              <ul class="dropdown-menu menu-share-mobile">
+                {% for pdf in article.pdfs  %}
+                  <li>
+                    <a target='_blank' href="{{ url_for('.article_detail_v3', url_seg=article.journal.url_segment, article_pid_v3=article.aid, format='pdf', lang=article.pdfs[0].lang) }}">
+                      {% if pdf.lang == 'es' %}
+                        {% trans %}Download PDF (Espanhol){% endtrans %}
+                      {% elif pdf.lang == 'en' %}
+                        {% trans %}Download PDF (Inglês){% endtrans %}
+                      {% elif pdf.lang == 'pt' %}
+                        {% trans %}Download PDF (Português){% endtrans %}
+                      {% else %}
+                        {{ pdf.lang }}
+                      {% endif %}
+                    </a>
+                  </li>
+                {% endfor %}
+              </ul>
+            </div>
           {% endif%}
 
           {% if config['READCUBE_ENABLED'] and article.doi and article.pid %}

--- a/package.json
+++ b/package.json
@@ -28,12 +28,13 @@
     "gulp-less": "^3.3.2",
     "gulp-minify-css": "^1.2.4",
     "gulp-rename": "^2.0.0",
+    "gulp-sourcemaps": "^3.0.0",
     "gulp-strip-debug": "^1.1.0",
-    "gulp-uglify": "^3.0.0"
+    "gulp-uglify": "^3.0.0",
+    "gulp-util": "^3.0.8"
   },
   "dependencies": {
     "bootstrap": "^3.4.1",
-    "gulp-sourcemaps": "^2.6.4",
     "jquery": "^3.6.0",
     "jquery-typeahead": "^2.11.1"
   }


### PR DESCRIPTION
#### O que esse PR faz?
Corrige o gulpfile.js, responsável por gerar os arquivos css e js minificados.
Atualiza o package.json, responsável por instalar as dependências necessárias para rodar o gulpfile.js
Atualiza o arquivo article.less adicionando classes que corrigem posicionamento de alguns elementos de interface quando em dispositivos móveis.
Atualiza o arquivo levelMenu_pdf exibindo um dropdown mesmo quando houver apenas uma possibilidade de idioma em arquivos PDF. Ao abrir o dropdown a opção de idioma é exibida.

#### Onde a revisão poderia começar?
1 - Baixe a atualização
2 - rode um npm install para instalar as dependencias necessárias pra rodar o gulpfile e gerar os arquivos css e js minificados
3 - na raiz do projeto, rode o comando "gulp". Esse comando vai gerar todos os arquivos css e js atualizados com base nos arquivos .less e js.
4 - acesse a tela do artigo e teste em diferentes resoluções. Não deve haver quebra de layout ou desalinhamento de botões

#### Como este poderia ser testado manualmente?
Siga os passos descritos anteriormente.

#### Algum cenário de contexto que queira dar?
Como serão gerados novos arquivos .css é sempre recomendável limpar o cache do navegador.
Recomendo o teste nos mais variados tipos de artigos.
Caso haja alguma quebra, favor especificar o periódico e se possível o artigo do ocorrido. Isso facilita bastante toda e qualquer correção.
![Screen Shot 2021-05-14 at 5 37 57 PM](https://user-images.githubusercontent.com/22373640/118330272-e8b6d380-b4dd-11eb-8b34-fbd19929ee62.png)


### Screenshots
![Screen Shot 2021-05-14 at 5 37 11 PM](https://user-images.githubusercontent.com/22373640/118330065-a097b100-b4dd-11eb-9a42-9f16fbeb612a.png)

![Screen Shot 2021-05-14 at 5 37 29 PM](https://user-images.githubusercontent.com/22373640/118330090-a8575580-b4dd-11eb-9361-635746965b36.png)


#### Quais são tickets relevantes?
#tk1762

### Referências
-

