### PR TITLE
Recupera artigo usando também o campo `scielo_pids.other`

### DIFF
--- a/opac/tests/test_controller.py
+++ b/opac/tests/test_controller.py
@@ -1519,9 +1519,9 @@ class ArticleControllerTestCase(BaseTestCase):
     def test_get_article_by_aid_raises_missing_journal_url_seg_parameter_error(
             self):
         article = self._make_one()
-        with self.assertRaises(ValueError) as exc:
+        with self.assertRaises(controllers.ArticleJournalNotFoundError) as exc:
             controllers.get_article_by_aid(article.id, None)
-        self.assertIn("journal_url_seg", str(exc.exception))
+        self.assertIn("journal_acron", str(exc.exception))
 
     def test_get_article_by_aid_raises_not_found_article_journal_error(
             self):
@@ -1530,10 +1530,10 @@ class ArticleControllerTestCase(BaseTestCase):
             controllers.get_article_by_aid(article.id, "JOURNALID01")
         self.assertIn(article.journal.acronym, str(exc.exception))
 
-    def test_get_article_by_aid_raises_article_is_not_published_error(
+    def test_get_article_by_aid_raises_article_is_not_found_error(
             self):
         article = self._make_one({"is_public": False})
-        with self.assertRaises(controllers.ArticleIsNotPublishedError):
+        with self.assertRaises(controllers.ArticleNotFoundError):
             controllers.get_article_by_aid(
                 article.id, article.journal.url_segment)
 

--- a/opac/tests/test_legacy_urls.py
+++ b/opac/tests/test_legacy_urls.py
@@ -194,15 +194,12 @@ class LegacyURLTestCase(BaseTestCase):
 
             with self.client as c:
 
-                for pid in article.scielo_pids.values():
-
-                    url = 'scielo.php?script=sci_arttext&pid=%s' % pid
-
-                    response = c.get(url, follow_redirects=True)
-
-                    self.assertStatus(response, 200)
-
-                    self.assertTemplateUsed('article/detail.html')
+                for pid in ['0000-00000000000000001', '0000-00000000000000002']:
+                    with self.subTest(pid):
+                        url = 'scielo.php?script=sci_arttext&pid=%s' % pid
+                        response = c.get(url, follow_redirects=True)
+                        self.assertStatus(response, 200)
+                        self.assertTemplateUsed('article/detail.html')
 
     def test_article_text_check_redirect(self):
         """
@@ -319,13 +316,11 @@ class LegacyURLTestCase(BaseTestCase):
 
             with self.client as c:
 
-                for pid in article.scielo_pids.values():
-
-                    url = 'scielo.php?script=sci_pdf&pid=%s' % pid
-
-                    response = c.get(url, follow_redirects=True)
-
-                    self.assertStatus(response, 200)
+                for pid in ['0000-00000000000000001', '0000-00000000000000002']:
+                    with self.subTest(pid):
+                        url = 'scielo.php?script=sci_pdf&pid=%s' % pid
+                        response = c.get(url, follow_redirects=False)
+                        self.assertStatus(response, 301)
 
     @patch('requests.get')
     def test_router_legacy_pdf(self, mocked_requests_get):

--- a/opac/tests/test_main_views.py
+++ b/opac/tests/test_main_views.py
@@ -1096,7 +1096,6 @@ class MainTestCase(BaseTestCase):
                     'main.article_detail_v3',
                     url_seg=journal.url_segment,
                     article_pid_v3=article.aid,
-                    lang='en'
                 ),
             )
 
@@ -1197,7 +1196,6 @@ class MainTestCase(BaseTestCase):
                                            lang='pt'))
 
         self.assertStatus(response, 404)
-        self.assertIn(unpublish_reason, response.data.decode('utf-8'))
 
     def test_pdf_url(self):
         """

--- a/opac/tests/test_main_views_abstract.py
+++ b/opac/tests/test_main_views_abstract.py
@@ -35,7 +35,7 @@ class TestArticleDetailV3Abstract(BaseTestCase):
                     {'language': 'es', 'name': u'Artículo en español'},
                     {'language': 'pt', 'name': u'Artigo en Português'},
                 ],
-                'pid': 'pidv2'
+                'pid': 'PIDV2'
             }
             _article_data.update(article_data or {})
             self.article = utils.makeOneArticle(_article_data)

--- a/opac/webapp/controllers.py
+++ b/opac/webapp/controllers.py
@@ -1100,6 +1100,23 @@ def is_open_issue(articles):
         return False
 
 
+def get_article_by_pid_v1(v1, **kwargs):
+    """
+    Retorna um artigo considerando os parâmetros ``v1``.
+
+    - ``v1``: string, contendo o PID do artigo versão 1, 2 ou 3
+    """
+
+    if not v1:
+        raise ValueError(__('Obrigatório um pid.'))
+
+    return Article.objects(
+        scielo_pids__v1=v1,
+        is_public=True,
+        **kwargs
+    ).first()
+
+
 def get_article_by_pid(pid, **kwargs):
     """
     Retorna um artigo considerando os parâmetros ``pid``.
@@ -1142,7 +1159,7 @@ def get_article_by_scielo_pid(scielo_pid, **kwargs):
     ).first()
 
 
-def get_article_by_pid_v2(v2, is_public=True, **kwargs):
+def get_article_by_pid_v2(v2, **kwargs):
     """
     Retorna um artigo considerando os parâmetros ``v2``.
 
@@ -1159,6 +1176,7 @@ def get_article_by_pid_v2(v2, is_public=True, **kwargs):
         Q(aop_pid=v2) |
         Q(scielo_pids__v2=v2) |
         Q(scielo_pids__other__in=[v2]),
+        is_public=True,
         **kwargs
     ).first()
 

--- a/opac/webapp/controllers.py
+++ b/opac/webapp/controllers.py
@@ -1142,6 +1142,27 @@ def get_article_by_scielo_pid(scielo_pid, **kwargs):
     ).first()
 
 
+def get_article_by_pid_v2(v2, is_public=True, **kwargs):
+    """
+    Retorna um artigo considerando os parâmetros ``v2``.
+
+    - ``v2``: string, contendo o PID do artigo versão 2, seja pid ou aop_pid
+    """
+
+    if not v2:
+        raise ValueError(__('Obrigatório um pid.'))
+
+    v2 = v2.upper()
+
+    return Article.objects(
+        Q(pid=v2) |
+        Q(aop_pid=v2) |
+        Q(scielo_pids__v2=v2) |
+        Q(scielo_pids__other__in=[v2]),
+        **kwargs
+    ).first()
+
+
 def get_recent_articles_of_issue(issue_iid, is_public=True):
     """
     Retorna a lista de artigos de um issue/

--- a/opac/webapp/controllers.py
+++ b/opac/webapp/controllers.py
@@ -808,25 +808,21 @@ def get_article_by_aid(aid, journal_url_seg, lang=None, gs_abstract=False, **kwa
         raise ValueError(__('Obrigatório um aid.'))
 
     try:
-        article = Article.objects.get(pk=aid, **kwargs)
-    except Article.DoesNotExist as e:
-        raise ArticleNotFoundError(aid)
-    except Article.MultipleObjectsReturned as e:
-        article = Article.objects(aid=aid, **kwargs).first()
+        article = Article.objects.get(pk=aid, is_public=True, **kwargs)
+    except (Article.DoesNotExist, Article.MultipleObjectsReturned) as e:
+        article = Article.objects(
+            Q(scielo_pids__v3=aid) |
+            Q(scielo_pids__other__in=[aid]),
+            is_public=True,
+            **kwargs).first()
         if not article:
             raise ArticleNotFoundError(aid)
-
-    if not article.is_public:
-        raise ArticleIsNotPublishedError(article.unpublish_reason)
 
     if not article.issue.is_public:
         raise IssueIsNotPublishedError(article.issue.unpublish_reason)
 
     if not article.journal.is_public:
         raise JournalIsNotPublishedError(article.journal.unpublish_reason)
-
-    if not journal_url_seg:
-        raise ValueError(__('Obrigatório um journal_url_seg.'))
 
     if article.journal.url_segment != journal_url_seg:
         raise ArticleJournalNotFoundError(article.journal.url_segment)

--- a/opac/webapp/main/views.py
+++ b/opac/webapp/main/views.py
@@ -405,11 +405,14 @@ def router_legacy():
             # 'abstract' or None (not False, porque False converterá a string 'False')
             part = (script_php == 'sci_abstract' and 'abstract') or None
 
+            if tlng not in article.languages:
+                tlng = article.original_language
+
             return redirect(url_for('main.article_detail_v3',
                                     url_seg=article.journal.url_segment,
                                     article_pid_v3=article.aid,
                                     part=part,
-                                    lang=tlng or article.original_language),
+                                    lang=tlng),
                             code=301)
 
         elif script_php == 'sci_issues':

--- a/opac/webapp/main/views.py
+++ b/opac/webapp/main/views.py
@@ -1422,7 +1422,7 @@ def router_legacy_article(text_or_abstract):
         # se tem pid
         abort(400, _('Requsição inválida ao tentar acessar o artigo com pid: %s' % pid))
 
-    article = controllers.get_article_by_scielo_pid(pid, is_public=True)
+    article = controllers.get_article_by_pid_v1(pid)
     if not article:
         abort(404, _('Artigo não encontrado'))
 
@@ -1431,7 +1431,6 @@ def router_legacy_article(text_or_abstract):
             'main.article_detail_v3',
             url_seg=article.journal.url_segment,
             article_pid_v3=article.aid,
-            lang=lng
         ),
         code=301
     )

--- a/opac/webapp/main/views.py
+++ b/opac/webapp/main/views.py
@@ -398,13 +398,7 @@ def router_legacy():
             )
 
         elif script_php == 'sci_arttext' or script_php == 'sci_abstract':
-            if pid.startswith("s"):
-                pid = pid.upper()
-            article = controllers.get_article_by_scielo_pid(pid)
-
-            if not article:
-                article = controllers.get_article_by_oap_pid(pid)
-
+            article = controllers.get_article_by_pid_v2(pid)
             if not article:
                 abort(404, _('Artigo não encontrado'))
 
@@ -433,13 +427,7 @@ def router_legacy():
 
         elif script_php == 'sci_pdf':
             # accesso ao pdf do artigo:
-            if pid.startswith("s"):
-                pid = pid.upper()
-            article = controllers.get_article_by_scielo_pid(pid)
-
-            if not article:
-                article = controllers.get_article_by_oap_pid(pid)
-
+            article = controllers.get_article_by_pid_v2(pid)
             if not article:
                 abort(404, _('Artigo não encontrado'))
 


### PR DESCRIPTION
#### O que esse PR faz?
Recupera artigo usando também o campo `scielo_pids.other`, que pode conter qualquer tipo de pid.

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
Acessando uma página de artigo seja pelo pid v1, v2 ou v3 e que estes valores estejam no campo `scielo_pids.other` no lugar de estar em `pid`, `aop_pid`

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
n/a

#### Quais são tickets relevantes?
https://github.com/scieloorg/opac-airflow/issues/287

### Referências
```python
from mongoengine import connect
conn = connect(host="mongodb://127.0.0.1:27017/meu_opac")
from opac_schema.v1.models import (
    Journal,
    Issue,
    Article,
    Collection,
    News,
    Pages,
    PressRelease,
    Sponsor)
a = Article.objects(authors__in=["CASTRO, RODRIGO B."])
a = Article.objects(scielo_pids__v2__contains='S1')

scielo_pid = 'S0001-37652020000300725'
a = Article.objects(Q(pid=scielo_pid) | Q(scielo_pids__v1=scielo_pid) | Q(scielo_pids__other__in=scielo_pid)).first()
a.scielo_pids
{'v2': 'S0001-37652020000300725', 'v3': 'hYnMxt6qc7qsHQtZqMcgYmv'}
```
