### PR TITLE
Tk1131 - Ajuste no badge do Plumx

### DIFF
--- a/opac/webapp/config/default.py
+++ b/opac/webapp/config/default.py
@@ -79,9 +79,10 @@ import os
         - OPAC_USE_DIMENSIONS:   ativa/desativa a integração com o Dimensions. Se sim, definir como 'True' (default: 'False')
         - OPAC_DIMENSIONS_METRICS_URL:   URL para o Dimensions (default: https://badge.dimensions.ai/details/doi)
         - OPAC_USE_PLUMX:    ativa/desativa a integração com o PlumX. Se sim, definir como 'True' (default: 'False')
-        - OPAC_PLUMX_METRICS_URL:   URL para o PlumX (default: https://plu.mx/scielo/a)
+        - OPAC_PLUMX_METRICS_URL:   URL para o PlumX (default: //cdn.plu.mx/widget-popup.js)
         - OPAC_USE_SCIENCEOPEN:  ativa/desativa a integração de métricas com o ScienceOpen. Se sim, definir como 'True' (default: 'False')
         - OPAC_USE_SCITE:  ativa/desativa a integração de métricas com _SCITE. Se sim, definir como 'True' (default: 'False')
+        - OPAC_SCITE_URL:  URL para o SCITE_ (default: https://cdn.scite.ai/badge/scite-badge-latest.min.js)
 
       - Timezone:
         - LOCAL_ZONE: Default 'America/Sao_Paulo'
@@ -363,7 +364,8 @@ DIMENSIONS_METRICS_URL = os.environ.get(
     'https://badge.dimensions.ai/details/doi'
 )
 USE_PLUMX = os.environ.get('OPAC_USE_PLUMX', 'False') == 'True'
-PLUMX_METRICS_URL = os.environ.get('OPAC_PLUMX_METRICS_URL', 'https://plu.mx/scielo/a')
+PLUMX_METRICS_URL = os.environ.get(
+    'OPAC_PLUMX_METRICS_URL', '//cdn.plu.mx/widget-popup.js')
 
 
 USE_ALTMETRIC = os.environ.get('OPAC_USE_ALTMETRIC', 'False') == 'True'
@@ -372,6 +374,8 @@ ALTMETRIC_METRICS_URL = os.environ.get('OPAC_ALTMETRIC_METRICS_URL', 'https://ww
 USE_SCIENCEOPEN = os.environ.get('OPAC_USE_SCIENCEOPEN', 'False') == 'True'
 
 USE_SCITE = os.environ.get('OPAC_USE_SCITE', 'False') == 'True'
+SCITE_URL = os.environ.get('OPAC_SCITE_URL',
+                           '//cdn.scite.ai/badge/scite-badge-latest.min.js')
 
 NEWS_LIST_LIMIT = 10
 

--- a/opac/webapp/main/views.py
+++ b/opac/webapp/main/views.py
@@ -104,6 +104,10 @@ def add_collection_to_g():
             # discutir o que fazer aqui
             setattr(g, 'collection', {})
 
+@main.after_request
+def add_header(response):
+    response.headers['x-content-type-options'] = 'nosniff'
+    return response
 
 @main.after_request
 def add_language_code(response):

--- a/opac/webapp/templates/article/base.html
+++ b/opac/webapp/templates/article/base.html
@@ -39,7 +39,10 @@
 
 {% block extra_js %}
   <script type="text/javascript" src="{{ url_for('static', filename='js/scielo-article-min.js') }}"></script>
-  <script type="text/javascript" src="//cdn.plu.mx/widget-popup.js"></script>
+
+  {% if config.USE_PLUMX %}
+    <script type="text/javascript" src="{{ config.PLUMX_METRICS_URL }}"></script>
+  {% endif %}
 
   {% if config.USE_ALTMETRIC %}
     <script type="text/javascript" src="https://d1bxh8uas1mnw7.cloudfront.net/assets/embed.js"></script>
@@ -51,7 +54,7 @@
   {% endif %}
 
   {% if config.USE_SCITE %}
-    <script async type="application/javascript" src="https://cdn.scite.ai/badge/scite-badge-latest.min.js"></script>
+    <script async type="application/javascript" src="{{ config.SCITE_URL}}"></script>
   {% endif %}
 
   {% if config.MATHJAX_CDN_URL %}

--- a/opac/webapp/templates/includes/metric_modal.html
+++ b/opac/webapp/templates/includes/metric_modal.html
@@ -39,13 +39,9 @@
                         <div class="badge-link col-center">
                             <div class="logo-statistc logo-statistc-plumx">
                                 <div class="badge-logo">
-                                    <a href="{{ config.PLUMX_METRICS_URL }}/?doi={{ article.doi }}"
-                                        data-popup="hidden"
-                                        data-size="large"
-                                        class="plumx-plum-print-popup"
-                                        data-site="scielo">
-                                        {{ article.title }}
-                                    </a>
+                                    <a href="{{ config.PLUMX_METRICS_URL }}/?doi={{ article.doi }}" data-popup="button"
+                                        data-size="large" class="plumx-plum-print-popup plum-liberty-theme"
+                                        data-site="plum" data-hide-when-empty="true" data-no-link="true" target="_blank">{{ article.title }}</a>
                                 </div>
                             </div>
                             <a target="_blank" href="{{ config.PLUMX_METRICS_URL }}/?doi={{ article.doi }}">


### PR DESCRIPTION
#### O que esse PR faz?

Realiza um ajuste de segurança para garantir que o badge do plumx funcione sem bloqueio de javascript de terceiros.

#### Onde a revisão poderia começar?

Olhando os commit e avaliando de forma visual a imagem do badge.

#### Como este poderia ser testado manualmente?


#### Algum cenário de contexto que queira dar?
Acessando o site e clicando no link de métricas no canto inferior esquerdo:

![Captura de Tela 2021-07-06 às 19 49 13](https://user-images.githubusercontent.com/86991526/124675565-44c12700-de93-11eb-97ca-56453f58dac4.png)

### Screenshots

![Captura de Tela 2021-07-06 às 23 38 56](https://user-images.githubusercontent.com/86991526/124696127-e3ad4980-deba-11eb-939b-e844b42c706f.png)


#### Quais são tickets relevantes?

#1131 

### Referências

Para resolução dessa atividade foi necessário estudar sobre os seguinte assunto nos diferentes links: 

**Content-Type**: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Content-Type-Options
**Nosniff:** https://fetch.spec.whatwg.org/#should-response-to-request-be-blocked-due-to-nosniff?
Google sobre o erro: **foi bloqueado devido ao tipo mime (“text/html”) não coincidir com (x-content-type-options: nosniff)**
