### PR TITLE
Tk1950 - Compartilhamento.

### DIFF
--- a/opac/tests/test_interface_journal_home.py
+++ b/opac/tests/test_interface_journal_home.py
@@ -603,3 +603,30 @@ class JournalHomeTestCase(BaseTestCase):
 
                 for item, expected in zip(mission_tag.find_all("strong"), ["58", "42"]):
                     self.assertEqual(item.text.strip(), expected)
+
+    def test_journal_social_meta_tags(self):
+        """
+        Teste para verificar a página do periódico apresenta as tags de compartilhamento
+        com redes sociais.
+        """
+        journal = utils.makeOneJournal({'title': 'Social Meta tags'})
+
+        with self.client as c:
+            # Criando uma coleção para termos o objeto ``g`` na interface
+            utils.makeOneCollection()
+
+            header = {'Referer': url_for('main.journal_detail',
+                                         url_seg=journal.url_segment)}
+
+            response = c.get(
+                url_for('main.set_locale', lang_code='en'),
+                headers=header,
+                follow_redirects=True)
+
+            self.assertEqual(200, response.status_code)
+
+            self.assertIn('<meta property="og:url" content="http://0.0.0.0:8000/j/journal_acron/"/>', response.data.decode('utf-8'))
+            self.assertIn('<meta property="og:type" content="website"/>', response.data.decode('utf-8'))
+            self.assertIn('<meta property="og:title" content="Social Meta tags"/>', response.data.decode('utf-8'))
+            self.assertIn('<meta property="og:image" content="http://0.0.0.0:8000/None"/>', response.data.decode('utf-8'))
+            self.assertIn('<meta property="og:description" content="This journal is aiming xpto"/>', response.data.decode('utf-8'))

--- a/opac/tests/test_main_views.py
+++ b/opac/tests/test_main_views.py
@@ -48,7 +48,7 @@ class MainTestCase(BaseTestCase):
                 response = client.get(url_for('main.index'))
                 collection = g.get('collection')
                 self.assertEqual(0, collection.metrics.total_journal)
-            
+
 
             utils.makeOneJournal({'is_public': True, 'current_status': 'current'})
             utils.makeOneArticle({'is_public': True})
@@ -577,11 +577,11 @@ class MainTestCase(BaseTestCase):
                                                lang='ru'))
 
             self.assertRedirects(
-                response, 
+                response,
                 url_for(
                     'main.article_detail_v3',
-                    url_seg=journal.url_segment, 
-                    article_pid_v3=article.aid, 
+                    url_seg=journal.url_segment,
+                    article_pid_v3=article.aid,
                     format='html',
                 )
             )
@@ -1943,6 +1943,29 @@ class TestJournalGrid(BaseTestCase):
             response = self.client.get('/grid/{}'.format(journal.url_segment))
 
             self.assertStatus(response, 301)
+
+    def test_issue_grid_social_meta_tags(self):
+        """
+        Teste para verificar a página da grade do periódico apresenta as
+        tags de compartilhamento com redes sociais.
+        """
+
+        with current_app.app_context():
+
+            utils.makeOneCollection()
+
+            journal = utils.makeOneJournal({'title': 'Social Meta tags'})
+
+            response = self.client.get(
+                url_for('main.issue_grid', url_seg=journal.url_segment))
+
+            self.assertStatus(response, 200)
+            self.assertTemplateUsed('issue/grid.html')
+            self.assertIn('<meta property="og:url" content="http://0.0.0.0:8000/j/journal_acron/grid"/>', response.data.decode('utf-8'))
+            self.assertIn('<meta property="og:type" content="website"/>', response.data.decode('utf-8'))
+            self.assertIn('<meta property="og:title" content="Social Meta tags"/>', response.data.decode('utf-8'))
+            self.assertIn('<meta property="og:description" content="Esse periódico tem com objetivo xpto"/>', response.data.decode('utf-8'))
+            self.assertIn('<meta property="og:image" content="http://0.0.0.0:8000/None"/>', response.data.decode('utf-8'))
 
 
 class TestIssueToc(BaseTestCase):

--- a/opac/tests/test_main_views.py
+++ b/opac/tests/test_main_views.py
@@ -1961,11 +1961,11 @@ class TestJournalGrid(BaseTestCase):
 
             self.assertStatus(response, 200)
             self.assertTemplateUsed('issue/grid.html')
-            self.assertIn('<meta property="og:url" content="http://0.0.0.0:8000/j/journal_acron/grid"/>', response.data.decode('utf-8'))
-            self.assertIn('<meta property="og:type" content="website"/>', response.data.decode('utf-8'))
-            self.assertIn('<meta property="og:title" content="Social Meta tags"/>', response.data.decode('utf-8'))
-            self.assertIn('<meta property="og:description" content="Esse periódico tem com objetivo xpto"/>', response.data.decode('utf-8'))
-            self.assertIn('<meta property="og:image" content="http://0.0.0.0:8000/None"/>', response.data.decode('utf-8'))
+            self.assertIn('<meta property="og:url" content="http://0.0.0.0:8000/j/journal_acron/grid" />', response.data.decode('utf-8'))
+            self.assertIn('<meta property="og:type" content="website" />', response.data.decode('utf-8'))
+            self.assertIn('<meta property="og:title" content="Social Meta tags" />', response.data.decode('utf-8'))
+            self.assertIn('<meta property="og:description" content="Esse periódico tem com objetivo xpto" />', response.data.decode('utf-8'))
+            self.assertIn('<meta property="og:image" content="http://0.0.0.0:8000/None" />', response.data.decode('utf-8'))
 
 
 class TestIssueToc(BaseTestCase):
@@ -2138,6 +2138,36 @@ class TestIssueToc(BaseTestCase):
                     url_seg=journal.url_segment
                 ),
             )
+
+    def test_issue_toc_social_meta_tags(self):
+        """
+        Teste para verificar a página da TOC do periódico apresenta as
+        tags de compartilhamento com redes sociais.
+        """
+
+        with current_app.app_context():
+
+            utils.makeOneCollection()
+
+            journal = utils.makeOneJournal({'title': 'Social Meta tags'})
+
+            issue = utils.makeOneIssue({'number': '31',
+                                        'volume': '10',
+                                        'journal': journal})
+
+            response = self.client.get(url_for('main.issue_toc',
+                                       url_seg=journal.url_segment,
+                                       url_seg_issue=issue.url_segment))
+
+            self.assertStatus(response, 200)
+            self.assertTemplateUsed('issue/toc.html')
+
+            self.assertIn(
+                '<meta property="og:url" content="http://0.0.0.0:8000/j/journal_acron/i/2021.v10n31supplX/" />', response.data.decode('utf-8'))
+            self.assertIn('<meta property="og:type" content="website" />', response.data.decode('utf-8'))
+            self.assertIn('<meta property="og:title" content="Social Meta tags" />', response.data.decode('utf-8'))
+            self.assertIn('<meta property="og:description" content="Esse periódico tem com objetivo xpto" />', response.data.decode('utf-8'))
+            self.assertIn('<meta property="og:image" content="http://0.0.0.0:8000/None" />', response.data.decode('utf-8'))
 
 
 class TestAOPToc(BaseTestCase):
@@ -2426,3 +2456,41 @@ class TestArticleDetailV3Meta(BaseTestCase):
             self.assertEqual(
                 parse_qs(content_url.query), {'format': ['xml']}
             )
+
+    def test_article_detail_v3_social_meta_tags(self):
+        """
+        Teste para verificar a página do artigo apresenta as tags de compartilhamento
+        com redes sociais.
+        """
+
+        with current_app.test_request_context() as context:
+            utils.makeOneCollection({ 'acronym': "DUMMY_TEST2" })
+            journal = utils.makeOneJournal()
+            issue = utils.makeOneIssue({'journal': journal})
+            article = utils.makeOneArticle({
+                'title': 'Article Y',
+                'original_language': 'en',
+                'languages': ['es', 'pt', 'en'],
+                'issue': issue,
+                'journal': journal,
+                'url_segment': '10-11'
+            })
+
+            response = self.client.get(
+                url_for(
+                    'main.article_detail_v3',
+                    url_seg=journal.url_segment,
+                    article_pid_v3=article.aid,
+                )
+            )
+
+            self.assertStatus(response, 200)
+            content = response.data.decode('utf-8')
+
+            self.assertIn(
+                '<meta property="og:url" content="http://0.0.0.0:8000/j/journal_acron/a/%s/" />' % article.aid, response.data.decode('utf-8'))
+            self.assertIn('<meta property="og:type" content="article" />', response.data.decode('utf-8'))
+            self.assertIn('<meta property="og:title" content="%s" />' % article.title, response.data.decode('utf-8'))
+            self.assertIn('<meta property="og:description" content="%s" />' % article.abstract, response.data.decode('utf-8'))
+            self.assertIn('<meta property="og:image" content="http://0.0.0.0:8000/None" />', response.data.decode('utf-8'))
+

--- a/opac/webapp/templates/article/includes/meta.html
+++ b/opac/webapp/templates/article/includes/meta.html
@@ -1,8 +1,14 @@
+<!-- social share tags -->
+<meta property="og:url" content="{{ request.url }}" />
+<meta property="og:type" content="article" />
+<meta property="og:title" content="{{ article.title }}" />
+<meta property="og:description" content="{{ article.abstract|escape|truncate(100) }}" />
+<meta property="og:image" content="{{request.url_root}}{{ journal.logo_url|replace(" /", "" , 1) }}" />
+<!-- social share tags -->
 
 {% if journal.title -%}
     <meta name="citation_journal_title" content="{{ journal.title }}"></meta>
 {% endif -%}
-
 
 {% if journal.short_title -%}
     <meta name="citation_journal_abbrev" content="{{ journal.short_title }}"></meta>

--- a/opac/webapp/templates/base.html
+++ b/opac/webapp/templates/base.html
@@ -11,10 +11,9 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1.0">
+    <title>SciELO - {% block title %}{{ coll_macro.get_collection_name() }}{% endblock %}</title>
 
     {% block extra_meta %}{% endblock %}
-
-    <title>SciELO - {% block title %}{{ coll_macro.get_collection_name() }}{% endblock %}</title>
 
     <link rel="icon" href="{{ url_for('static', filename='img/favicon.ico') }}" />
     <link rel="stylesheet" href="{{ url_for('static', filename='css/scielo-bundle.css') }}?v={{ config.VCS_REF }}">

--- a/opac/webapp/templates/issue/base.html
+++ b/opac/webapp/templates/issue/base.html
@@ -6,7 +6,7 @@
 {% block extra_namespaces %}xmlns:mml="http://www.w3.org/1998/Math/MathML"{% endblock extra_namespaces %}
 
 {% block extra_meta %}
-{% include "journal/includes/meta.html" %}
+{% include "issue/includes/meta.html" %}
 {% endblock %}
 
 {% block body_class %}journal{% endblock %}

--- a/opac/webapp/templates/issue/base.html
+++ b/opac/webapp/templates/issue/base.html
@@ -5,8 +5,13 @@
 {% block ie9_extra_namespaces %}xmlns:mml="http://www.w3.org/1998/Math/MathML"{% endblock ie9_extra_namespaces %}
 {% block extra_namespaces %}xmlns:mml="http://www.w3.org/1998/Math/MathML"{% endblock extra_namespaces %}
 
+{% block extra_meta %}
+{% include "journal/includes/meta.html" %}
+{% endblock %}
+
 {% block body_class %}journal{% endblock %}
 {% block content %}
+
   {% include "journal/includes/header.html" %}
   <!-- alterar o levelmenu -->
   {% include "journal/includes/levelMenu.html" %}

--- a/opac/webapp/templates/issue/includes/meta.html
+++ b/opac/webapp/templates/issue/includes/meta.html
@@ -1,0 +1,8 @@
+    <!-- social share tags -->
+    <meta property="og:url" content="{{ request.url }}" />
+    <meta property="og:type" content="website" />
+    <meta property="og:title" content="{{ journal.title }}" />
+    <meta property="og:description" content="{{ journal.get_mission_by_lang(session.lang[:2])|safe|default(_(" Periódico sem
+        missão cadastrada"), true) }}" />
+    <meta property="og:image" content="{{request.url_root}}{{ journal.logo_url|replace(" /", "" , 1) }}" />
+    <!-- social share tags -->

--- a/opac/webapp/templates/journal/base.html
+++ b/opac/webapp/templates/journal/base.html
@@ -2,6 +2,10 @@
 
 {% block title %}{{ journal.title }}{% endblock %}
 
+{% block extra_meta %}
+{% include "journal/includes/meta.html" %}
+{% endblock %}
+
 {% block body_class %}journal{% endblock %}
 {% block content %}
   {% include "journal/includes/header.html" %}

--- a/opac/webapp/templates/journal/includes/meta.html
+++ b/opac/webapp/templates/journal/includes/meta.html
@@ -1,0 +1,7 @@
+    <!-- social share tags -->
+    <meta property="og:url" content="{{ request.url }}"/>
+    <meta property="og:type" content="website"/>
+    <meta property="og:title" content="{{ journal.title }}"/>
+    <meta property="og:description" content="{{ journal.get_mission_by_lang(session.lang[:2])|safe|default(_("Periódico sem missão cadastrada"), true) }}"/>
+    <meta property="og:image" content="{{request.url_root}}{{ journal.logo_url|replace("/", "", 1) }}"/>
+    <!-- social share tags -->


### PR DESCRIPTION
#### O que esse PR faz?

Adiciona no cabeçalho das páginas que contém compartilhamento tags "**Open Graph**" objetivando um compartilhamento mais elegante e aderente.

#### Onde a revisão poderia começar?

É possível testar esse PR olhando os commit e rodando os teste: ```export OPAC_CONFIG="config/templates/testing.template" && python opac/manager.py test```

#### Como este poderia ser testado manualmente?

Acessando a página do (periódico, fascículo ou artigo) e clicando no ícone de compartilhamento do facebook ou twitter.

#### Algum cenário de contexto que queira dar?

Não foi possível realizar testes de compartilhamento com o facebook e o twitter utilizando a novas tags já que a aplicação precisa que esteja com uma URL pública.

Sugiro que após aprovado esse PR possamos utilizar o ambiente de homologação para esse teste.

Ferramenta do facebook para teste:  https://developers.facebook.com/tools/debug/

#### Quais são tíquetes relevantes?

Esse PR resolve o tíquete #1950.

### Referências

Veja as referências para esse PR nos comentários do tíquete https://github.com/scieloorg/opac/issues/1950#issuecomment-873616415

