### PR TITLE
Altera worker do Gunicorn e robots.txt

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,4 +46,4 @@ EXPOSE 8000
 HEALTHCHECK --interval=5m --timeout=3s \
   CMD curl -f http://localhost:8000/ || exit 1
 
-CMD gunicorn --workers 3 --bind 0.0.0.0:8000 manager:app --chdir=/app/opac --timeout 150 --log-level INFO
+CMD gunicorn --workers 3 -k gthread --threads 4 --bind 0.0.0.0:8000 manager:app --chdir=/app/opac --timeout 150 --log-level INFO

--- a/opac/webapp/static/robots.txt
+++ b/opac/webapp/static/robots.txt
@@ -1,40 +1,7 @@
-# Allow only major search spiders
-# User-agent: *
-# Crawl-delay: 10
-
-# User-agent: Mediapartners-Google
-# Disallow:
-
-# User-agent: Googlebot
-# Disallow:
-
-# User-agent: Adsbot-Google
-# Disallow:
-
-# User-agent: Googlebot-Image
-# Disallow:
-
-# User-agent: Googlebot-Mobile
-# Disallow:
-
-# User-agent: MSNBot
-# Disallow:
-
-# User-agent: bingbot
-# Disallow:
-
-# User-agent: Slurp
-# Disallow:
-
-# User-agent: Yahoo! Slurp
-# Disallow:
-
-# User-agent: ia_archiver
-# Allow: /
-
-# User-agent: archive.org_bot
-# Allow: /
-
-# Block all other spiders
+# Block admin to all crawlers
 User-agent: *
-Disallow: /
+Disallow: /admin
+
+# Allow all crawlers
+User-agent: *
+Allow: /


### PR DESCRIPTION
Faz com que por padrão o Gunicorn use workers do tipo gthread, com 4 threads por worker. Essa mudança visa fazer com que cada worker seja capaz de atender mais requisições concorrentes sem aumentar significativamente o consumo de recursos, em específico de memória.

Além disso, este _pull request_ também altera o arquivo `robots.txt` de forma que fique mais permissivo por
padrão.

#### Como este poderia ser testado manualmente?
Basta subir localmente uma instância da aplicação. Durante a inicialização, o Gunicorn imprime na tela qual tipo de worker está sendo utilizado, observe se `gthreads` é escrito.

Para testar o `robots.txt`, acesse 0.0.0.0:8000/robots.txt e veja se ele está como o arquivo enviado neste PR.

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
n/a

#### Quais são tickets relevantes?
n/a

### Referências
n/a

