### PR TITLE
Altera a forma do uso de threads no Gunicorn. 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.5-alpine
+FROM python:3.6-alpine
 ENV PYTHONUNBUFFERED 1
 
 # Build-time metadata as defined at http://label-schema.org

--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -1,4 +1,4 @@
-FROM python:3.5-alpine
+FROM python:3.6-alpine
 ENV PYTHONUNBUFFERED 1
 
 # Build-time metadata as defined at http://label-schema.org

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -30,7 +30,7 @@ services:
                 - OPAC_BUILD_DATE=${OPAC_BUILD_DATE}            # export OPAC_BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"`
                 - OPAC_VCS_REF=${OPAC_VCS_REF}                  # export OPAC_VCS_REF=`git rev-parse --short HEAD`
                 - OPAC_WEBAPP_VERSION=${OPAC_WEBAPP_VERSION}    # export OPAC_WEBAPP_VERSION="v0.1.0-dev"
-        command: gunicorn --workers 3 --bind 0.0.0.0:8000 manager:app --chdir=/app/opac --reload --timeout 1000 --log-level DEBUG
+        command: gunicorn --worker-class=gevent --worker-connections=1000 --workers 3 --bind 0.0.0.0:8000 manager:app --chdir=/app/opac --reload --timeout 1000 --log-level DEBUG
         user: nobody
         restart: always
         hostname: opac_webapp

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,8 @@ Flask-Security==3.0.0
 Flask-SQLAlchemy==2.3.2
 Flask-Testing==0.6.2
 Flask-WTF==0.14.2
-gunicorn==19.8.1
+gunicorn==20.1.0
+gevent==1.4.0
 htmlmin==0.1.12
 idna==2.10
 itsdangerous==1.1.0


### PR DESCRIPTION
#### O que esse PR faz?

* Alterar o comando do servidor de desenvolvimento para utilizar pseudo-threads.

* Atualiza a versão do Python 3.5 para Python 3.6, adiciona **gevent** como dependência e atualiza a versão do **Gunicorn**.

#### Onde a revisão poderia começar?
Rodando a aplicação em ambiente de desenvolvimento com ``docker-compose -f docker-compose-dev.yml build`` e ``docker-compose -f docker-compose-dev.yml up -d``

#### Como este poderia ser testado manualmente?

Acessando a aplicação e verificando se tem uma melhoria na velocidade de repostas das páginas.

#### Algum cenário de contexto que queira dar?
N/A

### Screenshots
N/A

#### Quais são tickets relevantes?
N/A

### Referências
N/A

