### PR TITLE
Deixa a mensagem no topo da home configurável e com possibilidade de acrescentar um link para a versão anterior do website.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -48,6 +48,18 @@ Guia de configuração do site
 Pode acessar `nossa wiki <https://github.com/scieloorg/opac/wiki/Configura%C3%A7%C3%A3o-padr%C3%A3o-e-vari%C3%A1veis-de-ambiente>`_ para ter uma guia completa e como ajustar a configuração a partir de un arquivo de configuração em cada instância ou utilizando variáveis de ambiente.
 
 
+Caso queira apresentar na home do website que o atual tem versão anterior
+
+PREVIOUS_WEBSITE_URI=https://old.scielo.br
+
+
+Caso queira apresentar na home do website qualquer mensagem de texto
+
+ALERT_MSG_PT=Novo portal pode conter incorreções
+ALERT_MSG_EN=New portal may contain inaccuracies 
+ALERT_MSG_ES=Nuevo portal puede contener incorrecciones
+
+
 ======================
 Como executar os tests
 ======================
@@ -127,11 +139,3 @@ Reportar problemas, ou solicitar mudanças
 
 Para reportar problemas, bugs, ou simplesmente solicitar alguma nova funcionalidade, pode `criar um ticket <https://github.com/scieloorg/opac/issues>`_ com seus pedidos.
 
-
-=========================================
-Equipe responsável por instalação, desenvolvimento e manutenção
-=========================================
-
-- Jamil Atta Junior (Desenvolvimento) <jamil.atta@scielo.org>
-- Juan Funez (Desenvolvimento) <juan.funez@scielo.org>
-- Rondineli Gama Saad (Infraestrutura) <rondineli.saad@scielo.org>

--- a/opac/webapp/config/default.py
+++ b/opac/webapp/config/default.py
@@ -524,3 +524,12 @@ APM_DEBUG = os.environ.get("OPAC_APM_DEBUG", False)
 APM_DISABLE_SEND = os.environ.get("OPAC_APM_DISABLE_SEND", False)
 APM_INSTRUMENT = os.environ.get("OPAC_APM_INSTRUMENT", True)
 APM_VERIFY_SERVER_CERT = os.environ.get("OPAC_APM_APM_VERIFY_SERVER_CERT", True)
+
+# Caso queira apresentar na home do website que o atual tem versão anterior
+PREVIOUS_WEBSITE_URI = os.environ.get("PREVIOUS_WEBSITE_URI", '')
+
+# Caso queira apresentar na home do website qualquer mensagem de texto
+ALERT_MSG_PT = os.environ.get("ALERT_MSG_PT", '')
+ALERT_MSG_EN = os.environ.get("ALERT_MSG_EN", '')
+ALERT_MSG_ES = os.environ.get("ALERT_MSG_ES", '')
+ALERT_MSG = bool(ALERT_MSG_PT or ALERT_MSG_EN or ALERT_MSG_ES)

--- a/opac/webapp/templates/collection/base.html
+++ b/opac/webapp/templates/collection/base.html
@@ -3,12 +3,28 @@
 {% block content %}
   <div class="alert-warning" style="padding: 0 5px; text-align: center">
     {% with html_lang=session.get('lang', config.get('BABEL_DEFAULT_LOCALE')) %}
-      {% if html_lang == 'pt_BR' %}
-        <strong>Novo portal</strong> - pode conter incorreções
-      {% elif html_lang == 'en' %}
-        <strong>New portal</strong> - may contain inaccuracies
-      {% elif html_lang == 'es' %}
-        <strong>Nuevo portal</strong> - puede contener incorrecciones
+      {% if config.get('ALERT_MSG') %}
+        <span>
+        {% if html_lang == 'pt_BR' %}
+          {{ config.get('ALERT_MSG_PT') }}
+        {% elif html_lang == 'es' %}
+          {{ config.get('ALERT_MSG_ES') }}
+        {% else %}
+          {{ config.get('ALERT_MSG_EN') }}
+        {% endif %}
+        </span>
+      {% endif %}
+
+      {% if config.get('PREVIOUS_WEBSITE_URI') %}
+        {% if '://' in config.get('PREVIOUS_WEBSITE_URI') %}
+          <a href="{{ config.get('PREVIOUS_WEBSITE_URI') }}">
+          {{ config.get('PREVIOUS_WEBSITE_URI') }}
+          </a>
+        {% else %}
+          <a href="https://{{ config.get('PREVIOUS_WEBSITE_URI') }}">
+          {{ config.get('PREVIOUS_WEBSITE_URI') }}
+          </a>
+        {% endif %}
       {% endif %}
     {% endwith %}
   </div>


### PR DESCRIPTION
#### O que esse PR faz?
Deixa a mensagem no topo da home configurável e com possibilidade de acrescentar um link para a versão anterior do website.

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
configurando as variáveis como variáveis de ambiente, subindo a aplicação, e olhando a página principal. 

#### Algum cenário de contexto que queira dar?
Há "duas" variáveis configuráveis:

- texto que corresponde a "New portal may contain inaccuracies", pode ser qualquer mensagem ou nenhuma mensagem.

```
ALERT_MSG_PT=Novo portal pode conter incorreções
ALERT_MSG_EN=New portal may contain inaccuracies 
ALERT_MSG_ES=Nuevo portal puede contener incorrecciones
```

- exclusivamente o endereço do website anterior
``` 
PREVIOUS_WEBSITE_URI=https://old.scielo.br
```

### Screenshots

**AMBAS CONFIGURADAS**

<img width="738" alt="Captura de Tela 2021-05-18 às 15 07 57" src="https://user-images.githubusercontent.com/505143/118703416-72231a00-b7ec-11eb-9d04-8a700689a8d4.png">

**TEXTO CONFIGURADO**
<img width="542" alt="Captura de Tela 2021-05-18 às 15 23 35" src="https://user-images.githubusercontent.com/505143/118704158-35a3ee00-b7ed-11eb-999a-bbbb59b74984.png">


**LINK CONFIGURADO**
<img width="740" alt="Captura de Tela 2021-05-18 às 15 22 59" src="https://user-images.githubusercontent.com/505143/118704159-35a3ee00-b7ed-11eb-9114-76ac3cd1c893.png">


**NENHUM**
<img width="746" alt="Captura de Tela 2021-05-18 às 15 22 14" src="https://user-images.githubusercontent.com/505143/118704179-389ede80-b7ed-11eb-9fbb-b298d7202329.png">


#### Quais são tickets relevantes?
#1895

### Referências
n/a
