### PR TITLE
Corrige "migração de páginas" para conseguir salvar páginas informativas

### DIFF
--- a/opac/tests/test_utils.py
+++ b/opac/tests/test_utils.py
@@ -260,11 +260,14 @@ class UtilsTestCase(BaseTestCase):
         registered_page.content = ''
         mocked_create_page.side_effect = registered_page
         mocked_delete_file.side_effect = None
-        content = '<img src="/img/revistas/abc.jpg"><a href="http://www.scielo.br/avaliacao/avaliacao_en.htm"/>'
+        content = (
+            '<img src="/img/revistas/abc.jpg">'
+            '<a href="http://www.scielo.br/avaliacao/avaliacao_en.htm"/>'
+        )
         new_content = wutils.migrate_page_content(
             content, acron='rbep', page_name=None, language='pt')
         self.assertEqual(
             '<img src="/media/rbep_abc.jpg"/>'
-            '<a href="/media/rbep_avaliacao_en.htm"></a>',
+            '<a href="http://www.scielo.br/avaliacao/avaliacao_en.htm"></a>',
             new_content
         )

--- a/opac/webapp/config/default.py
+++ b/opac/webapp/config/default.py
@@ -285,12 +285,15 @@ GA_TRACKING_CODE = os.environ.get('GA_TRACKING_CODE', None)
 # debug toolbar:
 DEBUG_TB_INTERCEPT_REDIRECTS = False
 
-# paginas secundarias
+# migracao de paginas secundarias
 DATA_PATH = os.path.join(PROJECT_PATH, '../../data')
+# url do site anterior / indica quais links e imagens mudar de endereço
 JOURNAL_PAGES_ORIGINAL_WEBSITE = os.environ.get(
-  'ORIGINAL_WEBSITE', 'www.scielo.br')
+  'ORIGINAL_WEBSITE') or ''
+# local novo das páginas secundárias (antigo `/revistas`)
 JOURNAL_PAGES_SOURCE_PATH = os.environ.get(
   'OPAC_JOURNAL_PAGES_SOURCE_PATH', os.path.join(DATA_PATH, 'pages'))
+# local novo das images (antigo `/img/revistas`)
 JOURNAL_IMAGES_SOURCE_PATH = os.environ.get(
   'OPAC_JOURNAL_IMAGES_SOURCE_PATH', os.path.join(DATA_PATH, 'img'))
 

--- a/opac/webapp/config/default.py
+++ b/opac/webapp/config/default.py
@@ -290,10 +290,10 @@ DATA_PATH = os.path.join(PROJECT_PATH, '../../data')
 # url do site anterior / indica quais links e imagens mudar de endereço
 JOURNAL_PAGES_ORIGINAL_WEBSITE = os.environ.get(
   'ORIGINAL_WEBSITE') or ''
-# local novo das páginas secundárias (antigo `/revistas`)
+# local mapeado para obter as páginas secundárias (antigo `/revistas`)
 JOURNAL_PAGES_SOURCE_PATH = os.environ.get(
   'OPAC_JOURNAL_PAGES_SOURCE_PATH', os.path.join(DATA_PATH, 'pages'))
-# local novo das images (antigo `/img/revistas`)
+# local mapeado para obter as images (antigo `/img/revistas`)
 JOURNAL_IMAGES_SOURCE_PATH = os.environ.get(
   'OPAC_JOURNAL_IMAGES_SOURCE_PATH', os.path.join(DATA_PATH, 'img'))
 

--- a/opac/webapp/main/views.py
+++ b/opac/webapp/main/views.py
@@ -398,7 +398,8 @@ def router_legacy():
             )
 
         elif script_php == 'sci_arttext' or script_php == 'sci_abstract':
-            pid = pid.upper()
+            if pid.startswith("s"):
+                pid = pid.upper()
             article = controllers.get_article_by_scielo_pid(pid)
 
             if not article:
@@ -432,6 +433,8 @@ def router_legacy():
 
         elif script_php == 'sci_pdf':
             # accesso ao pdf do artigo:
+            if pid.startswith("s"):
+                pid = pid.upper()
             article = controllers.get_article_by_scielo_pid(pid)
 
             if not article:

--- a/opac/webapp/utils/page_migration.py
+++ b/opac/webapp/utils/page_migration.py
@@ -63,7 +63,8 @@ def downloaded_file(url):
             with open(file_path, 'wb') as f:
                 f.write(response.content)
             return file_path
-    except requests.exceptions.ConnectionError as e:
+    except (requests.exceptions.ConnectionError,
+            requests.exceptions.HTTPError) as e:
         logging.error(
             u'%s (corresponding to %s)' % (e, url))
 
@@ -220,7 +221,8 @@ class PageMigration(object):
 
     def get_file_info(self, referenced):
         """
-
+        Retorna a localização do arquivo
+        que será migrado do site antigo para o novo
         """
         # obtém o local de importação dos arquivos para o site novo
         file_location = self.get_file_location(referenced)
@@ -239,11 +241,8 @@ class PageMigration(object):
 
         if valid_path:
             # se existe arquivo no local de importação dos arquivos,
-            # então retorna seus dados
-            file_dest_name = self.get_prefixed_slug_name(file_location)
-            return (file_location, file_dest_name, url is not None)
-
-        logging.info('CONFERIR: {} não encontrado'.format(referenced))
+            # então retorna file_location
+            return file_location
 
 
 class JournalPageMigration:

--- a/opac/webapp/utils/page_migration.py
+++ b/opac/webapp/utils/page_migration.py
@@ -387,17 +387,30 @@ class MigratedPage(object):
         return '_'.join(parts + [new_name])
 
     def get_file_info(self, referenced):
+        """
+
+        """
+        # obtém o local de importação dos arquivos para o site novo
         file_location = self.migration.get_file_location(referenced)
+
+        # verifica se arquivo existe no local de importação dos arquivos
         valid_path = confirm_file_location(file_location, referenced)
+
         url = None
         if not valid_path:
+            # tenta baixar arquivo
+            # se não existe no local de importação dos arquivos
             url = self.migration.is_asset_url(referenced)
             if url:
                 file_location = downloaded_file(url)
                 valid_path = confirm_file_location(file_location, referenced)
+
         if valid_path:
+            # se existe arquivo no local de importação dos arquivos,
+            # então retorna seus dados
             file_dest_name = self.get_prefixed_slug_name(file_location)
             return (file_location, file_dest_name, url is not None)
+
         logging.info('CONFERIR: {} não encontrado'.format(referenced))
 
     def create_images(self, create_image_function):

--- a/opac/webapp/utils/page_migration.py
+++ b/opac/webapp/utils/page_migration.py
@@ -402,7 +402,6 @@ class MigratedPage(object):
                 continue
 
             parsed_uri = urlparse(uri)
-            print(parsed_uri)
             if (parsed_uri.path == "" and
                     parsed_uri.netloc in self.migration.original_website):
                 yield item

--- a/opac/webapp/utils/page_migration.py
+++ b/opac/webapp/utils/page_migration.py
@@ -333,7 +333,7 @@ class MigratedPage(object):
     def fix_urls(self):
         replacements = []
         for elem_name, attr_name in [('a', 'href'), ('img', 'src')]:
-            for elem in self.find_original_website_reference(
+            for elem in self.find_old_website_uri_items(
                     elem_name, attr_name):
                 old_url = str(elem[attr_name])
                 new_url = old_url
@@ -356,13 +356,17 @@ class MigratedPage(object):
                 logging.info(
                     'CONFERIR: ainda existe: {} ({})'.format(old, q))
 
-    def find_original_website_reference(self, elem_name, attribute_name):
-        mentions = []
+    def find_old_website_uri_items(self, elem_name, attribute_name):
+        """
+        Busca a[@href] e/ou img[@src] com padrão do site antigo
+        """
         for item in self.tree.find_all(elem_name):
-            value = item.get(attribute_name, '')
-            if self.migration.original_website in value:
-                mentions.append(item)
-        return mentions
+            uri = item.get(attribute_name, '')
+            parsed_uri = urlparse(uri)
+            if (parsed_uri.path.startswith("/img/revistas/") or
+                    parsed_uri.path.startswith("/fbpe/") or
+                    parsed_uri.path.startswith("/revistas/")):
+                yield item
 
     @property
     def images(self):

--- a/opac/webapp/utils/page_migration.py
+++ b/opac/webapp/utils/page_migration.py
@@ -218,6 +218,33 @@ class PageMigration(object):
             return 'http://{}{}{}'.format(
                 self.original_website, sep, referenced)
 
+    def get_file_info(self, referenced):
+        """
+
+        """
+        # obtém o local de importação dos arquivos para o site novo
+        file_location = self.get_file_location(referenced)
+
+        # verifica se arquivo existe no local de importação dos arquivos
+        valid_path = confirm_file_location(file_location, referenced)
+
+        url = None
+        if not valid_path:
+            # tenta baixar arquivo
+            # se não existe no local de importação dos arquivos
+            url = self.is_asset_url(referenced)
+            if url:
+                file_location = downloaded_file(url)
+                valid_path = confirm_file_location(file_location, referenced)
+
+        if valid_path:
+            # se existe arquivo no local de importação dos arquivos,
+            # então retorna seus dados
+            file_dest_name = self.get_prefixed_slug_name(file_location)
+            return (file_location, file_dest_name, url is not None)
+
+        logging.info('CONFERIR: {} não encontrado'.format(referenced))
+
 
 class JournalPageMigration:
     """

--- a/opac/webapp/utils/page_migration.py
+++ b/opac/webapp/utils/page_migration.py
@@ -242,7 +242,7 @@ class PageMigration(object):
         if valid_path:
             # se existe arquivo no local de importação dos arquivos,
             # então retorna file_location
-            return file_location
+            return file_location, url is not None
 
 
 class JournalPageMigration:
@@ -413,29 +413,15 @@ class MigratedPage(object):
         return '_'.join(parts + [new_name])
 
     def get_file_info(self, referenced):
-        """
-
-        """
-        # obtém o local de importação dos arquivos para o site novo
-        file_location = self.migration.get_file_location(referenced)
-
-        # verifica se arquivo existe no local de importação dos arquivos
-        valid_path = confirm_file_location(file_location, referenced)
-
-        url = None
-        if not valid_path:
-            # tenta baixar arquivo
-            # se não existe no local de importação dos arquivos
-            url = self.migration.is_asset_url(referenced)
-            if url:
-                file_location = downloaded_file(url)
-                valid_path = confirm_file_location(file_location, referenced)
-
-        if valid_path:
+        # obtém o local de origem do arquivo a ser migrado
+        # do site antigo para o site novo
+        info = self.migration.get_file_info(referenced)
+        if info:
+            file_location, is_temp = info
             # se existe arquivo no local de importação dos arquivos,
             # então retorna seus dados
             file_dest_name = self.get_prefixed_slug_name(file_location)
-            return (file_location, file_dest_name, url is not None)
+            return (file_location, file_dest_name, is_temp)
 
         logging.info('CONFERIR: {} não encontrado'.format(referenced))
 


### PR DESCRIPTION
#### O que esse PR faz?
Corrige "migração de páginas" para conseguir salvar páginas informativas. A "migração de páginas informativas" corrige URI e migra imagens e arquivos do site anterior para o novo.

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
Ver como simular o erro em #1935

#### Algum cenário de contexto que queira dar?
O erro ocorria ao tentar baixar a imagem `https://www.scielo.br/media/images/capes_jvatitd.png` do site novo como se fosse do site anterior.

### Screenshots
n/a

#### Quais são tickets relevantes?
#1935

### Referências
n/a
