### PR TITLE
Garante que o parâmetro section_filter funcione somente quando a variável de confirguração FILTER_SECTION_ENABLE

### DIFF
--- a/opac/webapp/main/views.py
+++ b/opac/webapp/main/views.py
@@ -799,6 +799,7 @@ def issue_toc_legacy(url_seg, url_seg_issue):
 @main.route('/j/<string:url_seg>/i/<string:url_seg_issue>/')
 @cache.cached(key_prefix=cache_key_with_lang_with_qs)
 def issue_toc(url_seg, url_seg_issue):
+    section_filter = None
     goto = request.args.get("goto", None, type=str)
     if goto not in ("previous", "next"):
         goto = None
@@ -810,8 +811,9 @@ def issue_toc(url_seg, url_seg_issue):
     # idioma da sessão
     language = session.get('lang', get_locale())
 
-    # seção dos documentos, se selecionada
-    section_filter = request.args.get('section', '', type=str).upper()
+    if current_app.config["FILTER_SECTION_ENABLE"]:
+        # seção dos documentos, se selecionada
+        section_filter = request.args.get('section', '', type=str).upper()
 
     # obtém o issue
     issue = controllers.get_issue_by_url_seg(url_seg, url_seg_issue)
@@ -843,9 +845,10 @@ def issue_toc(url_seg, url_seg_issue):
         # obtém as seções dos documentos deste sumário
         sections = []
 
-    if section_filter != '':
-        # obtém somente os documentos da seção selecionada
-        articles = [a for a in articles if a.section.upper() == section_filter]
+    if current_app.config["FILTER_SECTION_ENABLE"]:
+        if section_filter != '':
+            # obtém somente os documentos da seção selecionada
+            articles = [a for a in articles if a.section.upper() == section_filter]
 
     # obtém PDF e TEXT de cada documento
     has_math_content = False

--- a/opac/webapp/main/views.py
+++ b/opac/webapp/main/views.py
@@ -845,10 +845,9 @@ def issue_toc(url_seg, url_seg_issue):
         # obtém as seções dos documentos deste sumário
         sections = []
 
-    if current_app.config["FILTER_SECTION_ENABLE"]:
-        if section_filter != '':
-            # obtém somente os documentos da seção selecionada
-            articles = [a for a in articles if a.section.upper() == section_filter]
+    if current_app.config["FILTER_SECTION_ENABLE"] and section_filter != '':
+        # obtém somente os documentos da seção selecionada
+        articles = [a for a in articles if a.section.upper() == section_filter]
 
     # obtém PDF e TEXT de cada documento
     has_math_content = False

--- a/opac/webapp/templates/issue/toc.html
+++ b/opac/webapp/templates/issue/toc.html
@@ -101,7 +101,7 @@
 
                         {% if sections %}
                           <li>
-                            <a href="{{this_page_url}}">
+                            <a href="{{this_page_url}}" rel="nofollow">
                               {% if section_filter|length == 0 %}
                                 {% trans %}Todas as seções{% endtrans %} <span style="color: #6789d3;">&laquo;</span>
                               {% else %}
@@ -114,7 +114,7 @@
                         {% for section in sections %}
                           {% if section %}
                             <li>
-                              <a href="{{this_page_url}}?section={{ section|upper }}">
+                              <a href="{{this_page_url}}?section={{ section|upper }}" rel="nofollow">
                                 {% if section_filter|upper == section|upper %}
                                   {{ section }} <span style="color: #6789d3;">&laquo;</span>
                                 {% else %}


### PR DESCRIPTION
#### O que esse PR faz?
Garante que o parâmetro section_filter funcione somente quando a variável de confirguração **FILTER_SECTION_ENABLE** esteva como True e adiciona o atributo **rel="nofollow"** nos links do section_filter.

#### Onde a revisão poderia começar?

Analisando o módulo: opac/webapp/main/views.py e opac/webapp/templates/issue/toc.html

#### Como este poderia ser testado manualmente?

Acessando a página do Table of Contents com um parâmetro no QueryString ?section=bla

Exemplo: http://localhot:8000/j/aabc/i/2021.v93n1/?section=bla


#### Algum cenário de contexto que queira dar?

Repare que esse parâmetro fica desativado caso a variável de ambiente **OPAC_FILTER_SECTION_ENABLE** esteja como False.

### Screenshots
N/A

#### Quais são tickets relevantes?

Tíquete relacionado: https://github.com/scieloorg/opac/issues/2139

### Referências
N/A

