### PR TITLE
correcao na geracao do scielo-bundle.css 

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -149,26 +149,29 @@ function processScieloBundleJs(){
 // Task para gerar o scielo-bundle-print.less
 function processScieloBundlePrintLess(){
     return src(target_src['less']['scielo-bundle-print'])
+    .pipe(sourceMaps.init({loadMaps: true}))
     .pipe(concat(output['css']['scielo-bundle-print']))
     .pipe(less(output['css']['scielo-bundle-print']))
     .pipe(minifyCSS())
+    .pipe(sourceMaps.write('./'))
     .pipe(dest(output['css']['folder']));
 }
 
 // Task para gerar o scielo-article-standalone.less
 function processScieloArticleStandaloneLess(){
     return src(target_src['less']['scielo-article-standalone'])
+    .pipe(sourceMaps.init({loadMaps: true}))
     .pipe(concat(output['css']['scielo-article-standalone']))
     .pipe(less(output['css']['scielo-article-standalone']))
     .pipe(minifyCSS())
+    .pipe(sourceMaps.write('./'))
     .pipe(dest(output['css']['folder']));
 }
 
 function processScieloBundleLess(){
     return src(target_src['less']['scielo-bundle'])
-    .pipe(
-        sourceMaps.init()
-    )
+    .pipe(sourceMaps.init({loadMaps: true}))
+    .pipe(concat(output['css']['scielo-bundle']))
     .pipe(
         less().on('error', function(err) {
             gutil.log(err);
@@ -180,6 +183,7 @@ function processScieloBundleLess(){
     .pipe(
         minifyCSS()
     )
+    .pipe(sourceMaps.write('./'))
     .pipe(
         dest(output['css']['folder'])
     )
@@ -190,9 +194,7 @@ function processScieloBundleLess(){
 
 function processScieloArticleLess(){
     return src(target_src['less']['scielo-article'])
-    .pipe(
-        sourceMaps.init()
-    )
+    .pipe(sourceMaps.init({loadMaps: true}))
     .pipe(
         less().on('error', function(err) {
             gutil.log(err);
@@ -204,6 +206,7 @@ function processScieloArticleLess(){
     .pipe(
         minifyCSS()
     )
+    .pipe(sourceMaps.write('./'))
     .pipe(
         dest(output['css']['folder'])
     )


### PR DESCRIPTION

#### O que esse PR faz?
corrige o arquivo gulpfile.js

Foi adicionado na função processScieloArticleLess o comando concat, que é reponsável por agrupar mais de um arquivo de entrada e transformar em um único arquivo de saída.

#### Onde a revisão poderia começar?
Na linha de comando, rode o comando "gulp"
Os arquivos .css e .css.map serão criados. Perceba que o arquivo scielo-bundle.css contém todas as classes que estão nos arquivos:
scielo-bundle.less
style.less
jquery.typeahead.less


#### Como este poderia ser testado manualmente?
Siga os passos citados acima e teste na aplicação.

#### Algum cenário de contexto que queira dar?
Não.

### Screenshots

Perceba o css do autocomplete. Está correto.
<img width="1235" alt="Screen Shot 2021-08-23 at 6 21 42 PM" src="https://user-images.githubusercontent.com/22373640/130521163-bbdcb2a2-f352-42f0-bfe7-4573def4daf3.png">

Perceba o resumo não é mais exibido:
<img width="1006" alt="Screen Shot 2021-08-23 at 6 22 00 PM" src="https://user-images.githubusercontent.com/22373640/130521231-74ed1e7e-a962-4e73-a940-631c5b00456e.png">



#### Quais são tickets relevantes?
#2031 

### Referências
-

