### PR TITLE
Adiciona uma verificação nas rotas legadas dos PDFs para garantir um 404 quando o periódico não existe.

### DIFF
--- a/opac/webapp/main/views.py
+++ b/opac/webapp/main/views.py
@@ -1428,7 +1428,7 @@ def router_legacy_pdf(journal_acron, issue_info, pdf_filename):
     journal = controllers.get_journal_by_url_seg(journal_acron)
 
     if not journal:
-        abort(404, _('Periódico não encontrado'))
+        abort(404, _('Este PDF não existe em http://www.scielo.br. Consulte http://search.scielo.org'))
 
     article = controllers.get_article_by_pdf_filename(
         journal_acron, issue_info, pdf_filename)

--- a/opac/webapp/main/views.py
+++ b/opac/webapp/main/views.py
@@ -1424,10 +1424,18 @@ def article_detail_pdf(url_seg, url_seg_issue, url_seg_article, lang_code=''):
 @cache.cached(key_prefix=cache_key_with_lang_with_qs)
 def router_legacy_pdf(journal_acron, issue_info, pdf_filename):
     pdf_filename = '%s.pdf' % pdf_filename
+
+    journal = controllers.get_journal_by_url_seg(journal_acron)
+
+    if not journal:
+        abort(404, _('Periódico não encontrado'))
+
     article = controllers.get_article_by_pdf_filename(
         journal_acron, issue_info, pdf_filename)
+
     if not article:
         abort(404, _('PDF do artigo não foi encontrado'))
+
     return redirect(
         url_for(
             'main.article_detail_v3',

--- a/opac/webapp/templates/errors/500.html
+++ b/opac/webapp/templates/errors/500.html
@@ -2,7 +2,7 @@
 
 {% block error_message %}
 
-  {% trans %}Erro interno do servidor. Tente novamente mais tarde. Nossos engenheiros foram notificados.{% endtrans %}
+  {% trans %}Erro interno do servidor. Tente novamente mais tarde.{% endtrans %}
 
   {% if g.sentry_event_id %}
     <p>

--- a/opac/webapp/translations/en/LC_MESSAGES/messages.po
+++ b/opac/webapp/translations/en/LC_MESSAGES/messages.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version:  OPAC\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2021-10-18 09:36-0300\n"
+"POT-Creation-Date: 2021-11-17 16:45+0000\n"
 "PO-Revision-Date: 2018-03-06 19:50+0000\n"
 "Last-Translator: jamil Atta <atta.jamil@gmail.com>\n"
 "Language: en\n"
@@ -935,7 +935,7 @@ msgstr "Authors"
 #: opac/webapp/templates/article/includes/levelMenu_abstracts.html:26
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:29
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:72
-#: opac/webapp/templates/issue/toc.html:161
+#: opac/webapp/templates/issue/toc.html:164
 msgid "Resumo"
 msgstr "Abstract"
 
@@ -1050,12 +1050,12 @@ msgstr "Latest journals added to the collection"
 msgid "10 últimos periódicos inseridos na coleção %s"
 msgstr "10 latest journals added to the collection %s"
 
-#: opac/webapp/main/views.py:347 opac/webapp/main/views.py:1650
+#: opac/webapp/main/views.py:347 opac/webapp/main/views.py:1658
 msgid "Página não encontrada"
 msgstr ""
 
 #: opac/webapp/main/views.py:372 opac/webapp/main/views.py:461
-#: opac/webapp/main/views.py:1449
+#: opac/webapp/main/views.py:1457
 #, python-format
 msgid "Requsição inválida ao tentar acessar o artigo com pid: %s"
 msgstr ""
@@ -1075,7 +1075,7 @@ msgstr "Issue not found"
 #: opac/webapp/main/views.py:416 opac/webapp/main/views.py:448
 #: opac/webapp/main/views.py:1038 opac/webapp/main/views.py:1138
 #: opac/webapp/main/views.py:1188 opac/webapp/main/views.py:1410
-#: opac/webapp/main/views.py:1453
+#: opac/webapp/main/views.py:1461
 msgid "Artigo não encontrado"
 msgstr "Article not found"
 
@@ -1173,11 +1173,17 @@ msgstr "Insufficient parameters to obtain article's EPDF"
 msgid "PDF não encontrado"
 msgstr ""
 
-#: opac/webapp/main/views.py:1430
+#: opac/webapp/main/views.py:1431
+msgid ""
+"Este PDF não existe em http://www.scielo.br. Consulte "
+"http://search.scielo.org/""
+msgstr "This PDF does not exist in https//www.scielo.br. See https://search.scielo.org"
+
+#: opac/webapp/main/views.py:1437
 msgid "PDF do artigo não foi encontrado"
 msgstr "Article's PDF not found"
 
-#: opac/webapp/main/views.py:1472 opac/webapp/main/views.py:1503
+#: opac/webapp/main/views.py:1480 opac/webapp/main/views.py:1511
 msgid "Requisição inválida."
 msgstr "Invalid request"
 
@@ -1471,7 +1477,7 @@ msgstr "Download PDF (Portuguese)"
 
 #: opac/webapp/templates/article/includes/levelMenu_texts.html:5
 #: opac/webapp/templates/article/includes/levelMenu_texts.html:27
-#: opac/webapp/templates/issue/toc.html:174
+#: opac/webapp/templates/issue/toc.html:177
 msgid "Texto"
 msgstr "Text"
 
@@ -1480,7 +1486,7 @@ msgid "Texto "
 msgstr ""
 
 #: opac/webapp/templates/article/includes/recent_articles_row.html:6
-#: opac/webapp/templates/issue/toc.html:141
+#: opac/webapp/templates/issue/toc.html:144
 msgid "Documento sem título"
 msgstr "Untitled document"
 
@@ -1893,10 +1899,8 @@ msgstr ""
 "please check it and try again."
 
 #: opac/webapp/templates/errors/500.html:5
-msgid ""
-"Erro interno do servidor. Tente novamente mais tarde."
-msgstr ""
-"Internal server error. Please try again later."
+msgid "Erro interno do servidor. Tente novamente mais tarde."
+msgstr "Internal server error. Please try again later."
 
 #: opac/webapp/templates/errors/500.html:9
 msgid "Id. do erro"
@@ -2047,20 +2051,20 @@ msgstr "Newest first"
 msgid "Mais antigos primeiro"
 msgstr "Oldest first"
 
-#: opac/webapp/templates/issue/toc.html:105
-#: opac/webapp/templates/issue/toc.html:107
+#: opac/webapp/templates/issue/toc.html:106
+#: opac/webapp/templates/issue/toc.html:108
 msgid "Todas as seções"
 msgstr "All the sections"
 
-#: opac/webapp/templates/issue/toc.html:185
+#: opac/webapp/templates/issue/toc.html:188
 msgid "PDF"
 msgstr ""
 
-#: opac/webapp/templates/issue/toc.html:196
+#: opac/webapp/templates/issue/toc.html:199
 msgid "ePDF"
 msgstr ""
 
-#: opac/webapp/templates/issue/toc.html:211
+#: opac/webapp/templates/issue/toc.html:214
 msgid "Resumo em"
 msgstr "Abstract in"
 

--- a/opac/webapp/translations/en/LC_MESSAGES/messages.po
+++ b/opac/webapp/translations/en/LC_MESSAGES/messages.po
@@ -1894,11 +1894,9 @@ msgstr ""
 
 #: opac/webapp/templates/errors/500.html:5
 msgid ""
-"Erro interno do servidor. Tente novamente mais tarde. Nossos engenheiros "
-"foram notificados."
+"Erro interno do servidor. Tente novamente mais tarde."
 msgstr ""
-"Internal server error. Please try again later. Our technical staff has "
-"been notified."
+"Internal server error. Please try again later."
 
 #: opac/webapp/templates/errors/500.html:9
 msgid "Id. do erro"

--- a/opac/webapp/translations/es/LC_MESSAGES/messages.po
+++ b/opac/webapp/translations/es/LC_MESSAGES/messages.po
@@ -1896,11 +1896,9 @@ msgstr ""
 
 #: opac/webapp/templates/errors/500.html:5
 msgid ""
-"Erro interno do servidor. Tente novamente mais tarde. Nossos engenheiros "
-"foram notificados."
+"Erro interno do servidor. Tente novamente mais tarde."
 msgstr ""
-"Error interno del servidor. Intente nuevamente luego. Nuestros ingenieros"
-" fueron notificados."
+"Error interno del servidor. Intente nuevamente luego."
 
 #: opac/webapp/templates/errors/500.html:9
 msgid "Id. do erro"

--- a/opac/webapp/translations/es/LC_MESSAGES/messages.po
+++ b/opac/webapp/translations/es/LC_MESSAGES/messages.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version:  OPAC\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2021-10-18 09:36-0300\n"
+"POT-Creation-Date: 2021-11-17 16:48+0000\n"
 "PO-Revision-Date: 2018-03-07 00:47+0000\n"
 "Last-Translator: jamil Atta <atta.jamil@gmail.com>\n"
 "Language: es\n"
@@ -938,7 +938,7 @@ msgstr "Autores"
 #: opac/webapp/templates/article/includes/levelMenu_abstracts.html:26
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:29
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:72
-#: opac/webapp/templates/issue/toc.html:161
+#: opac/webapp/templates/issue/toc.html:164
 msgid "Resumo"
 msgstr "Resumen"
 
@@ -1051,12 +1051,12 @@ msgstr "Últimas revistas incluidas en la colección"
 msgid "10 últimos periódicos inseridos na coleção %s"
 msgstr "10 últimas revistas incluidas en la colección %s"
 
-#: opac/webapp/main/views.py:347 opac/webapp/main/views.py:1650
+#: opac/webapp/main/views.py:347 opac/webapp/main/views.py:1658
 msgid "Página não encontrada"
 msgstr "Página no encontrada"
 
 #: opac/webapp/main/views.py:372 opac/webapp/main/views.py:461
-#: opac/webapp/main/views.py:1449
+#: opac/webapp/main/views.py:1457
 #, python-format
 msgid "Requsição inválida ao tentar acessar o artigo com pid: %s"
 msgstr "Requiere no válida al intentar tener acceso al artículo con pid:% s"
@@ -1076,7 +1076,7 @@ msgstr "Fascículo no encontrado"
 #: opac/webapp/main/views.py:416 opac/webapp/main/views.py:448
 #: opac/webapp/main/views.py:1038 opac/webapp/main/views.py:1138
 #: opac/webapp/main/views.py:1188 opac/webapp/main/views.py:1410
-#: opac/webapp/main/views.py:1453
+#: opac/webapp/main/views.py:1461
 msgid "Artigo não encontrado"
 msgstr "Artículo no encontrado"
 
@@ -1174,11 +1174,17 @@ msgstr "Parámetros insuficientes para obtener el EPDF del artículo"
 msgid "PDF não encontrado"
 msgstr ""
 
-#: opac/webapp/main/views.py:1430
+#: opac/webapp/main/views.py:1431
+msgid ""
+"Este PDF não existe em http://www.scielo.br. Consulte "
+"http://search.scielo.org"
+msgstr "Este PDF no existe en http://www.scielo.br. Ver http://search.scielo.org"
+
+#: opac/webapp/main/views.py:1437
 msgid "PDF do artigo não foi encontrado"
 msgstr "PDF del artículo no encontrado"
 
-#: opac/webapp/main/views.py:1472 opac/webapp/main/views.py:1503
+#: opac/webapp/main/views.py:1480 opac/webapp/main/views.py:1511
 msgid "Requisição inválida."
 msgstr "Petición inválida."
 
@@ -1473,7 +1479,7 @@ msgstr ""
 
 #: opac/webapp/templates/article/includes/levelMenu_texts.html:5
 #: opac/webapp/templates/article/includes/levelMenu_texts.html:27
-#: opac/webapp/templates/issue/toc.html:174
+#: opac/webapp/templates/issue/toc.html:177
 msgid "Texto"
 msgstr "Texto"
 
@@ -1482,7 +1488,7 @@ msgid "Texto "
 msgstr ""
 
 #: opac/webapp/templates/article/includes/recent_articles_row.html:6
-#: opac/webapp/templates/issue/toc.html:141
+#: opac/webapp/templates/issue/toc.html:144
 msgid "Documento sem título"
 msgstr "Documento sin título"
 
@@ -1895,10 +1901,8 @@ msgstr ""
 "por favor, revise e intente nuevamente."
 
 #: opac/webapp/templates/errors/500.html:5
-msgid ""
-"Erro interno do servidor. Tente novamente mais tarde."
-msgstr ""
-"Error interno del servidor. Intente nuevamente luego."
+msgid "Erro interno do servidor. Tente novamente mais tarde."
+msgstr "Error interno del servidor. Intente nuevamente luego."
 
 #: opac/webapp/templates/errors/500.html:9
 msgid "Id. do erro"
@@ -2047,20 +2051,20 @@ msgstr ""
 msgid "Mais antigos primeiro"
 msgstr ""
 
-#: opac/webapp/templates/issue/toc.html:105
-#: opac/webapp/templates/issue/toc.html:107
+#: opac/webapp/templates/issue/toc.html:106
+#: opac/webapp/templates/issue/toc.html:108
 msgid "Todas as seções"
 msgstr "Todas las secciones"
 
-#: opac/webapp/templates/issue/toc.html:185
+#: opac/webapp/templates/issue/toc.html:188
 msgid "PDF"
 msgstr ""
 
-#: opac/webapp/templates/issue/toc.html:196
+#: opac/webapp/templates/issue/toc.html:199
 msgid "ePDF"
 msgstr ""
 
-#: opac/webapp/templates/issue/toc.html:211
+#: opac/webapp/templates/issue/toc.html:214
 msgid "Resumo em"
 msgstr "Resumen en"
 
@@ -2421,4 +2425,9 @@ msgstr "Ver"
 
 #~ msgid "Este documento contém correções"
 #~ msgstr "Este documento tiene una errata"
+
+#~ msgid ""
+#~ "Este PDF não existe em "
+#~ "http://www.scielo.br. Consulte http://search.scielo.org\""
+#~ msgstr ""
 

--- a/opac/webapp/translations/es_ES/LC_MESSAGES/messages.po
+++ b/opac/webapp/translations/es_ES/LC_MESSAGES/messages.po
@@ -1867,9 +1867,8 @@ msgstr ""
 
 #: opac/webapp/templates/errors/500.html:5
 msgid ""
-"Erro interno do servidor. Tente novamente mais tarde. Nossos engenheiros "
-"foram notificados."
-msgstr ""
+"Erro interno do servidor. Tente novamente mais tarde."
+msgstr "Error interno del servidor. Intente nuevamente luego."
 
 #: opac/webapp/templates/errors/500.html:9
 msgid "Id. do erro"

--- a/opac/webapp/translations/es_ES/LC_MESSAGES/messages.po
+++ b/opac/webapp/translations/es_ES/LC_MESSAGES/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2021-10-18 09:36-0300\n"
+"POT-Creation-Date: 2021-11-17 16:48+0000\n"
 "PO-Revision-Date: 2016-02-09 09:39-0600\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es_ES\n"
@@ -924,7 +924,7 @@ msgstr ""
 #: opac/webapp/templates/article/includes/levelMenu_abstracts.html:26
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:29
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:72
-#: opac/webapp/templates/issue/toc.html:161
+#: opac/webapp/templates/issue/toc.html:164
 msgid "Resumo"
 msgstr ""
 
@@ -1035,12 +1035,12 @@ msgstr ""
 msgid "10 últimos periódicos inseridos na coleção %s"
 msgstr ""
 
-#: opac/webapp/main/views.py:347 opac/webapp/main/views.py:1650
+#: opac/webapp/main/views.py:347 opac/webapp/main/views.py:1658
 msgid "Página não encontrada"
 msgstr ""
 
 #: opac/webapp/main/views.py:372 opac/webapp/main/views.py:461
-#: opac/webapp/main/views.py:1449
+#: opac/webapp/main/views.py:1457
 #, python-format
 msgid "Requsição inválida ao tentar acessar o artigo com pid: %s"
 msgstr ""
@@ -1060,7 +1060,7 @@ msgstr ""
 #: opac/webapp/main/views.py:416 opac/webapp/main/views.py:448
 #: opac/webapp/main/views.py:1038 opac/webapp/main/views.py:1138
 #: opac/webapp/main/views.py:1188 opac/webapp/main/views.py:1410
-#: opac/webapp/main/views.py:1453
+#: opac/webapp/main/views.py:1461
 msgid "Artigo não encontrado"
 msgstr ""
 
@@ -1154,11 +1154,17 @@ msgstr ""
 msgid "PDF não encontrado"
 msgstr ""
 
-#: opac/webapp/main/views.py:1430
+#: opac/webapp/main/views.py:1431
+msgid ""
+"Este PDF não existe em http://www.scielo.br. Consulte "
+"http://search.scielo.org"
+msgstr "Este PDF no existe en http://www.scielo.br. Ver http://search.scielo.org"
+
+#: opac/webapp/main/views.py:1437
 msgid "PDF do artigo não foi encontrado"
 msgstr ""
 
-#: opac/webapp/main/views.py:1472 opac/webapp/main/views.py:1503
+#: opac/webapp/main/views.py:1480 opac/webapp/main/views.py:1511
 msgid "Requisição inválida."
 msgstr ""
 
@@ -1446,7 +1452,7 @@ msgstr ""
 
 #: opac/webapp/templates/article/includes/levelMenu_texts.html:5
 #: opac/webapp/templates/article/includes/levelMenu_texts.html:27
-#: opac/webapp/templates/issue/toc.html:174
+#: opac/webapp/templates/issue/toc.html:177
 msgid "Texto"
 msgstr ""
 
@@ -1455,7 +1461,7 @@ msgid "Texto "
 msgstr ""
 
 #: opac/webapp/templates/article/includes/recent_articles_row.html:6
-#: opac/webapp/templates/issue/toc.html:141
+#: opac/webapp/templates/issue/toc.html:144
 msgid "Documento sem título"
 msgstr ""
 
@@ -1866,8 +1872,7 @@ msgid ""
 msgstr ""
 
 #: opac/webapp/templates/errors/500.html:5
-msgid ""
-"Erro interno do servidor. Tente novamente mais tarde."
+msgid "Erro interno do servidor. Tente novamente mais tarde."
 msgstr "Error interno del servidor. Intente nuevamente luego."
 
 #: opac/webapp/templates/errors/500.html:9
@@ -2017,20 +2022,20 @@ msgstr ""
 msgid "Mais antigos primeiro"
 msgstr ""
 
-#: opac/webapp/templates/issue/toc.html:105
-#: opac/webapp/templates/issue/toc.html:107
+#: opac/webapp/templates/issue/toc.html:106
+#: opac/webapp/templates/issue/toc.html:108
 msgid "Todas as seções"
 msgstr ""
 
-#: opac/webapp/templates/issue/toc.html:185
+#: opac/webapp/templates/issue/toc.html:188
 msgid "PDF"
 msgstr ""
 
-#: opac/webapp/templates/issue/toc.html:196
+#: opac/webapp/templates/issue/toc.html:199
 msgid "ePDF"
 msgstr ""
 
-#: opac/webapp/templates/issue/toc.html:211
+#: opac/webapp/templates/issue/toc.html:214
 msgid "Resumo em"
 msgstr ""
 
@@ -2583,5 +2588,10 @@ msgstr ""
 #~ msgstr ""
 
 #~ msgid "Este documento contém correções"
+#~ msgstr ""
+
+#~ msgid ""
+#~ "Este PDF não existe em "
+#~ "http://www.scielo.br. Consulte http://search.scielo.org\""
 #~ msgstr ""
 

--- a/opac/webapp/translations/es_MX/LC_MESSAGES/messages.po
+++ b/opac/webapp/translations/es_MX/LC_MESSAGES/messages.po
@@ -1867,9 +1867,8 @@ msgstr ""
 
 #: opac/webapp/templates/errors/500.html:5
 msgid ""
-"Erro interno do servidor. Tente novamente mais tarde. Nossos engenheiros "
-"foram notificados."
-msgstr ""
+"Erro interno do servidor. Tente novamente mais tarde."
+msgstr "Error interno del servidor. Intente nuevamente luego."
 
 #: opac/webapp/templates/errors/500.html:9
 msgid "Id. do erro"

--- a/opac/webapp/translations/es_MX/LC_MESSAGES/messages.po
+++ b/opac/webapp/translations/es_MX/LC_MESSAGES/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2021-10-18 09:36-0300\n"
+"POT-Creation-Date: 2021-11-17 16:48+0000\n"
 "PO-Revision-Date: 2016-02-09 09:39-0600\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es_MX\n"
@@ -924,7 +924,7 @@ msgstr ""
 #: opac/webapp/templates/article/includes/levelMenu_abstracts.html:26
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:29
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:72
-#: opac/webapp/templates/issue/toc.html:161
+#: opac/webapp/templates/issue/toc.html:164
 msgid "Resumo"
 msgstr ""
 
@@ -1035,12 +1035,12 @@ msgstr ""
 msgid "10 últimos periódicos inseridos na coleção %s"
 msgstr ""
 
-#: opac/webapp/main/views.py:347 opac/webapp/main/views.py:1650
+#: opac/webapp/main/views.py:347 opac/webapp/main/views.py:1658
 msgid "Página não encontrada"
 msgstr ""
 
 #: opac/webapp/main/views.py:372 opac/webapp/main/views.py:461
-#: opac/webapp/main/views.py:1449
+#: opac/webapp/main/views.py:1457
 #, python-format
 msgid "Requsição inválida ao tentar acessar o artigo com pid: %s"
 msgstr ""
@@ -1060,7 +1060,7 @@ msgstr ""
 #: opac/webapp/main/views.py:416 opac/webapp/main/views.py:448
 #: opac/webapp/main/views.py:1038 opac/webapp/main/views.py:1138
 #: opac/webapp/main/views.py:1188 opac/webapp/main/views.py:1410
-#: opac/webapp/main/views.py:1453
+#: opac/webapp/main/views.py:1461
 msgid "Artigo não encontrado"
 msgstr ""
 
@@ -1154,11 +1154,17 @@ msgstr ""
 msgid "PDF não encontrado"
 msgstr ""
 
-#: opac/webapp/main/views.py:1430
+#: opac/webapp/main/views.py:1431
+msgid ""
+"Este PDF não existe em http://www.scielo.br. Consulte "
+"http://search.scielo.org"
+msgstr "Este PDF no existe en http://www.scielo.br. Ver http://search.scielo.org"
+
+#: opac/webapp/main/views.py:1437
 msgid "PDF do artigo não foi encontrado"
 msgstr ""
 
-#: opac/webapp/main/views.py:1472 opac/webapp/main/views.py:1503
+#: opac/webapp/main/views.py:1480 opac/webapp/main/views.py:1511
 msgid "Requisição inválida."
 msgstr ""
 
@@ -1446,7 +1452,7 @@ msgstr ""
 
 #: opac/webapp/templates/article/includes/levelMenu_texts.html:5
 #: opac/webapp/templates/article/includes/levelMenu_texts.html:27
-#: opac/webapp/templates/issue/toc.html:174
+#: opac/webapp/templates/issue/toc.html:177
 msgid "Texto"
 msgstr ""
 
@@ -1455,7 +1461,7 @@ msgid "Texto "
 msgstr ""
 
 #: opac/webapp/templates/article/includes/recent_articles_row.html:6
-#: opac/webapp/templates/issue/toc.html:141
+#: opac/webapp/templates/issue/toc.html:144
 msgid "Documento sem título"
 msgstr ""
 
@@ -1866,8 +1872,7 @@ msgid ""
 msgstr ""
 
 #: opac/webapp/templates/errors/500.html:5
-msgid ""
-"Erro interno do servidor. Tente novamente mais tarde."
+msgid "Erro interno do servidor. Tente novamente mais tarde."
 msgstr "Error interno del servidor. Intente nuevamente luego."
 
 #: opac/webapp/templates/errors/500.html:9
@@ -2017,20 +2022,20 @@ msgstr ""
 msgid "Mais antigos primeiro"
 msgstr ""
 
-#: opac/webapp/templates/issue/toc.html:105
-#: opac/webapp/templates/issue/toc.html:107
+#: opac/webapp/templates/issue/toc.html:106
+#: opac/webapp/templates/issue/toc.html:108
 msgid "Todas as seções"
 msgstr ""
 
-#: opac/webapp/templates/issue/toc.html:185
+#: opac/webapp/templates/issue/toc.html:188
 msgid "PDF"
 msgstr ""
 
-#: opac/webapp/templates/issue/toc.html:196
+#: opac/webapp/templates/issue/toc.html:199
 msgid "ePDF"
 msgstr ""
 
-#: opac/webapp/templates/issue/toc.html:211
+#: opac/webapp/templates/issue/toc.html:214
 msgid "Resumo em"
 msgstr ""
 
@@ -2583,5 +2588,10 @@ msgstr ""
 #~ msgstr ""
 
 #~ msgid "Este documento contém correções"
+#~ msgstr ""
+
+#~ msgid ""
+#~ "Este PDF não existe em "
+#~ "http://www.scielo.br. Consulte http://search.scielo.org\""
 #~ msgstr ""
 

--- a/opac/webapp/translations/messages.pot
+++ b/opac/webapp/translations/messages.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2021-10-18 09:36-0300\n"
+"POT-Creation-Date: 2021-11-17 16:48+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -922,7 +922,7 @@ msgstr ""
 #: opac/webapp/templates/article/includes/levelMenu_abstracts.html:26
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:29
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:72
-#: opac/webapp/templates/issue/toc.html:161
+#: opac/webapp/templates/issue/toc.html:164
 msgid "Resumo"
 msgstr ""
 
@@ -1033,12 +1033,12 @@ msgstr ""
 msgid "10 últimos periódicos inseridos na coleção %s"
 msgstr ""
 
-#: opac/webapp/main/views.py:347 opac/webapp/main/views.py:1650
+#: opac/webapp/main/views.py:347 opac/webapp/main/views.py:1658
 msgid "Página não encontrada"
 msgstr ""
 
 #: opac/webapp/main/views.py:372 opac/webapp/main/views.py:461
-#: opac/webapp/main/views.py:1449
+#: opac/webapp/main/views.py:1457
 #, python-format
 msgid "Requsição inválida ao tentar acessar o artigo com pid: %s"
 msgstr ""
@@ -1058,7 +1058,7 @@ msgstr ""
 #: opac/webapp/main/views.py:416 opac/webapp/main/views.py:448
 #: opac/webapp/main/views.py:1038 opac/webapp/main/views.py:1138
 #: opac/webapp/main/views.py:1188 opac/webapp/main/views.py:1410
-#: opac/webapp/main/views.py:1453
+#: opac/webapp/main/views.py:1461
 msgid "Artigo não encontrado"
 msgstr ""
 
@@ -1152,11 +1152,17 @@ msgstr ""
 msgid "PDF não encontrado"
 msgstr ""
 
-#: opac/webapp/main/views.py:1430
+#: opac/webapp/main/views.py:1431
+msgid ""
+"Este PDF não existe em http://www.scielo.br. Consulte "
+"http://search.scielo.org"
+msgstr ""
+
+#: opac/webapp/main/views.py:1437
 msgid "PDF do artigo não foi encontrado"
 msgstr ""
 
-#: opac/webapp/main/views.py:1472 opac/webapp/main/views.py:1503
+#: opac/webapp/main/views.py:1480 opac/webapp/main/views.py:1511
 msgid "Requisição inválida."
 msgstr ""
 
@@ -1444,7 +1450,7 @@ msgstr ""
 
 #: opac/webapp/templates/article/includes/levelMenu_texts.html:5
 #: opac/webapp/templates/article/includes/levelMenu_texts.html:27
-#: opac/webapp/templates/issue/toc.html:174
+#: opac/webapp/templates/issue/toc.html:177
 msgid "Texto"
 msgstr ""
 
@@ -1453,7 +1459,7 @@ msgid "Texto "
 msgstr ""
 
 #: opac/webapp/templates/article/includes/recent_articles_row.html:6
-#: opac/webapp/templates/issue/toc.html:141
+#: opac/webapp/templates/issue/toc.html:144
 msgid "Documento sem título"
 msgstr ""
 
@@ -1864,9 +1870,7 @@ msgid ""
 msgstr ""
 
 #: opac/webapp/templates/errors/500.html:5
-msgid ""
-"Erro interno do servidor. Tente novamente mais tarde. Nossos engenheiros "
-"foram notificados."
+msgid "Erro interno do servidor. Tente novamente mais tarde."
 msgstr ""
 
 #: opac/webapp/templates/errors/500.html:9
@@ -2016,20 +2020,20 @@ msgstr ""
 msgid "Mais antigos primeiro"
 msgstr ""
 
-#: opac/webapp/templates/issue/toc.html:105
-#: opac/webapp/templates/issue/toc.html:107
+#: opac/webapp/templates/issue/toc.html:106
+#: opac/webapp/templates/issue/toc.html:108
 msgid "Todas as seções"
 msgstr ""
 
-#: opac/webapp/templates/issue/toc.html:185
+#: opac/webapp/templates/issue/toc.html:188
 msgid "PDF"
 msgstr ""
 
-#: opac/webapp/templates/issue/toc.html:196
+#: opac/webapp/templates/issue/toc.html:199
 msgid "ePDF"
 msgstr ""
 
-#: opac/webapp/templates/issue/toc.html:211
+#: opac/webapp/templates/issue/toc.html:214
 msgid "Resumo em"
 msgstr ""
 

--- a/opac/webapp/translations/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/opac/webapp/translations/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2021-10-18 09:36-0300\n"
+"POT-Creation-Date: 2021-11-17 16:48+0000\n"
 "PO-Revision-Date: 2021-10-18 09:36-0300\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: pt_BR\n"
@@ -923,7 +923,7 @@ msgstr ""
 #: opac/webapp/templates/article/includes/levelMenu_abstracts.html:26
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:29
 #: opac/webapp/templates/collection/includes/levelMenu_search.html:72
-#: opac/webapp/templates/issue/toc.html:161
+#: opac/webapp/templates/issue/toc.html:164
 msgid "Resumo"
 msgstr ""
 
@@ -1034,12 +1034,12 @@ msgstr ""
 msgid "10 últimos periódicos inseridos na coleção %s"
 msgstr ""
 
-#: opac/webapp/main/views.py:347 opac/webapp/main/views.py:1650
+#: opac/webapp/main/views.py:347 opac/webapp/main/views.py:1658
 msgid "Página não encontrada"
 msgstr ""
 
 #: opac/webapp/main/views.py:372 opac/webapp/main/views.py:461
-#: opac/webapp/main/views.py:1449
+#: opac/webapp/main/views.py:1457
 #, python-format
 msgid "Requsição inválida ao tentar acessar o artigo com pid: %s"
 msgstr ""
@@ -1059,7 +1059,7 @@ msgstr ""
 #: opac/webapp/main/views.py:416 opac/webapp/main/views.py:448
 #: opac/webapp/main/views.py:1038 opac/webapp/main/views.py:1138
 #: opac/webapp/main/views.py:1188 opac/webapp/main/views.py:1410
-#: opac/webapp/main/views.py:1453
+#: opac/webapp/main/views.py:1461
 msgid "Artigo não encontrado"
 msgstr ""
 
@@ -1153,11 +1153,17 @@ msgstr ""
 msgid "PDF não encontrado"
 msgstr ""
 
-#: opac/webapp/main/views.py:1430
+#: opac/webapp/main/views.py:1431
+msgid ""
+"Este PDF não existe em http://www.scielo.br. Consulte "
+"http://search.scielo.org"
+msgstr ""
+
+#: opac/webapp/main/views.py:1437
 msgid "PDF do artigo não foi encontrado"
 msgstr ""
 
-#: opac/webapp/main/views.py:1472 opac/webapp/main/views.py:1503
+#: opac/webapp/main/views.py:1480 opac/webapp/main/views.py:1511
 msgid "Requisição inválida."
 msgstr ""
 
@@ -1445,7 +1451,7 @@ msgstr ""
 
 #: opac/webapp/templates/article/includes/levelMenu_texts.html:5
 #: opac/webapp/templates/article/includes/levelMenu_texts.html:27
-#: opac/webapp/templates/issue/toc.html:174
+#: opac/webapp/templates/issue/toc.html:177
 msgid "Texto"
 msgstr ""
 
@@ -1454,7 +1460,7 @@ msgid "Texto "
 msgstr ""
 
 #: opac/webapp/templates/article/includes/recent_articles_row.html:6
-#: opac/webapp/templates/issue/toc.html:141
+#: opac/webapp/templates/issue/toc.html:144
 msgid "Documento sem título"
 msgstr ""
 
@@ -1865,9 +1871,7 @@ msgid ""
 msgstr ""
 
 #: opac/webapp/templates/errors/500.html:5
-msgid ""
-"Erro interno do servidor. Tente novamente mais tarde. Nossos engenheiros "
-"foram notificados."
+msgid "Erro interno do servidor. Tente novamente mais tarde."
 msgstr ""
 
 #: opac/webapp/templates/errors/500.html:9
@@ -2017,20 +2021,20 @@ msgstr ""
 msgid "Mais antigos primeiro"
 msgstr ""
 
-#: opac/webapp/templates/issue/toc.html:105
-#: opac/webapp/templates/issue/toc.html:107
+#: opac/webapp/templates/issue/toc.html:106
+#: opac/webapp/templates/issue/toc.html:108
 msgid "Todas as seções"
 msgstr ""
 
-#: opac/webapp/templates/issue/toc.html:185
+#: opac/webapp/templates/issue/toc.html:188
 msgid "PDF"
 msgstr ""
 
-#: opac/webapp/templates/issue/toc.html:196
+#: opac/webapp/templates/issue/toc.html:199
 msgid "ePDF"
 msgstr ""
 
-#: opac/webapp/templates/issue/toc.html:211
+#: opac/webapp/templates/issue/toc.html:214
 msgid "Resumo em"
 msgstr ""
 
@@ -2224,4 +2228,15 @@ msgstr ""
 #: opac/webapp/templates/news/includes/issue_last_row.html:20
 msgid "Ver"
 msgstr ""
+
+#~ msgid ""
+#~ "Erro interno do servidor. Tente "
+#~ "novamente mais tarde. Nossos engenheiros "
+#~ "foram notificados."
+#~ msgstr ""
+
+#~ msgid ""
+#~ "Este PDF não existe em "
+#~ "http://www.scielo.br. Consulte http://search.scielo.org\""
+#~ msgstr ""
 


### PR DESCRIPTION

#### O que esse PR faz?
Adiciona uma verificação nas rotas legadas dos PDFs para garantir que não levante uma exceção ao tentar acessar um PDF em que não exista o periódico na coleção.

Esse PR também remove o texto "Nossos engenheiros foram notificados." dos erros com status code 500.

#### Onde a revisão poderia começar?
 No módulo: opac/webapp/main/views.py

#### Como este poderia ser testado manualmente?


Para teste manual é necessário algumas URL para PDFs com rotas legadas, segue: 

Rotas em que o periódico não exita: 

- /pdf/ijmorphol/v39n1/0717-9502-ijmorphol-39-01-70.pdf
- /pdf/rmie/v26n90/1405-6666-rmie-26-90-887.pdf
- /pdf/ride/v11n22/2007-7467-ride-11-22-e047.pdf 
- /pdf/orl/v81n3/0718-4816-orl-81-03-0397.pdf
- /pdf/eia/v17n34/2463-0950-eia-17-34-113.pdf

Rota onde o periódico exista e o PDF não:

- /pdf/aabc/v17n34/2463-0950-eia-17-34-113.pdf


#### Algum cenário de contexto que queira dar?

Para a URL onde o periódico não exista deve retorna a seguinte tela com status code 404:

![Captura de Tela 2021-11-17 às 07 21 01](https://user-images.githubusercontent.com/86991526/142182531-1ee89fbc-f588-4e85-a66d-0c5adf4d279f.png)

Para a URL onde o PDF não exista deve retorna a seguinte tela com status code 404:


![Captura de Tela 2021-11-17 às 07 21 50](https://user-images.githubusercontent.com/86991526/142182619-b127c9a4-74af-4a74-af3d-05d66f529a46.png)

**Esse ajuste é necessário visando evitar exceções desnecessárias.**

### Screenshots
N/A

#### Quais são tickets relevantes?
N/A

### Referências
N/A

