### PR TITLE
Atualizar a versão do packtools para v2.7.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -42,7 +42,7 @@ mongoengine==0.16.3
 natsort==7.0.1
 oauthlib==3.1.0
 -e git+https://git@github.com/scieloorg/opac_schema@499062237426fd5597a50ca81c9172852a9e1f81#egg=Opac_Schema
--e git+https://github.com/scieloorg/packtools/@2.7.0#egg=packtools
+-e git+https://github.com/scieloorg/packtools/@2.7.1#egg=packtools
 passlib==1.7.2
 pbr==5.4.5
 picles.plumber==0.11


### PR DESCRIPTION
#### O que esse PR faz?
Atualizar a versão do packtools para v2.7.1 para corrigir questões do resumo

- garantir que apresentação de highlights tem que ser antes dos demais resumos
- os highlights não tem palavras-chaves
- o primeiro resumo está com as palavras-chaves em idioma incorreto (isso só ocorre nos XML cujo grupo de palavras chaves está em ordem diferente da dos resumos)
- artigo não tem resumo, mas apresenta o título "Abstract" (isso ocorre porque no XML tem a tag <abstract/> vazia)

#### Onde a revisão poderia começar?
n/a

#### Como este poderia ser testado manualmente?
https://github.com/scieloorg/packtools/pull/266

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
n/a

#### Quais são tickets relevantes?
https://github.com/scieloorg/packtools/issues/265
https://github.com/scieloorg/packtools/issues/217

### Referências
n/a
