### PR TITLE
Remove métricas de "Números" da faixa "Brasil em números | Métricas"

### DIFF
--- a/opac/webapp/main/views.py
+++ b/opac/webapp/main/views.py
@@ -196,7 +196,6 @@ def index():
         g.collection.metrics.total_journal = Journal.objects.filter(
             is_public=True, current_status="current"
         ).count()
-        g.collection.metrics.total_issue = Issue.objects.filter(is_public=True).count()
         g.collection.metrics.total_article = Article.objects.filter(
             is_public=True
         ).count()

--- a/opac/webapp/templates/collection/index.html
+++ b/opac/webapp/templates/collection/index.html
@@ -27,10 +27,6 @@
                   <span>{% trans %}períodicos{% endtrans %}</span>
                 </div>
                 <div class="col-md-3 col-sm-3">
-                  {{ g.collection.metrics.total_issue }}
-                  <span>{% trans %}números{% endtrans %}</span>
-                </div>
-                <div class="col-md-3 col-sm-3">
                   {{ g.collection.metrics.total_article }}
                   <span>{% trans %}artigos{% endtrans %}</span>
                 </div>


### PR DESCRIPTION
#### O que esse PR faz?
Remove métricas de "Números" da faixa "Brasil em números | Métricas"

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
ver #1908

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
antes:
<img width="674" alt="Captura de Tela 2021-05-25 às 11 23 47" src="https://user-images.githubusercontent.com/505143/119514804-b44bde80-bd4b-11eb-9db1-a6041221793c.png">



#### Quais são tickets relevantes?
#1908 

### Referências
n/a
