### PR TITLE
Disponibiliza o resumo no idioma correspondente em uma página de resumos para resumos proveniente de marcação HTML

### DIFF
--- a/opac/webapp/main/views.py
+++ b/opac/webapp/main/views.py
@@ -1077,10 +1077,21 @@ def render_html_from_html(article, lang):
     return html, text_languages
 
 
+def render_html_abstract(article, lang):
+    abstract_text = ''
+    for abstract in article.abstracts:
+        if abstract['language'] == lang:
+            abstract_text = abstract["text"]
+            break
+    return abstract_text, article.abstract_languages
+
+
 def render_html(article, lang, gs_abstract=False):
     if article.xml:
         return render_html_from_xml(article, lang, gs_abstract)
     elif article.htmls:
+        if gs_abstract:
+            return render_html_abstract(article, lang)
         return render_html_from_html(article, lang)
     else:
         # TODO: Corrigir os teste que esperam ter o atributo ``htmls``


### PR DESCRIPTION
#### O que esse PR faz?
Disponibiliza o resumo no idioma correspondente em uma página de resumos para resumos proveniente de marcação HTML

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
Acesse o sumário de um periódico ingressado como HTML
O campo `article.xml` não deve estar preenchido.
Acesse o resumo do documento ingressado como HTML.

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
<img width="1208" alt="Captura de Tela 2021-09-08 às 18 20 15" src="https://user-images.githubusercontent.com/505143/132587207-9b9d654f-ccd1-4151-84c2-6a5ea0e29c59.png">


#### Quais são tickets relevantes?
#2045

### Referências
n/a
