### PR TITLE
Adiciona a capacidade de ligar e desligar a faixa de métricas no site.

### DIFF
--- a/opac/webapp/config/default.py
+++ b/opac/webapp/config/default.py
@@ -24,6 +24,10 @@ import os
 
   Variavies de ambiente:
 
+      - Home Metrics:
+        - OPAC_USE_HOME_METRICS: ativa/desativa a apresentação dos dados de métricas da coleção (default: False),
+                                 o padrão é não apresentar
+
       - Modo Debug:
         - OPAC_DEBUG_MODE:      ativa/desativa o modo Debug da app, deve estar desativado em produção! (default: False)
 
@@ -31,7 +35,7 @@ import os
         - OPAC_SECRET_KEY:      chave necessária para segurança nos formulario da app.
 
       - Coleção:
-        - OPAC_COLLECTION: acrônimo da coleção do opac (default: 'spa')
+        - OPAC_COLLECTION: acrônimo da coleção do opac (default: 'scl')
 
       - Para envio de emails:
         - OPAC_DEFAULT_EMAIL:   conta de email para envio de mensagens desde o site (default: 'scielo@scielo.org')
@@ -202,10 +206,13 @@ MINIFY_PAGE = os.environ.get('OPAC_MINIFY_PAGE', 'False') == 'True'
 # não encontrada e correções no conteúdo da aplicacão.
 WEBMASTER_EMAIL = "webmaster@scielo.org"
 
+# ativa/desativa a apresentação dos dados de métricas da coleção (default: False),
+# o padrão é não apresentar
+USE_HOME_METRICS = os.environ.get('OPAC_USE_HOME_METRICS', False)
 
 # Acrônimo da coleção OPAC: 'spa' ou 'esp' por exemplo.
 # -*- DEVE SER AJUSTADO NA INSTALAÇÃO -*-
-OPAC_COLLECTION = os.environ.get('OPAC_COLLECTION', 'spa')
+OPAC_COLLECTION = os.environ.get('OPAC_COLLECTION', 'scl')
 
 
 # Conta de email padrão para emails enviado do site - deve ser um email válido

--- a/opac/webapp/main/views.py
+++ b/opac/webapp/main/views.py
@@ -96,6 +96,10 @@ def fetch_data(url: str, timeout: float = 2) -> bytes:
 
 @main.before_app_request
 def add_collection_to_g():
+
+    if not current_app.config['USE_HOME_METRICS']:
+        setattr(g, 'collection', {})
+
     if not hasattr(g, 'collection'):
         try:
             collection = controllers.get_current_collection()
@@ -103,6 +107,7 @@ def add_collection_to_g():
         except Exception:
             # discutir o que fazer aqui
             setattr(g, 'collection', {})
+
 
 @main.after_request
 def add_header(response):
@@ -202,6 +207,7 @@ def index():
         g.collection is not None
         and isinstance(g.collection, Collection)
         and g.collection.metrics is not None
+        and current_app.config['USE_HOME_METRICS']
     ):
         g.collection.metrics.total_journal = Journal.objects.filter(
             is_public=True, current_status="current"

--- a/opac/webapp/templates/collection/index.html
+++ b/opac/webapp/templates/collection/index.html
@@ -55,7 +55,14 @@
       {% endif %}
       <div class="row">
         <div class="col-md-12 col-sm-12 periodicals">
-          <h2>{% trans %}Lista de periódicos{% endtrans %}</h2>
+          <div class="row">
+            <div class="col-md-6">
+              <h2>{% trans %}Lista de periódicos{% endtrans %}</h2>
+            </div>
+            <div class="col-md-6 right">
+              <div class="datetime"><span id="date"></span></div>
+            </div>
+          </div>
           <div class="levelMenu">
             <ul>
               <li>

--- a/opac/webapp/templates/collection/index.html
+++ b/opac/webapp/templates/collection/index.html
@@ -60,7 +60,6 @@
               <h2>{% trans %}Lista de periódicos{% endtrans %}</h2>
             </div>
             <div class="col-md-6 right">
-              <div class="datetime"><span id="date"></span></div>
             </div>
           </div>
           <div class="levelMenu">


### PR DESCRIPTION
#### O que esse PR faz?

Adiciona a capacidade de ligar e desligar a faixa de métricas no site.

#### Onde a revisão poderia começar?

Por commit. 

#### Como este poderia ser testado manualmente?

Iniciando o site e visualizando que a faixa está desativada.

#### Algum cenário de contexto que queira dar?

A partir do momento que é desligado a exibição da faixa, não será mais consultado a tabela de coleção do site.

### Screenshots

![Captura de Tela 2021-08-11 às 16 48 18](https://user-images.githubusercontent.com/86991526/129093747-6b328db7-381c-437b-bcea-3b1904ab080f.png)


#### Quais são tickets relevantes?

#2007

### Referências
N/A

