### PR TITLE
Adiciona um parametro de configuração para forçar o uso de https na formação das tags do google.

### DIFF
--- a/opac/manager.py
+++ b/opac/manager.py
@@ -228,7 +228,9 @@ def test(pattern=None, failfast=False):
     antes de executar este comando:
     > export OPAC_CONFIG="/foo/bar/config.testing" && python manager.py test
 
-    Utilize -p para rodar testes específicos, ex.: test_admin_*.'
+    Utilize -p para rodar testes específicos'
+
+    ex.: export OPAC_CONFIG="config/templates/testing.template" && python opac/manager.py test -p "test_main_views"
     """
     failfast = True if failfast else False
 

--- a/opac/tests/test_main_views.py
+++ b/opac/tests/test_main_views.py
@@ -2352,6 +2352,12 @@ class TestArticleDetailV3Meta(BaseTestCase):
         https://website/j/acron/a/pidv3/?format=pdf&amp;lang=idioma_selecionado
         `<meta name="citation_pdf_url"
           content="https://website/j/acron/a/pidv3/?format=pdf&amp;lang=idioma_selecionado"/>`
+
+        Verifica na view se o valor da variável FORCE_USE_HTTPS_GOOGLE_TAGS é True ou False,
+        no caso de True monta a URL para o PDF sempre com protocolo https, em caso de False
+        monta a URL com o ``scheme`` obtido pelo urlparsed.scheme.
+
+        FORCE_USE_HTTPS_GOOGLE_TAGS is False in testting.template
         """
 
         with current_app.test_request_context() as context:
@@ -2403,7 +2409,8 @@ class TestArticleDetailV3Meta(BaseTestCase):
 
             content_url = urlparse(meta_tags[0].get("content"))
             self.assertEqual(
-                "{}://{}/".format(content_url.scheme, content_url.netloc),
+                "{}://{}/".format(content_url.scheme,
+                                  content_url.netloc),
                 context.request.url_root
             )
             self.assertEqual(
@@ -2421,6 +2428,12 @@ class TestArticleDetailV3Meta(BaseTestCase):
         https://website/j/acron/a/pidv3/?format=xml
         `<meta name="citation_xml_url"
           content="https://website/j/acron/a/pidv3/?format=xml"/>`
+
+        Verifica na view se o valor da variável FORCE_USE_HTTPS_GOOGLE_TAGS é True ou False,
+        no caso de True monta a URL para o XML sempre com protocolo https, em caso de False
+        monta a URL com o ``scheme`` obtido pelo urlparsed.scheme.
+
+        FORCE_USE_HTTPS_GOOGLE_TAGS is False in testting.template
         """
 
         with current_app.test_request_context() as context:

--- a/opac/webapp/config/default.py
+++ b/opac/webapp/config/default.py
@@ -176,6 +176,10 @@ import os
       - ORCID:
         - OPAC_ORCID_URL: URL do ORCID. (default: http://orcid.org/)
 
+      - Google Meta tags (https://developers.google.com/search/docs/advanced/crawling/special-tags)
+        - OPAC_FORCE_USE_HTTPS_GOOGLE_TAGS: Força o uso de https nas URLs para do site do OPAC nas tags do google. (default: True)
+
+
 """
 
 PROJECT_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
@@ -562,3 +566,8 @@ ALERT_MSG_PT = os.environ.get("ALERT_MSG_PT", '')
 ALERT_MSG_EN = os.environ.get("ALERT_MSG_EN", '')
 ALERT_MSG_ES = os.environ.get("ALERT_MSG_ES", '')
 ALERT_MSG = bool(ALERT_MSG_PT or ALERT_MSG_EN or ALERT_MSG_ES)
+
+
+# Google Meta tags
+FORCE_USE_HTTPS_GOOGLE_TAGS = os.environ.get(
+    "OPAC_FORCE_USE_HTTPS_GOOGLE_TAGS", True)

--- a/opac/webapp/config/templates/testing.template
+++ b/opac/webapp/config/templates/testing.template
@@ -124,3 +124,12 @@ TWITTER_LIMIT = '10'
 
 # Server Name
 SERVER_NAME = os.environ.get('OPAC_SERVER_NAME', '0.0.0.0:8000')
+
+# Google Meta tags
+FORCE_USE_HTTPS_GOOGLE_TAGS = False
+
+# ativa/desativa a apresentação dos dados de métricas da coleção (default: False),
+# o padrão é não apresentar
+USE_HOME_METRICS = True
+
+

--- a/opac/webapp/main/views.py
+++ b/opac/webapp/main/views.py
@@ -1213,7 +1213,10 @@ def article_detail_v3(url_seg, article_pid_v3, part=None):
         website = request.url
         if website:
             parsed_url = urlparse(request.url)
-            website = "{}://{}".format(parsed_url.scheme, parsed_url.netloc)
+            if current_app.config["FORCE_USE_HTTPS_GOOGLE_TAGS"]:
+                website = "{}://{}".format('https', parsed_url.netloc)
+            else:
+                website = "{}://{}".format(parsed_url.scheme, parsed_url.netloc)
         if citation_pdf_url:
             citation_pdf_url = "{}{}".format(website, citation_pdf_url)
         try:


### PR DESCRIPTION
#### O que esse PR faz?

Adiciona um parâmetro de configuração para forçar o uso de **https** na formação das meta_tags do google.

Meta tags do google: https://developers.google.com/search/docs/advanced/crawling/special-tags

#### Onde a revisão poderia começar?

Por commit e rodando os testes.

#### Como este poderia ser testado manualmente?

É possível acessando a página de um artigo e verificando que a formação para URL do pdf e xml nos meta_tags: 

```
citation_pdf_url
e
citation_xml_url
```

Estão com https na formação da URL.

#### Algum cenário de contexto que queira dar?

Essa alteração foi realizada devido um comportamento não desejado em ambiente de produção do projeto, o trecho de código que utiliza o ``.scheme`` deveria pegar o protocolo correto sem a necessidade de forçamos o uso de **https**.

