### PR TITLE
Resolve a indisponibilidade dos PDFs de aop e daqueles que tem idioma no nome do arquivo 

### DIFF
--- a/opac/tests/test_controller.py
+++ b/opac/tests/test_controller.py
@@ -1420,6 +1420,31 @@ class ArticleControllerTestCase(BaseTestCase):
                                                           pdfs__filename='article.pdf'
                                                           )
 
+    @patch('webapp.controllers.Article.objects')
+    @patch('webapp.controllers.get_journal_by_acron')
+    @patch('webapp.controllers.get_issue_by_label')
+    def test_get_article_by_pdf_filename_retrieves_articles_by_pdf_filename(
+        self, mk_get_issue_by_label, mk_get_journal_by_acron, mk_article_objects
+    ):
+
+        article = self._make_one(attrib={
+                                 '_id': '012ijs9y24',
+                                 'issue': '012ijs9y24-aop',
+                                 'journal': 'oak,ajimn1'
+                                 })
+
+        mk_get_journal_by_acron.return_value = article.journal
+        mk_get_issue_by_label.assert_not_called()
+
+        controllers.get_article_by_pdf_filename(
+            article.journal, "ahead", "article.pdf")
+
+        mk_article_objects.filter.assert_called_once_with(
+            is_public=True,
+            issue=article.issue,
+            pdfs__filename='article.pdf'
+        )
+
     def test_get_article_by_pdf_filename_raises_error_if_no_journal_acronym(self):
         with self.assertRaises(ValueError) as exc_info:
             controllers.get_article_by_pdf_filename("", "v1n3s2", "article.pdf")

--- a/opac/tests/test_controller.py
+++ b/opac/tests/test_controller.py
@@ -1412,7 +1412,9 @@ class ArticleControllerTestCase(BaseTestCase):
         mk_get_journal_by_acron.return_value = article.journal
         mk_get_issue_by_label.return_value = article.issue
 
-        controllers.get_article_by_pdf_filename(article.journal, article.issue, "article.pdf")
+        controllers.get_article_by_pdf_filename(
+            article.journal.acronym, article.issue.label, "article.pdf"
+        )
 
         mk_article_objects.filter.assert_called_once_with(is_public=True,
                                                           issue=article.issue,
@@ -1423,7 +1425,7 @@ class ArticleControllerTestCase(BaseTestCase):
     @patch('webapp.controllers.Article.objects')
     @patch('webapp.controllers.get_journal_by_acron')
     @patch('webapp.controllers.get_issue_by_label')
-    def test_get_article_by_pdf_filename_retrieves_articles_by_pdf_filename(
+    def test_get_article_by_pdf_filename_retrieves_aop_article_by_pdf_filename(
         self, mk_get_issue_by_label, mk_get_journal_by_acron, mk_article_objects
     ):
 
@@ -1437,11 +1439,11 @@ class ArticleControllerTestCase(BaseTestCase):
         mk_get_issue_by_label.assert_not_called()
 
         controllers.get_article_by_pdf_filename(
-            article.journal, "ahead", "article.pdf")
+            article.journal.acronym, "ahead", "article.pdf")
 
         mk_article_objects.filter.assert_called_once_with(
             is_public=True,
-            issue=article.issue,
+            issue=article.issue.label,
             pdfs__filename='article.pdf'
         )
 

--- a/opac/tests/test_controller.py
+++ b/opac/tests/test_controller.py
@@ -1442,8 +1442,9 @@ class ArticleControllerTestCase(BaseTestCase):
             article.journal.acronym, "ahead", "article.pdf")
 
         mk_article_objects.filter.assert_called_once_with(
+            journal=article.journal,
             is_public=True,
-            issue=article.issue.label,
+            issue='oak,ajimn1-aop',
             pdfs__filename='article.pdf'
         )
 
@@ -1454,11 +1455,11 @@ class ArticleControllerTestCase(BaseTestCase):
             str(exc_info.exception), __('Obrigatório o acrônimo do periódico.')
         )
 
-    def test_get_article_by_pdf_filename_raises_error_if_no_issue_info(self):
+    def test_get_article_by_pdf_filename_raises_error_if_no_issue_label(self):
         with self.assertRaises(ValueError) as exc_info:
             controllers.get_article_by_pdf_filename("abc", "", "article.pdf")
         self.assertEqual(
-            str(exc_info.exception), __('Obrigatório o campo issue_info.')
+            str(exc_info.exception), __('Obrigatório o campo issue_label.')
         )
 
     def test_get_article_by_pdf_filename_raises_error_if_no_pdf_filename(self):

--- a/opac/tests/test_legacy_urls.py
+++ b/opac/tests/test_legacy_urls.py
@@ -366,9 +366,9 @@ class LegacyURLTestCase(BaseTestCase):
 
                 url = '/pdf/cta/v39s2/0101-2061-cta-fst30618.pdf'
 
-                response = c.get(url, follow_redirects=True)
+                response = c.get(url, follow_redirects=False)
 
-                self.assertStatus(response, 200)
+                self.assertStatus(response, 301)
 
     def test_article_text_with_lng(self):
         """

--- a/opac/tests/test_main_views.py
+++ b/opac/tests/test_main_views.py
@@ -55,7 +55,6 @@ class MainTestCase(BaseTestCase):
 
             with self.client as client:
                 response = client.get(url_for('main.index'))
-                self.assertEqual(1, collection.metrics.total_issue)
                 self.assertEqual(1, collection.metrics.total_article)
                 self.assertEqual(1, collection.metrics.total_journal)
 

--- a/opac/webapp/config/default.py
+++ b/opac/webapp/config/default.py
@@ -418,6 +418,7 @@ SSM_DOMAIN = os.environ.get('OPAC_SSM_DOMAIN', 'homolog.ssm.scielo.org')
 SSM_PORT = os.environ.get('OPAC_SSM_PORT', '443')
 SSM_MEDIA_PATH = os.environ.get('OPAC_SSM_MEDIA_PATH', '/media/assets/')
 SSM_XML_URL_REWRITE = os.environ.get('OPAC_SSM_XML_URL_REWRITE', 'True') == 'True'
+SSM_ARTICLE_ASSETS_OR_RENDITIONS_URL_REWRITE = SSM_XML_URL_REWRITE
 
 # SSM_BASE_URI ex: 'https://homolog.ssm.scielo.org:80/'
 SSM_BASE_URI = "{scheme}://{domain}:{port}".format(

--- a/opac/webapp/controllers.py
+++ b/opac/webapp/controllers.py
@@ -1161,7 +1161,7 @@ def get_recent_articles_of_issue(issue_iid, is_public=True):
 
 def get_article_by_pdf_filename(journal_acron, issue_info, pdf_filename):
     """
-    Retorna dados dos pdfs de um artigo.
+    Retorna artigo pelo nome de arquivo pdf legado
     """
 
     if not journal_acron:
@@ -1172,17 +1172,24 @@ def get_article_by_pdf_filename(journal_acron, issue_info, pdf_filename):
         raise ValueError(__('Obrigatório o nome do arquivo PDF.'))
 
     journal = get_journal_by_acron(journal_acron)
-
-    issue = get_issue_by_label(journal, issue_info)
-
-    article = Article.objects.filter(journal=journal,
-                                     issue=issue, pdfs__filename=pdf_filename,
-                                     is_public=True).first()
+    if issue_info.endswith("ahead"):
+        article = Article.objects.filter(
+                    issue="{}-aop".format(journal.jid),
+                    pdfs__filename=pdf_filename,
+                    is_public=True).first()
+    else:
+        issue = get_issue_by_label(journal, issue_info)
+        article = Article.objects.filter(
+                    journal=journal,
+                    issue=issue, pdfs__filename=pdf_filename,
+                    is_public=True).first()
 
     if article:
         for pdf in article.pdfs:
             if pdf["filename"] == pdf_filename:
-                return pdf["url"]
+                article._pdf_lang = pdf["lang"]
+                article._pdf_url = pdf["url"]
+                return article
 
 
 def get_articles_by_date_range(begin_date, end_date):

--- a/opac/webapp/controllers.py
+++ b/opac/webapp/controllers.py
@@ -1181,14 +1181,20 @@ def get_article_by_pdf_filename(journal_acron, issue_label, pdf_filename):
     else:
         issue = get_issue_by_label(journal, issue_label)
 
+    splitted = pdf_filename.split("_")
+    prefix = ''
+    if len(splitted) > 1 and len(splitted[0]) == 2:
+        prefix = splitted[0]
+        pdf_filename = pdf_filename[3:]
+
     article = Article.objects.filter(
                 journal=journal,
                 issue=issue, pdfs__filename=pdf_filename,
                 is_public=True).first()
-
     if article:
         for pdf in article.pdfs:
-            if pdf["filename"] == pdf_filename:
+            if ((pdf["filename"] == pdf_filename and prefix == '') or
+                    pdf["lang"] == prefix):
                 article._pdf_lang = pdf["lang"]
                 article._pdf_url = pdf["url"]
                 return article

--- a/opac/webapp/main/views.py
+++ b/opac/webapp/main/views.py
@@ -1033,7 +1033,7 @@ def article_detail_pid(pid):
 
 def render_html_from_xml(article, lang, gs_abstract=False):
     if current_app.config["SSM_XML_URL_REWRITE"]:
-        result = fetch_data(normalize_ssm_url(article.xml))
+        result = fetch_data(use_ssm_url(article.xml))
     else:
         result = fetch_data(article.xml)
 
@@ -1055,7 +1055,7 @@ def render_html_from_html(article, lang):
     except IndexError:
         raise ValueError('Artigo não encontrado') from None
 
-    result = fetch_data(normalize_ssm_url(html_url))
+    result = fetch_data(use_ssm_url(html_url))
 
     html = result.decode('utf8')
 
@@ -1077,7 +1077,7 @@ def render_html(article, lang, gs_abstract=False):
 
 # TODO: Remover assim que o valor Article.xml estiver consistente na base de
 # dados
-def normalize_ssm_url(url):
+def use_ssm_url(url):
     """Normaliza a string `url` de acordo com os valores das diretivas de
     configuração OPAC_SSM_SCHEME, OPAC_SSM_DOMAIN e OPAC_SSM_PORT.
 
@@ -1274,7 +1274,7 @@ def article_detail_v3(url_seg, article_pid_v3, part=None):
 
     def _handle_xml():
         if current_app.config["SSM_XML_URL_REWRITE"]:
-            result = fetch_data(normalize_ssm_url(article.xml))
+            result = fetch_data(use_ssm_url(article.xml))
         else:
             result = fetch_data(article.xml)
         response = make_response(result)
@@ -1314,7 +1314,7 @@ def article_epdf():
 
 def get_pdf_content(url):
     if current_app.config["SSM_ARTICLE_ASSETS_OR_RENDITIONS_URL_REWRITE"]:
-        url = normalize_ssm_url(url)
+        url = use_ssm_url(url)
     try:
         response = fetch_data(url)
     except NonRetryableError:

--- a/opac/webapp/main/views.py
+++ b/opac/webapp/main/views.py
@@ -1383,13 +1383,20 @@ def article_detail_pdf(url_seg, url_seg_issue, url_seg_article, lang_code=''):
 @cache.cached(key_prefix=cache_key_with_lang_with_qs)
 def router_legacy_pdf(journal_acron, issue_info, pdf_filename):
     pdf_filename = '%s.pdf' % pdf_filename
-    pdf_url = controllers.get_article_by_pdf_filename(journal_acron, issue_info, pdf_filename)
-    if pdf_url is None:
+    article = controllers.get_article_by_pdf_filename(
+        journal_acron, issue_info, pdf_filename)
+    if not article:
         abort(404, _('PDF do artigo não foi encontrado'))
-    else:
-        pdf_url_parsed = urlparse(pdf_url)
-        return get_content_from_ssm(pdf_url_parsed.path)
-
+    return redirect(
+        url_for(
+            'main.article_detail_v3',
+            url_seg=article.journal.url_segment,
+            article_pid_v3=article.aid,
+            format='pdf',
+            lang=article._pdf_lang,
+        ),
+        code=301
+    )
 
 @main.route('/cgi-bin/fbpe/<string:text_or_abstract>/')
 @cache.cached(key_prefix=cache_key_with_lang_with_qs)

--- a/opac/webapp/main/views.py
+++ b/opac/webapp/main/views.py
@@ -1254,29 +1254,23 @@ def article_detail_v3(url_seg, article_pid_v3, part=None):
         return render_template("article/detail.html", **context)
 
     def _handle_pdf():
-        pdf_ssm_path = None
-
-        if article.pdfs:
-            try:
-                pdf_url = [pdf for pdf in article.pdfs if pdf['lang'] == qs_lang]
-
-                if len(pdf_url) != 1:
-                    abort(404, _('PDF do Artigo não encontrado'))
-                else:
-                    pdf_url = pdf_url[0]['url']
-
-                pdf_url_parsed = urlparse(pdf_url)
-                pdf_ssm_path = pdf_url_parsed.path
-
-            except Exception:
-                abort(404, _('PDF do Artigo não encontrado'))
-        else:
+        if not article.pdfs:
             abort(404, _('PDF do Artigo não encontrado'))
 
-        if not pdf_ssm_path:
-            raise abort(404, _('Recurso do Artigo não encontrado. Caminho inválido!'))
-        else:
+        pdf_url = [pdf for pdf in article.pdfs if pdf['lang'] == qs_lang]
+        if len(pdf_url) != 1:
+            abort(404, _('PDF do Artigo não encontrado'))
+
+        try:
+            pdf_url = pdf_url[0]['url']
+            pdf_url_parsed = urlparse(pdf_url)
+            pdf_ssm_path = pdf_url_parsed.path
+        except (IndexError, KeyError, ValueError, TypeError):
+            abort(404, _('PDF do Artigo não encontrado'))
+
+        if pdf_ssm_path:
             return get_content_from_ssm(pdf_ssm_path)
+        raise abort(404, _('Recurso do Artigo não encontrado. Caminho inválido!'))
 
     def _handle_xml():
         if current_app.config["SSM_XML_URL_REWRITE"]:

--- a/opac/webapp/main/views.py
+++ b/opac/webapp/main/views.py
@@ -1257,19 +1257,17 @@ def article_detail_v3(url_seg, article_pid_v3, part=None):
         if not article.pdfs:
             abort(404, _('PDF do Artigo não encontrado'))
 
-        pdf_url = [pdf for pdf in article.pdfs if pdf['lang'] == qs_lang]
-        if len(pdf_url) != 1:
+        pdf_info = [pdf for pdf in article.pdfs if pdf['lang'] == qs_lang]
+        if len(pdf_info) != 1:
             abort(404, _('PDF do Artigo não encontrado'))
 
         try:
-            pdf_url = pdf_url[0]['url']
-            pdf_url_parsed = urlparse(pdf_url)
-            pdf_ssm_path = pdf_url_parsed.path
+            pdf_url = pdf_info[0]['url']
         except (IndexError, KeyError, ValueError, TypeError):
             abort(404, _('PDF do Artigo não encontrado'))
 
-        if pdf_ssm_path:
-            return get_content_from_ssm(pdf_ssm_path)
+        if pdf_url:
+            return get_pdf_content(pdf_url)
         raise abort(404, _('Recurso do Artigo não encontrado. Caminho inválido!'))
 
     def _handle_xml():

--- a/opac/webapp/main/views.py
+++ b/opac/webapp/main/views.py
@@ -1312,21 +1312,18 @@ def article_epdf():
         return render_template("article/epdf.html", **context)
 
 
-@cache.cached(key_prefix=cache_key_with_lang_with_qs)
-def get_pdf_content(resource_ssm_media_path):
-    resource_ssm_full_url = current_app.config['SSM_BASE_URI'] + resource_ssm_media_path
-
-    url = resource_ssm_full_url.strip()
-    mimetype, __ = mimetypes.guess_type(url)
-
+def get_pdf_content(url):
+    if current_app.config["SSM_ARTICLE_ASSETS_OR_RENDITIONS_URL_REWRITE"]:
+        url = normalize_ssm_url(url)
     try:
-        ssm_response = fetch_data(url)
+        response = fetch_data(url)
     except NonRetryableError:
-        abort(404, _('Recurso não encontrado'))
+        abort(404, _('PDF não encontrado'))
     except RetryableError:
         abort(500, _('Erro inesperado'))
     else:
-        return Response(ssm_response, mimetype=mimetype)
+        mimetype, __ = mimetypes.guess_type(url)
+        return Response(response, mimetype=mimetype)
 
 
 @cache.cached(key_prefix=cache_key_with_lang_with_qs)

--- a/opac/webapp/main/views.py
+++ b/opac/webapp/main/views.py
@@ -1313,6 +1313,23 @@ def article_epdf():
 
 
 @cache.cached(key_prefix=cache_key_with_lang_with_qs)
+def get_pdf_content(resource_ssm_media_path):
+    resource_ssm_full_url = current_app.config['SSM_BASE_URI'] + resource_ssm_media_path
+
+    url = resource_ssm_full_url.strip()
+    mimetype, __ = mimetypes.guess_type(url)
+
+    try:
+        ssm_response = fetch_data(url)
+    except NonRetryableError:
+        abort(404, _('Recurso não encontrado'))
+    except RetryableError:
+        abort(500, _('Erro inesperado'))
+    else:
+        return Response(ssm_response, mimetype=mimetype)
+
+
+@cache.cached(key_prefix=cache_key_with_lang_with_qs)
 def get_content_from_ssm(resource_ssm_media_path):
     resource_ssm_full_url = current_app.config['SSM_BASE_URI'] + resource_ssm_media_path
 


### PR DESCRIPTION
#### O que esse PR faz?
Resolve a indisponibilidade dos PDFs de aop e daqueles que tem idioma no nome do arquivo.
Arquivos no padrão `/pdf/acron/volumenumero/arquivo.pdf`. 

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
Acessando pdfs no padrão `/pdf/acron/volumenumero/arquivo.pdf` de aop e com idioma como prefixo, por exemplo:
http://www.scielo.br/pdf/rlae/v29/es_0104-1169-rlae-29-e3395.pdf
https://www.scielo.br/pdf/cta/2020nahead/0101-2061-cta-fst21020.pdf

#### Algum cenário de contexto que queira dar?
- Questão do aop é que mudamos a forma de modelar. Há apenas 1 registro de aop. Não há mais 1 aop por ano.
- Falta de adequação dos nomes dos pdf que tem idioma no nome do arquivo. No pacote SPS o idioma é sufixo enquanto no site era prefixo.

### Screenshots
n/a

#### Quais são tickets relevantes?
#1921

### Referências
n/a
