### PR TITLE
Adiciona paginação em rota api/v1/counter_dict

### DIFF
--- a/opac/webapp/controllers.py
+++ b/opac/webapp/controllers.py
@@ -1200,7 +1200,7 @@ def get_article_by_pdf_filename(journal_acron, issue_label, pdf_filename):
                 return article
 
 
-def get_articles_by_date_range(begin_date, end_date):
+def get_articles_by_date_range(begin_date, end_date, page=1, per_page=100):
     """
     Retorna artigos criados ou atualizados durante o período entre start_date e end_date.
     """

--- a/opac/webapp/controllers.py
+++ b/opac/webapp/controllers.py
@@ -1204,8 +1204,9 @@ def get_articles_by_date_range(begin_date, end_date, page=1, per_page=100):
     """
     Retorna artigos criados ou atualizados durante o período entre start_date e end_date.
     """
-    return Article.objects((Q(created__gte=begin_date) & Q(created__lte=end_date)) |
-                           (Q(updated__gte=begin_date) & Q(updated__lte=end_date)))
+    articles = Article.objects((Q(created__gte=begin_date) & Q(created__lte=end_date)) |
+                               (Q(updated__gte=begin_date) & Q(updated__lte=end_date))).order_by('pid')
+    return Pagination(articles, page, per_page)
 
 
 # -------- NEWS --------

--- a/opac/webapp/main/views.py
+++ b/opac/webapp/main/views.py
@@ -1580,7 +1580,8 @@ def router_counter_dicts():
                'documents': {},
                'collection': current_app.config['OPAC_COLLECTION']}
 
-    for a in controllers.get_articles_by_date_range(begin_date, end_date):
+    articles = controllers.get_articles_by_date_range(begin_date, end_date, page, limit)
+    for a in articles.items:
         results['documents'].update(get_article_counter_data(a))
 
     results['total'] = len(results['documents'])

--- a/opac/webapp/main/views.py
+++ b/opac/webapp/main/views.py
@@ -1566,6 +1566,10 @@ def router_counter_dicts():
         end_date = datetime.now()
     begin_date = end_date - timedelta(days=30)
 
+    page = request.args.get('page', type=int)
+    if not page:
+        page = 1
+
     results = {'dictionary_date': end_date,
                'end_date': end_date.strftime('%Y-%m-%d %H-%M-%S'),
                'begin_date': begin_date.strftime('%Y-%m-%d %H-%M-%S'),

--- a/opac/webapp/main/views.py
+++ b/opac/webapp/main/views.py
@@ -1584,7 +1584,10 @@ def router_counter_dicts():
     for a in articles.items:
         results['documents'].update(get_article_counter_data(a))
 
-    results['total'] = len(results['documents'])
+    results['total'] = articles.total
+    results['pages'] = articles.pages
+    results['limit'] = articles.per_page
+    results['page'] = articles.page
 
     return jsonify(results)
 

--- a/opac/webapp/main/views.py
+++ b/opac/webapp/main/views.py
@@ -1570,6 +1570,10 @@ def router_counter_dicts():
     if not page:
         page = 1
 
+    limit = request.args.get('limit', type=int)
+    if not limit or limit > 100 or limit < 0:
+        limit = 100
+
     results = {'dictionary_date': end_date,
                'end_date': end_date.strftime('%Y-%m-%d %H-%M-%S'),
                'begin_date': begin_date.strftime('%Y-%m-%d %H-%M-%S'),


### PR DESCRIPTION
#### O que esse PR faz?
Adiciona paginação em rota api/v1/counter_dict. Resolve bug #1953.

#### Onde a revisão poderia começar?
Por commits.

#### Como este poderia ser testado manualmente?
1. Tenha uma instância do OPAC
2. Tenha uma base de dados mongo/OPAC povoada com artigos e demais insumos
3. Acesse a rota http://0.0.0.0:8000/api/v1/counter_dict?end_date=2021-03-30
4. Verifique os parâmetros de paginação adicionado no JSON apresentado
5. Verifique que o número de documentos é limitado ao parâmetro "limit"
6. Acesse uma página válida, tam como http://0.0.0.0:8000/api/v1/counter_dict?end_date=2021-03-30&page=2

#### Algum cenário de contexto que queira dar?
A rota api/v1/counter_dict existe para disponibilizar insumos necessários ao cálculo de métricas COUNTER no contexto do novo site Brasil. São retornados dados dos 30 dias prévios ao parâmetro end_date - esse é um requisito da aplicação COUNTER.


#### Screenshots
_Trecho inicial de uma requisição_
![image](https://user-images.githubusercontent.com/2096125/122789152-61ebd800-d28d-11eb-906b-999c6d6ddc22.png)

_Trecho final de uma requisição_
![image](https://user-images.githubusercontent.com/2096125/122789203-6f08c700-d28d-11eb-9856-34c0449217f2.png)


#### Quais são tickets relevantes?
#1953 

#### Referências
N/A

