### PR TITLE
Não mostrar informação de que periódico não possui os índices h5 e m5…

### DIFF
--- a/opac/webapp/templates/journal/detail.html
+++ b/opac/webapp/templates/journal/detail.html
@@ -46,6 +46,7 @@
               {% if config.SCIMAGO_ENABLED and journal.scimago_id %}
               <li><a target="_blank" href="{{ config.SCIMAGO_URL }}{{ journal.scimago_id }}">Scimago</a>
               {% endif %}
+              {% if journal_metrics.total_h5_index and journal_metrics.h5_metric_year %}
               <li><a href="">Google Metrics</a>
                 <div>
                   <small>
@@ -71,6 +72,7 @@
                   </strong>
                 </div>
               </li>
+              {% endif %}
             </ul>
           </div>
           <div class="clearfix"></div>


### PR DESCRIPTION
#### O que esse PR faz?
Não mostrar informação de que periódico não possui os índices h5 e m5 do Google Scholar quando não há informação.

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
Acessando a página de um periódico que "não possui" dados do Google Scholar (ou seja, que não tem seu ISSN em https://github.com/scieloorg/scieloh5m5/blob/master/scieloh5m5/data/google_metrics_h5m5.csv)

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
n/a

#### Quais são tickets relevantes?
n/a

### Referências
n/a
