### PR TITLE
Simplifica consulta a artigos com base em período de datas

### DIFF
--- a/opac/webapp/controllers.py
+++ b/opac/webapp/controllers.py
@@ -1243,8 +1243,7 @@ def get_articles_by_date_range(begin_date, end_date, page=1, per_page=100):
     """
     Retorna artigos criados ou atualizados durante o período entre start_date e end_date.
     """
-    articles = Article.objects((Q(created__gte=begin_date) & Q(created__lte=end_date)) |
-                               (Q(updated__gte=begin_date) & Q(updated__lte=end_date))).order_by('pid')
+    articles = Article.objects(Q(updated__gte=begin_date) & Q(updated__lte=end_date)).order_by('pid')
     return Pagination(articles, page, per_page)
 
 


### PR DESCRIPTION
#### O que esse PR faz?
Otimiza método get_articles_by_date_range. A alteração consiste em remover da consulta o campo `create`. O campo `update` é mantido na consulta.

#### Onde a revisão poderia começar?
Por commit.

#### Como este poderia ser testado manualmente?
1. Ter instância do opac instalada
2. Acessar rota api/v1/counter_dict e verificar retorno de dicionário de dados

#### Algum cenário de contexto que queira dar?
A ideia do PR é melhorar o tempo de consulta à base mongodb.

### Screenshots
N/A

#### Quais são tickets relevantes?
#1988

### Referências
N/A