### PR TITLE
Imagem artigo - Preservação digital

### DIFF
--- a/opac/webapp/static/less/article.less
+++ b/opac/webapp/static/less/article.less
@@ -1610,6 +1610,39 @@
 			}
 		}
 
+		.thumbImg{
+			position: relative;
+			overflow: hidden;
+			box-sizing: border-box;
+			height: 140px;
+			border: 4px solid #e5e4e3;
+			border-radius: 3px;
+			background-color: #e5e4e3;
+			cursor: pointer;
+			
+			img{
+				width: 100%;
+				height: auto;
+				min-height: 131px; 
+				display: block;
+			}
+
+			.zoom{
+				position: absolute;
+				bottom: 10px;
+				right: 10px;
+				width: 30px;
+				height: 30px;
+				border-radius: 4px;
+				background-color: #6789d3;
+				padding: 5px;
+				display: inline-block;
+				font-size: 24px;
+				color: white;
+				line-height: 50%;
+			 }
+		}
+
 		.preview {
 			position: absolute;
 			border-radius: 3px;


### PR DESCRIPTION
Criação da classe thumbImg. A classe deve ser utilizada nas imagens dentro do artigo. Deve-se substituir thumb por thumbImg quando se necessita remover uma imagem de background e adicionar na própria tag img. 

No corpo do artigo, quando temos uma imagem em anexo, ela é exibida da seguinte maneira:

```
<div class="thumb" style="background-image: url(https://minio.scielo.br/documentstore/1678-2690/HvLdh4DtPD6YqV8WY3hNHPy/253016f9008b394cf453f197ff568fe31415fe6c.jpg);">
   Thumbnail
   <div class="zoom"><span class="sci-ico-zoom"></span></div>
</div>
```

Porém desta forma, não é possível ler / visualizar a imagem no que se diz respeito a preservação digital.
A solução para isso é remover a imagem do atributo css background-image e adicionar em uma tag img simples, padrão do html.
A solução consite em substituir no código acima a classe "thumb" pela nova classe "thumbImg". Logo após, podemos inserir a tag img dentro do div. Esta atualização mantém a aparência atual de visualização das imagens no corpo do artigo.

O novo código com o ajuste deve ficar assim:

```
<div class="thumbImg">
  <img src="https://minio.scielo.br/documentstore/1678-2690/HvLdh4DtPD6YqV8WY3hNHPy/253016f9008b394cf453f197ff568fe31415fe6c.jpg">
  <div class="zoom"><span class="sci-ico-zoom"></span></div>
</div>
```

Perceba que houve apenas a troca da classe "thumb" por "thumbImg" e foi adicionada a imagem no corpo do html. Desse modo, não há mais a necessidade de inclusão da imagem via background-image no style.


#### O que esse PR faz?
Resolve o problema de preservação digital no que diz respeito a visualização da imagens anexas ao artigo.

#### Onde a revisão poderia começar?
1 - Deve ser alterada a forma de criação do corpo do artigo. 
Quando houver uma imagem no corpo do artigo que necessite da preservação digital, substitua a classe "thumb" por "thumbImg" e adicione a tag <img src=""> com o respectivo caminho da imagem.

2 - Atualizar o sistema com o novo article.less
3 - Rodar o comando "gulp". Este comando é responsável por gerar os arquivos .css que farão a organização correta da informação em tela.
4 - Testar um artigo que contenha imagens em seu corpo. Se tudo ocorrer conforme o esperado, visualmente não será percebida mudança alguma. O comportamento de abertura do modal com a imagem deve permanecer exatamente igual. O ganho com esse ajuste é que agora passaremos a ter a tag <img src> exibindo a imagem direto em seu source.


#### Como este poderia ser testado manualmente?
Siga os passos já mencionados acima.

#### Algum cenário de contexto que queira dar?
Apenas rodar o gulp não vai surtir efeito.
É preciso seguir os passos já descritos no início desse PR.

### Screenshots

Antes:
![Screen Shot 2021-08-30 at 3 00 58 PM](https://user-images.githubusercontent.com/22373640/131383862-9d9b4f1a-a4fb-4755-bbfc-401a5f8e4839.png)


Depois:
![Screen Shot 2021-08-30 at 3 00 23 PM](https://user-images.githubusercontent.com/22373640/131383892-b6ab7396-68a9-4228-a54b-b2bff70f4bbe.png)


#### Quais são tickets relevantes?
Não tem ticket.

### Referências
-

