### PR TITLE
Remove a faixa de números (fascículos) da página inicial 

### DIFF
--- a/opac/webapp/main/views.py
+++ b/opac/webapp/main/views.py
@@ -206,7 +206,6 @@ def index():
         'urls': urls,
         'tweets': tweets,
         'press_releases': press_releases,
-        'journals': controllers.get_journals(query_filter="current", order_by="-last_issue.year")
     }
 
     return render_template("collection/index.html", **context)

--- a/opac/webapp/templates/collection/index.html
+++ b/opac/webapp/templates/collection/index.html
@@ -97,29 +97,6 @@
           </div>
         </div>
       </div>
-
-      {% if journals %}
-        <div class="row">
-          <div class="block last_issues">
-            <div class="col-md-12">
-              <h2><strong>{% trans %}Números <span>mais recentes</span>{% endtrans %}</strong></h2>
-              <div class="slider" id="last_issues">
-                <a href="javascript:;" class="slide-back"><span class="glyphBtn arrowLeft"></span></a>
-                <a href="javascript:;" class="slide-next"><span class="glyphBtn arrowRight"></span></a>
-                <div class="slide-container">
-                  <div class="slide-wrapper">
-                    {% for journal in journals %}
-                        {% include "news/includes/issue_last_row.html" %}
-                    {% endfor %}
-                  </div>
-                </div>
-              </div>
-            </div>
-            <div class="clearfix"></div>
-          </div>
-        </div> {# /row #}
-      {% endif %}
-
       {% if press_releases %}
         <div class="row">
           <div class="block releases">


### PR DESCRIPTION
#### O que esse PR faz?
Remove a faixa de números (fascículos) da página inicial

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
Acessando a página inicial e verificando a ausência da faixa de números

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
antes:
<img width="1178" alt="Captura de Tela 2021-05-25 às 10 26 42" src="https://user-images.githubusercontent.com/505143/119505932-d2addc00-bd43-11eb-8298-7189cbce8dbd.png">

depois:
<img width="1205" alt="Captura de Tela 2021-05-25 às 10 26 17" src="https://user-images.githubusercontent.com/505143/119505953-d6416300-bd43-11eb-90a2-0f1f395b0f30.png">

#### Quais são tickets relevantes?
Indique uma issue ao qual o pull request faz relacionamento.

### Referências
n/a
