### PR TITLE
Adiciona uma verificação de ausência do campo PDF. 

### DIFF
--- a/opac/webapp/templates/article/includes/modal/download.html
+++ b/opac/webapp/templates/article/includes/modal/download.html
@@ -9,30 +9,35 @@
       </div>
       <div class="modal-body">
         <div class="row modal-center">
-          <div class="{% if config['READCUBE_ENABLED'] %}col-md-6{% else %}col-md-12{%endif%}">
-            <span class="sci-ico-filePDF"></span>
-            <br/>
-            <strong>PDF</strong>
-            <ul class="md-list">
-            {% if article and article.pdfs %}
-              {% for pdf in article.pdfs  %}
-                <li>
-                  <a target='_blank' href="{{ url_for('.article_detail_v3', url_seg=article.journal.url_segment, article_pid_v3=article.aid, lang=pdf.lang, format='pdf') }}">
-                    {% if pdf.lang == 'es' %}
-                      {% trans %}Espanhol{% endtrans %}
-                    {% elif pdf.lang == 'en' %}
-                      {% trans %}Inglês{% endtrans %}
-                    {% elif pdf.lang == 'pt' %}
-                      {% trans %}Português{% endtrans %}
-                    {% else %}
-                      {{ pdf.lang }}
-                    {% endif %}
-                  </a>
-                </li>
-              {% endfor %}
-            {% endif %}
-            </ul>
-          </div>
+
+          {% if article.pdf %}
+            <div class="{% if config['READCUBE_ENABLED'] %}col-md-6{% else %}col-md-12{%endif%}">
+              <span class="sci-ico-filePDF"></span>
+              <br/>
+              <strong>PDF</strong>
+              <ul class="md-list">
+              {% if article and article.pdfs %}
+                {% for pdf in article.pdfs  %}
+                  <li>
+                    <a target='_blank' href="{{ url_for('.article_detail_v3', url_seg=article.journal.url_segment, article_pid_v3=article.aid, lang=pdf.lang, format='pdf') }}">
+                      {% if pdf.lang == 'es' %}
+                        {% trans %}Espanhol{% endtrans %}
+                      {% elif pdf.lang == 'en' %}
+                        {% trans %}Inglês{% endtrans %}
+                      {% elif pdf.lang == 'pt' %}
+                        {% trans %}Português{% endtrans %}
+                      {% else %}
+                        {{ pdf.lang }}
+                      {% endif %}
+                    </a>
+                  </li>
+                {% endfor %}
+              {% endif %}
+              </ul>
+            </div>
+          {% else %}
+            {% trans %}O periódico não forneceu este documento em formato PDF.{% endtrans%}
+          {% endif%}
           {% if config['READCUBE_ENABLED'] and article.doi and article.pid %}
             <div class="col-md-6">
               <span class="glyphBtn readcubeViewMid"></span>

--- a/opac/webapp/translations/en/LC_MESSAGES/messages.po
+++ b/opac/webapp/translations/en/LC_MESSAGES/messages.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version:  OPAC\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2021-11-17 16:45+0000\n"
+"POT-Creation-Date: 2021-11-25 12:08+0000\n"
 "PO-Revision-Date: 2018-03-06 19:50+0000\n"
 "Last-Translator: jamil Atta <atta.jamil@gmail.com>\n"
 "Language: en\n"
@@ -201,7 +201,7 @@ msgstr "Content temporarily unavailable"
 #: opac/webapp/templates/article/includes/levelMenu_abstracts.html:45
 #: opac/webapp/templates/article/includes/levelMenu_texts.html:33
 #: opac/webapp/templates/article/includes/levelMenu_texts.html:46
-#: opac/webapp/templates/article/includes/modal/download.html:26
+#: opac/webapp/templates/article/includes/modal/download.html:28
 msgid "Português"
 msgstr "Portuguese"
 
@@ -210,7 +210,7 @@ msgstr "Portuguese"
 #: opac/webapp/templates/article/includes/levelMenu_abstracts.html:43
 #: opac/webapp/templates/article/includes/levelMenu_texts.html:31
 #: opac/webapp/templates/article/includes/levelMenu_texts.html:44
-#: opac/webapp/templates/article/includes/modal/download.html:24
+#: opac/webapp/templates/article/includes/modal/download.html:26
 msgid "Inglês"
 msgstr "English"
 
@@ -219,7 +219,7 @@ msgstr "English"
 #: opac/webapp/templates/article/includes/levelMenu_abstracts.html:41
 #: opac/webapp/templates/article/includes/levelMenu_texts.html:29
 #: opac/webapp/templates/article/includes/levelMenu_texts.html:42
-#: opac/webapp/templates/article/includes/modal/download.html:22
+#: opac/webapp/templates/article/includes/modal/download.html:24
 msgid "Espanhol"
 msgstr "Spanish"
 
@@ -1050,12 +1050,12 @@ msgstr "Latest journals added to the collection"
 msgid "10 últimos periódicos inseridos na coleção %s"
 msgstr "10 latest journals added to the collection %s"
 
-#: opac/webapp/main/views.py:347 opac/webapp/main/views.py:1658
+#: opac/webapp/main/views.py:347 opac/webapp/main/views.py:1660
 msgid "Página não encontrada"
 msgstr ""
 
 #: opac/webapp/main/views.py:372 opac/webapp/main/views.py:461
-#: opac/webapp/main/views.py:1457
+#: opac/webapp/main/views.py:1459
 #, python-format
 msgid "Requsição inválida ao tentar acessar o artigo com pid: %s"
 msgstr ""
@@ -1067,15 +1067,15 @@ msgstr ""
 msgid "Periódico não encontrado"
 msgstr "Journal not found"
 
-#: opac/webapp/main/views.py:393 opac/webapp/main/views.py:819
-#: opac/webapp/main/views.py:987
+#: opac/webapp/main/views.py:393 opac/webapp/main/views.py:821
+#: opac/webapp/main/views.py:989
 msgid "Número não encontrado"
 msgstr "Issue not found"
 
 #: opac/webapp/main/views.py:416 opac/webapp/main/views.py:448
-#: opac/webapp/main/views.py:1038 opac/webapp/main/views.py:1138
-#: opac/webapp/main/views.py:1188 opac/webapp/main/views.py:1410
-#: opac/webapp/main/views.py:1461
+#: opac/webapp/main/views.py:1040 opac/webapp/main/views.py:1140
+#: opac/webapp/main/views.py:1190 opac/webapp/main/views.py:1412
+#: opac/webapp/main/views.py:1463
 msgid "Artigo não encontrado"
 msgstr "Article not found"
 
@@ -1119,71 +1119,71 @@ msgstr ""
 msgid "Requisição inválida, captcha inválido."
 msgstr ""
 
-#: opac/webapp/main/views.py:928 opac/webapp/main/views.py:949
+#: opac/webapp/main/views.py:930 opac/webapp/main/views.py:951
 msgid "Artigos ahead of print não encontrados"
 msgstr ""
 
-#: opac/webapp/main/views.py:1130 opac/webapp/main/views.py:1406
+#: opac/webapp/main/views.py:1132 opac/webapp/main/views.py:1408
 msgid "Issue não encontrado"
 msgstr "Issue not found"
 
-#: opac/webapp/main/views.py:1163
+#: opac/webapp/main/views.py:1165
 msgid "Não existe '{}'. No seu lugar use '{}'"
 msgstr ""
 
-#: opac/webapp/main/views.py:1184
+#: opac/webapp/main/views.py:1186
 msgid "Resumo inexistente"
 msgstr ""
 
-#: opac/webapp/main/views.py:1185
+#: opac/webapp/main/views.py:1187
 msgid "Artigo inexistente"
 msgstr ""
 
-#: opac/webapp/main/views.py:1200 opac/webapp/main/views.py:1364
+#: opac/webapp/main/views.py:1202 opac/webapp/main/views.py:1366
 msgid "Recurso não encontrado"
 msgstr ""
 
-#: opac/webapp/main/views.py:1236
+#: opac/webapp/main/views.py:1238
 msgid "HTML do Artigo não encontrado ou indisponível"
 msgstr "HTML of article not found or unavailable"
 
-#: opac/webapp/main/views.py:1238 opac/webapp/main/views.py:1348
-#: opac/webapp/main/views.py:1366
+#: opac/webapp/main/views.py:1240 opac/webapp/main/views.py:1350
+#: opac/webapp/main/views.py:1368
 msgid "Erro inesperado"
 msgstr ""
 
-#: opac/webapp/main/views.py:1284 opac/webapp/main/views.py:1288
-#: opac/webapp/main/views.py:1293
+#: opac/webapp/main/views.py:1286 opac/webapp/main/views.py:1290
+#: opac/webapp/main/views.py:1295
 msgid "PDF do Artigo não encontrado"
 msgstr "Article's PDF not found"
 
-#: opac/webapp/main/views.py:1297 opac/webapp/main/views.py:1385
+#: opac/webapp/main/views.py:1299 opac/webapp/main/views.py:1387
 msgid "Recurso do Artigo não encontrado. Caminho inválido!"
 msgstr "Article resource not found. Invalid path!"
 
-#: opac/webapp/main/views.py:1315
+#: opac/webapp/main/views.py:1317
 msgid "Formato não suportado"
 msgstr ""
 
-#: opac/webapp/main/views.py:1328
+#: opac/webapp/main/views.py:1330
 msgid "Parâmetros insuficientes para obter o EPDF do artigo"
 msgstr "Insufficient parameters to obtain article's EPDF"
 
-#: opac/webapp/main/views.py:1346
+#: opac/webapp/main/views.py:1348
 msgid "PDF não encontrado"
 msgstr ""
 
-#: opac/webapp/main/views.py:1431
+#: opac/webapp/main/views.py:1433
 msgid ""
 "Este PDF não existe em http://www.scielo.br. Consulte "
-"http://search.scielo.org/""
-msgstr "This PDF does not exist in https//www.scielo.br. See https://search.scielo.org"
+"http://search.scielo.org"
+msgstr ""
 
-#: opac/webapp/main/views.py:1437
+#: opac/webapp/main/views.py:1439
 msgid "PDF do artigo não foi encontrado"
 msgstr "Article's PDF not found"
 
-#: opac/webapp/main/views.py:1480 opac/webapp/main/views.py:1511
+#: opac/webapp/main/views.py:1482 opac/webapp/main/views.py:1513
 msgid "Requisição inválida."
 msgstr "Invalid request"
 
@@ -1529,6 +1529,10 @@ msgstr "Close"
 #: opac/webapp/templates/article/includes/modal/download.html:8
 msgid "Versão para download de PDF"
 msgstr "PDF version for download"
+
+#: opac/webapp/templates/article/includes/modal/download.html:39
+msgid "O periódico não forneceu este documento em formato PDF."
+msgstr "The journal did not provide this document in PDF format."
 
 #: opac/webapp/templates/article/includes/modal/translate_version.html:6
 msgid "Versões e tradução automática"
@@ -2408,4 +2412,11 @@ msgstr "Open"
 
 #~ msgid "Este documento contém correções"
 #~ msgstr "This document has an erratum"
+
+#~ msgid ""
+#~ "Este PDF não existe em "
+#~ "http://www.scielo.br. Consulte http://search.scielo.org/\""
+#~ msgstr ""
+#~ "This PDF does not exist in "
+#~ "https//www.scielo.br. See https://search.scielo.org"
 

--- a/opac/webapp/translations/es/LC_MESSAGES/messages.po
+++ b/opac/webapp/translations/es/LC_MESSAGES/messages.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version:  OPAC\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2021-11-17 16:48+0000\n"
+"POT-Creation-Date: 2021-11-25 12:08+0000\n"
 "PO-Revision-Date: 2018-03-07 00:47+0000\n"
 "Last-Translator: jamil Atta <atta.jamil@gmail.com>\n"
 "Language: es\n"
@@ -202,7 +202,7 @@ msgstr "Contenido indisponible temporalmente"
 #: opac/webapp/templates/article/includes/levelMenu_abstracts.html:45
 #: opac/webapp/templates/article/includes/levelMenu_texts.html:33
 #: opac/webapp/templates/article/includes/levelMenu_texts.html:46
-#: opac/webapp/templates/article/includes/modal/download.html:26
+#: opac/webapp/templates/article/includes/modal/download.html:28
 msgid "Português"
 msgstr "Portugués"
 
@@ -211,7 +211,7 @@ msgstr "Portugués"
 #: opac/webapp/templates/article/includes/levelMenu_abstracts.html:43
 #: opac/webapp/templates/article/includes/levelMenu_texts.html:31
 #: opac/webapp/templates/article/includes/levelMenu_texts.html:44
-#: opac/webapp/templates/article/includes/modal/download.html:24
+#: opac/webapp/templates/article/includes/modal/download.html:26
 msgid "Inglês"
 msgstr "Inglés"
 
@@ -220,7 +220,7 @@ msgstr "Inglés"
 #: opac/webapp/templates/article/includes/levelMenu_abstracts.html:41
 #: opac/webapp/templates/article/includes/levelMenu_texts.html:29
 #: opac/webapp/templates/article/includes/levelMenu_texts.html:42
-#: opac/webapp/templates/article/includes/modal/download.html:22
+#: opac/webapp/templates/article/includes/modal/download.html:24
 msgid "Espanhol"
 msgstr "Español"
 
@@ -1051,12 +1051,12 @@ msgstr "Últimas revistas incluidas en la colección"
 msgid "10 últimos periódicos inseridos na coleção %s"
 msgstr "10 últimas revistas incluidas en la colección %s"
 
-#: opac/webapp/main/views.py:347 opac/webapp/main/views.py:1658
+#: opac/webapp/main/views.py:347 opac/webapp/main/views.py:1660
 msgid "Página não encontrada"
 msgstr "Página no encontrada"
 
 #: opac/webapp/main/views.py:372 opac/webapp/main/views.py:461
-#: opac/webapp/main/views.py:1457
+#: opac/webapp/main/views.py:1459
 #, python-format
 msgid "Requsição inválida ao tentar acessar o artigo com pid: %s"
 msgstr "Requiere no válida al intentar tener acceso al artículo con pid:% s"
@@ -1068,15 +1068,15 @@ msgstr "Requiere no válida al intentar tener acceso al artículo con pid:% s"
 msgid "Periódico não encontrado"
 msgstr "Revista no encontrada"
 
-#: opac/webapp/main/views.py:393 opac/webapp/main/views.py:819
-#: opac/webapp/main/views.py:987
+#: opac/webapp/main/views.py:393 opac/webapp/main/views.py:821
+#: opac/webapp/main/views.py:989
 msgid "Número não encontrado"
 msgstr "Fascículo no encontrado"
 
 #: opac/webapp/main/views.py:416 opac/webapp/main/views.py:448
-#: opac/webapp/main/views.py:1038 opac/webapp/main/views.py:1138
-#: opac/webapp/main/views.py:1188 opac/webapp/main/views.py:1410
-#: opac/webapp/main/views.py:1461
+#: opac/webapp/main/views.py:1040 opac/webapp/main/views.py:1140
+#: opac/webapp/main/views.py:1190 opac/webapp/main/views.py:1412
+#: opac/webapp/main/views.py:1463
 msgid "Artigo não encontrado"
 msgstr "Artículo no encontrado"
 
@@ -1120,71 +1120,71 @@ msgstr "La revista no permite envío de correo electrónico"
 msgid "Requisição inválida, captcha inválido."
 msgstr "Solicitud no válida, captcha inválida."
 
-#: opac/webapp/main/views.py:928 opac/webapp/main/views.py:949
+#: opac/webapp/main/views.py:930 opac/webapp/main/views.py:951
 msgid "Artigos ahead of print não encontrados"
 msgstr ""
 
-#: opac/webapp/main/views.py:1130 opac/webapp/main/views.py:1406
+#: opac/webapp/main/views.py:1132 opac/webapp/main/views.py:1408
 msgid "Issue não encontrado"
 msgstr "Fascículo no encontrado"
 
-#: opac/webapp/main/views.py:1163
+#: opac/webapp/main/views.py:1165
 msgid "Não existe '{}'. No seu lugar use '{}'"
 msgstr ""
 
-#: opac/webapp/main/views.py:1184
+#: opac/webapp/main/views.py:1186
 msgid "Resumo inexistente"
 msgstr ""
 
-#: opac/webapp/main/views.py:1185
+#: opac/webapp/main/views.py:1187
 msgid "Artigo inexistente"
 msgstr ""
 
-#: opac/webapp/main/views.py:1200 opac/webapp/main/views.py:1364
+#: opac/webapp/main/views.py:1202 opac/webapp/main/views.py:1366
 msgid "Recurso não encontrado"
 msgstr ""
 
-#: opac/webapp/main/views.py:1236
+#: opac/webapp/main/views.py:1238
 msgid "HTML do Artigo não encontrado ou indisponível"
 msgstr ""
 
-#: opac/webapp/main/views.py:1238 opac/webapp/main/views.py:1348
-#: opac/webapp/main/views.py:1366
+#: opac/webapp/main/views.py:1240 opac/webapp/main/views.py:1350
+#: opac/webapp/main/views.py:1368
 msgid "Erro inesperado"
 msgstr ""
 
-#: opac/webapp/main/views.py:1284 opac/webapp/main/views.py:1288
-#: opac/webapp/main/views.py:1293
+#: opac/webapp/main/views.py:1286 opac/webapp/main/views.py:1290
+#: opac/webapp/main/views.py:1295
 msgid "PDF do Artigo não encontrado"
 msgstr "PDF del artículo no encontrado"
 
-#: opac/webapp/main/views.py:1297 opac/webapp/main/views.py:1385
+#: opac/webapp/main/views.py:1299 opac/webapp/main/views.py:1387
 msgid "Recurso do Artigo não encontrado. Caminho inválido!"
 msgstr "Recurso del Artículo no encontrado. Camino inválido!"
 
-#: opac/webapp/main/views.py:1315
+#: opac/webapp/main/views.py:1317
 msgid "Formato não suportado"
 msgstr ""
 
-#: opac/webapp/main/views.py:1328
+#: opac/webapp/main/views.py:1330
 msgid "Parâmetros insuficientes para obter o EPDF do artigo"
 msgstr "Parámetros insuficientes para obtener el EPDF del artículo"
 
-#: opac/webapp/main/views.py:1346
+#: opac/webapp/main/views.py:1348
 msgid "PDF não encontrado"
 msgstr ""
 
-#: opac/webapp/main/views.py:1431
+#: opac/webapp/main/views.py:1433
 msgid ""
 "Este PDF não existe em http://www.scielo.br. Consulte "
 "http://search.scielo.org"
 msgstr "Este PDF no existe en http://www.scielo.br. Ver http://search.scielo.org"
 
-#: opac/webapp/main/views.py:1437
+#: opac/webapp/main/views.py:1439
 msgid "PDF do artigo não foi encontrado"
 msgstr "PDF del artículo no encontrado"
 
-#: opac/webapp/main/views.py:1480 opac/webapp/main/views.py:1511
+#: opac/webapp/main/views.py:1482 opac/webapp/main/views.py:1513
 msgid "Requisição inválida."
 msgstr "Petición inválida."
 
@@ -1531,6 +1531,10 @@ msgstr "Cerrar"
 #: opac/webapp/templates/article/includes/modal/download.html:8
 msgid "Versão para download de PDF"
 msgstr "Versión para descarga de PDF"
+
+#: opac/webapp/templates/article/includes/modal/download.html:39
+msgid "O periódico não forneceu este documento em formato PDF."
+msgstr "La revista no proporcionó este documento en formato PDF."
 
 #: opac/webapp/templates/article/includes/modal/translate_version.html:6
 msgid "Versões e tradução automática"

--- a/opac/webapp/translations/es_ES/LC_MESSAGES/messages.po
+++ b/opac/webapp/translations/es_ES/LC_MESSAGES/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2021-11-17 16:48+0000\n"
+"POT-Creation-Date: 2021-11-25 12:08+0000\n"
 "PO-Revision-Date: 2016-02-09 09:39-0600\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es_ES\n"
@@ -197,7 +197,7 @@ msgstr ""
 #: opac/webapp/templates/article/includes/levelMenu_abstracts.html:45
 #: opac/webapp/templates/article/includes/levelMenu_texts.html:33
 #: opac/webapp/templates/article/includes/levelMenu_texts.html:46
-#: opac/webapp/templates/article/includes/modal/download.html:26
+#: opac/webapp/templates/article/includes/modal/download.html:28
 msgid "Português"
 msgstr ""
 
@@ -206,7 +206,7 @@ msgstr ""
 #: opac/webapp/templates/article/includes/levelMenu_abstracts.html:43
 #: opac/webapp/templates/article/includes/levelMenu_texts.html:31
 #: opac/webapp/templates/article/includes/levelMenu_texts.html:44
-#: opac/webapp/templates/article/includes/modal/download.html:24
+#: opac/webapp/templates/article/includes/modal/download.html:26
 msgid "Inglês"
 msgstr ""
 
@@ -215,7 +215,7 @@ msgstr ""
 #: opac/webapp/templates/article/includes/levelMenu_abstracts.html:41
 #: opac/webapp/templates/article/includes/levelMenu_texts.html:29
 #: opac/webapp/templates/article/includes/levelMenu_texts.html:42
-#: opac/webapp/templates/article/includes/modal/download.html:22
+#: opac/webapp/templates/article/includes/modal/download.html:24
 msgid "Espanhol"
 msgstr ""
 
@@ -1035,12 +1035,12 @@ msgstr ""
 msgid "10 últimos periódicos inseridos na coleção %s"
 msgstr ""
 
-#: opac/webapp/main/views.py:347 opac/webapp/main/views.py:1658
+#: opac/webapp/main/views.py:347 opac/webapp/main/views.py:1660
 msgid "Página não encontrada"
 msgstr ""
 
 #: opac/webapp/main/views.py:372 opac/webapp/main/views.py:461
-#: opac/webapp/main/views.py:1457
+#: opac/webapp/main/views.py:1459
 #, python-format
 msgid "Requsição inválida ao tentar acessar o artigo com pid: %s"
 msgstr ""
@@ -1052,15 +1052,15 @@ msgstr ""
 msgid "Periódico não encontrado"
 msgstr ""
 
-#: opac/webapp/main/views.py:393 opac/webapp/main/views.py:819
-#: opac/webapp/main/views.py:987
+#: opac/webapp/main/views.py:393 opac/webapp/main/views.py:821
+#: opac/webapp/main/views.py:989
 msgid "Número não encontrado"
 msgstr ""
 
 #: opac/webapp/main/views.py:416 opac/webapp/main/views.py:448
-#: opac/webapp/main/views.py:1038 opac/webapp/main/views.py:1138
-#: opac/webapp/main/views.py:1188 opac/webapp/main/views.py:1410
-#: opac/webapp/main/views.py:1461
+#: opac/webapp/main/views.py:1040 opac/webapp/main/views.py:1140
+#: opac/webapp/main/views.py:1190 opac/webapp/main/views.py:1412
+#: opac/webapp/main/views.py:1463
 msgid "Artigo não encontrado"
 msgstr ""
 
@@ -1100,71 +1100,71 @@ msgstr ""
 msgid "Requisição inválida, captcha inválido."
 msgstr ""
 
-#: opac/webapp/main/views.py:928 opac/webapp/main/views.py:949
+#: opac/webapp/main/views.py:930 opac/webapp/main/views.py:951
 msgid "Artigos ahead of print não encontrados"
 msgstr ""
 
-#: opac/webapp/main/views.py:1130 opac/webapp/main/views.py:1406
+#: opac/webapp/main/views.py:1132 opac/webapp/main/views.py:1408
 msgid "Issue não encontrado"
 msgstr ""
 
-#: opac/webapp/main/views.py:1163
+#: opac/webapp/main/views.py:1165
 msgid "Não existe '{}'. No seu lugar use '{}'"
 msgstr ""
 
-#: opac/webapp/main/views.py:1184
+#: opac/webapp/main/views.py:1186
 msgid "Resumo inexistente"
 msgstr ""
 
-#: opac/webapp/main/views.py:1185
+#: opac/webapp/main/views.py:1187
 msgid "Artigo inexistente"
 msgstr ""
 
-#: opac/webapp/main/views.py:1200 opac/webapp/main/views.py:1364
+#: opac/webapp/main/views.py:1202 opac/webapp/main/views.py:1366
 msgid "Recurso não encontrado"
 msgstr ""
 
-#: opac/webapp/main/views.py:1236
+#: opac/webapp/main/views.py:1238
 msgid "HTML do Artigo não encontrado ou indisponível"
 msgstr ""
 
-#: opac/webapp/main/views.py:1238 opac/webapp/main/views.py:1348
-#: opac/webapp/main/views.py:1366
+#: opac/webapp/main/views.py:1240 opac/webapp/main/views.py:1350
+#: opac/webapp/main/views.py:1368
 msgid "Erro inesperado"
 msgstr ""
 
-#: opac/webapp/main/views.py:1284 opac/webapp/main/views.py:1288
-#: opac/webapp/main/views.py:1293
+#: opac/webapp/main/views.py:1286 opac/webapp/main/views.py:1290
+#: opac/webapp/main/views.py:1295
 msgid "PDF do Artigo não encontrado"
 msgstr ""
 
-#: opac/webapp/main/views.py:1297 opac/webapp/main/views.py:1385
+#: opac/webapp/main/views.py:1299 opac/webapp/main/views.py:1387
 msgid "Recurso do Artigo não encontrado. Caminho inválido!"
 msgstr ""
 
-#: opac/webapp/main/views.py:1315
+#: opac/webapp/main/views.py:1317
 msgid "Formato não suportado"
 msgstr ""
 
-#: opac/webapp/main/views.py:1328
+#: opac/webapp/main/views.py:1330
 msgid "Parâmetros insuficientes para obter o EPDF do artigo"
 msgstr ""
 
-#: opac/webapp/main/views.py:1346
+#: opac/webapp/main/views.py:1348
 msgid "PDF não encontrado"
 msgstr ""
 
-#: opac/webapp/main/views.py:1431
+#: opac/webapp/main/views.py:1433
 msgid ""
 "Este PDF não existe em http://www.scielo.br. Consulte "
 "http://search.scielo.org"
 msgstr "Este PDF no existe en http://www.scielo.br. Ver http://search.scielo.org"
 
-#: opac/webapp/main/views.py:1437
+#: opac/webapp/main/views.py:1439
 msgid "PDF do artigo não foi encontrado"
 msgstr ""
 
-#: opac/webapp/main/views.py:1480 opac/webapp/main/views.py:1511
+#: opac/webapp/main/views.py:1482 opac/webapp/main/views.py:1513
 msgid "Requisição inválida."
 msgstr ""
 
@@ -1504,6 +1504,10 @@ msgstr ""
 #: opac/webapp/templates/article/includes/modal/download.html:8
 msgid "Versão para download de PDF"
 msgstr ""
+
+#: opac/webapp/templates/article/includes/modal/download.html:39
+msgid "O periódico não forneceu este documento em formato PDF."
+msgstr "La revista no proporcionó este documento en formato PDF."
 
 #: opac/webapp/templates/article/includes/modal/translate_version.html:6
 msgid "Versões e tradução automática"

--- a/opac/webapp/translations/es_MX/LC_MESSAGES/messages.po
+++ b/opac/webapp/translations/es_MX/LC_MESSAGES/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2021-11-17 16:48+0000\n"
+"POT-Creation-Date: 2021-11-25 12:08+0000\n"
 "PO-Revision-Date: 2016-02-09 09:39-0600\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es_MX\n"
@@ -197,7 +197,7 @@ msgstr ""
 #: opac/webapp/templates/article/includes/levelMenu_abstracts.html:45
 #: opac/webapp/templates/article/includes/levelMenu_texts.html:33
 #: opac/webapp/templates/article/includes/levelMenu_texts.html:46
-#: opac/webapp/templates/article/includes/modal/download.html:26
+#: opac/webapp/templates/article/includes/modal/download.html:28
 msgid "Português"
 msgstr ""
 
@@ -206,7 +206,7 @@ msgstr ""
 #: opac/webapp/templates/article/includes/levelMenu_abstracts.html:43
 #: opac/webapp/templates/article/includes/levelMenu_texts.html:31
 #: opac/webapp/templates/article/includes/levelMenu_texts.html:44
-#: opac/webapp/templates/article/includes/modal/download.html:24
+#: opac/webapp/templates/article/includes/modal/download.html:26
 msgid "Inglês"
 msgstr ""
 
@@ -215,7 +215,7 @@ msgstr ""
 #: opac/webapp/templates/article/includes/levelMenu_abstracts.html:41
 #: opac/webapp/templates/article/includes/levelMenu_texts.html:29
 #: opac/webapp/templates/article/includes/levelMenu_texts.html:42
-#: opac/webapp/templates/article/includes/modal/download.html:22
+#: opac/webapp/templates/article/includes/modal/download.html:24
 msgid "Espanhol"
 msgstr ""
 
@@ -1035,12 +1035,12 @@ msgstr ""
 msgid "10 últimos periódicos inseridos na coleção %s"
 msgstr ""
 
-#: opac/webapp/main/views.py:347 opac/webapp/main/views.py:1658
+#: opac/webapp/main/views.py:347 opac/webapp/main/views.py:1660
 msgid "Página não encontrada"
 msgstr ""
 
 #: opac/webapp/main/views.py:372 opac/webapp/main/views.py:461
-#: opac/webapp/main/views.py:1457
+#: opac/webapp/main/views.py:1459
 #, python-format
 msgid "Requsição inválida ao tentar acessar o artigo com pid: %s"
 msgstr ""
@@ -1052,15 +1052,15 @@ msgstr ""
 msgid "Periódico não encontrado"
 msgstr ""
 
-#: opac/webapp/main/views.py:393 opac/webapp/main/views.py:819
-#: opac/webapp/main/views.py:987
+#: opac/webapp/main/views.py:393 opac/webapp/main/views.py:821
+#: opac/webapp/main/views.py:989
 msgid "Número não encontrado"
 msgstr ""
 
 #: opac/webapp/main/views.py:416 opac/webapp/main/views.py:448
-#: opac/webapp/main/views.py:1038 opac/webapp/main/views.py:1138
-#: opac/webapp/main/views.py:1188 opac/webapp/main/views.py:1410
-#: opac/webapp/main/views.py:1461
+#: opac/webapp/main/views.py:1040 opac/webapp/main/views.py:1140
+#: opac/webapp/main/views.py:1190 opac/webapp/main/views.py:1412
+#: opac/webapp/main/views.py:1463
 msgid "Artigo não encontrado"
 msgstr ""
 
@@ -1100,71 +1100,71 @@ msgstr ""
 msgid "Requisição inválida, captcha inválido."
 msgstr ""
 
-#: opac/webapp/main/views.py:928 opac/webapp/main/views.py:949
+#: opac/webapp/main/views.py:930 opac/webapp/main/views.py:951
 msgid "Artigos ahead of print não encontrados"
 msgstr ""
 
-#: opac/webapp/main/views.py:1130 opac/webapp/main/views.py:1406
+#: opac/webapp/main/views.py:1132 opac/webapp/main/views.py:1408
 msgid "Issue não encontrado"
 msgstr ""
 
-#: opac/webapp/main/views.py:1163
+#: opac/webapp/main/views.py:1165
 msgid "Não existe '{}'. No seu lugar use '{}'"
 msgstr ""
 
-#: opac/webapp/main/views.py:1184
+#: opac/webapp/main/views.py:1186
 msgid "Resumo inexistente"
 msgstr ""
 
-#: opac/webapp/main/views.py:1185
+#: opac/webapp/main/views.py:1187
 msgid "Artigo inexistente"
 msgstr ""
 
-#: opac/webapp/main/views.py:1200 opac/webapp/main/views.py:1364
+#: opac/webapp/main/views.py:1202 opac/webapp/main/views.py:1366
 msgid "Recurso não encontrado"
 msgstr ""
 
-#: opac/webapp/main/views.py:1236
+#: opac/webapp/main/views.py:1238
 msgid "HTML do Artigo não encontrado ou indisponível"
 msgstr ""
 
-#: opac/webapp/main/views.py:1238 opac/webapp/main/views.py:1348
-#: opac/webapp/main/views.py:1366
+#: opac/webapp/main/views.py:1240 opac/webapp/main/views.py:1350
+#: opac/webapp/main/views.py:1368
 msgid "Erro inesperado"
 msgstr ""
 
-#: opac/webapp/main/views.py:1284 opac/webapp/main/views.py:1288
-#: opac/webapp/main/views.py:1293
+#: opac/webapp/main/views.py:1286 opac/webapp/main/views.py:1290
+#: opac/webapp/main/views.py:1295
 msgid "PDF do Artigo não encontrado"
 msgstr ""
 
-#: opac/webapp/main/views.py:1297 opac/webapp/main/views.py:1385
+#: opac/webapp/main/views.py:1299 opac/webapp/main/views.py:1387
 msgid "Recurso do Artigo não encontrado. Caminho inválido!"
 msgstr ""
 
-#: opac/webapp/main/views.py:1315
+#: opac/webapp/main/views.py:1317
 msgid "Formato não suportado"
 msgstr ""
 
-#: opac/webapp/main/views.py:1328
+#: opac/webapp/main/views.py:1330
 msgid "Parâmetros insuficientes para obter o EPDF do artigo"
 msgstr ""
 
-#: opac/webapp/main/views.py:1346
+#: opac/webapp/main/views.py:1348
 msgid "PDF não encontrado"
 msgstr ""
 
-#: opac/webapp/main/views.py:1431
+#: opac/webapp/main/views.py:1433
 msgid ""
 "Este PDF não existe em http://www.scielo.br. Consulte "
 "http://search.scielo.org"
 msgstr "Este PDF no existe en http://www.scielo.br. Ver http://search.scielo.org"
 
-#: opac/webapp/main/views.py:1437
+#: opac/webapp/main/views.py:1439
 msgid "PDF do artigo não foi encontrado"
 msgstr ""
 
-#: opac/webapp/main/views.py:1480 opac/webapp/main/views.py:1511
+#: opac/webapp/main/views.py:1482 opac/webapp/main/views.py:1513
 msgid "Requisição inválida."
 msgstr ""
 
@@ -1504,6 +1504,10 @@ msgstr ""
 #: opac/webapp/templates/article/includes/modal/download.html:8
 msgid "Versão para download de PDF"
 msgstr ""
+
+#: opac/webapp/templates/article/includes/modal/download.html:39
+msgid "O periódico não forneceu este documento em formato PDF."
+msgstr "La revista no proporcionó este documento en formato PDF."
 
 #: opac/webapp/templates/article/includes/modal/translate_version.html:6
 msgid "Versões e tradução automática"

--- a/opac/webapp/translations/messages.pot
+++ b/opac/webapp/translations/messages.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2021-11-17 16:48+0000\n"
+"POT-Creation-Date: 2021-11-25 12:08+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -195,7 +195,7 @@ msgstr ""
 #: opac/webapp/templates/article/includes/levelMenu_abstracts.html:45
 #: opac/webapp/templates/article/includes/levelMenu_texts.html:33
 #: opac/webapp/templates/article/includes/levelMenu_texts.html:46
-#: opac/webapp/templates/article/includes/modal/download.html:26
+#: opac/webapp/templates/article/includes/modal/download.html:28
 msgid "Português"
 msgstr ""
 
@@ -204,7 +204,7 @@ msgstr ""
 #: opac/webapp/templates/article/includes/levelMenu_abstracts.html:43
 #: opac/webapp/templates/article/includes/levelMenu_texts.html:31
 #: opac/webapp/templates/article/includes/levelMenu_texts.html:44
-#: opac/webapp/templates/article/includes/modal/download.html:24
+#: opac/webapp/templates/article/includes/modal/download.html:26
 msgid "Inglês"
 msgstr ""
 
@@ -213,7 +213,7 @@ msgstr ""
 #: opac/webapp/templates/article/includes/levelMenu_abstracts.html:41
 #: opac/webapp/templates/article/includes/levelMenu_texts.html:29
 #: opac/webapp/templates/article/includes/levelMenu_texts.html:42
-#: opac/webapp/templates/article/includes/modal/download.html:22
+#: opac/webapp/templates/article/includes/modal/download.html:24
 msgid "Espanhol"
 msgstr ""
 
@@ -1033,12 +1033,12 @@ msgstr ""
 msgid "10 últimos periódicos inseridos na coleção %s"
 msgstr ""
 
-#: opac/webapp/main/views.py:347 opac/webapp/main/views.py:1658
+#: opac/webapp/main/views.py:347 opac/webapp/main/views.py:1660
 msgid "Página não encontrada"
 msgstr ""
 
 #: opac/webapp/main/views.py:372 opac/webapp/main/views.py:461
-#: opac/webapp/main/views.py:1457
+#: opac/webapp/main/views.py:1459
 #, python-format
 msgid "Requsição inválida ao tentar acessar o artigo com pid: %s"
 msgstr ""
@@ -1050,15 +1050,15 @@ msgstr ""
 msgid "Periódico não encontrado"
 msgstr ""
 
-#: opac/webapp/main/views.py:393 opac/webapp/main/views.py:819
-#: opac/webapp/main/views.py:987
+#: opac/webapp/main/views.py:393 opac/webapp/main/views.py:821
+#: opac/webapp/main/views.py:989
 msgid "Número não encontrado"
 msgstr ""
 
 #: opac/webapp/main/views.py:416 opac/webapp/main/views.py:448
-#: opac/webapp/main/views.py:1038 opac/webapp/main/views.py:1138
-#: opac/webapp/main/views.py:1188 opac/webapp/main/views.py:1410
-#: opac/webapp/main/views.py:1461
+#: opac/webapp/main/views.py:1040 opac/webapp/main/views.py:1140
+#: opac/webapp/main/views.py:1190 opac/webapp/main/views.py:1412
+#: opac/webapp/main/views.py:1463
 msgid "Artigo não encontrado"
 msgstr ""
 
@@ -1098,71 +1098,71 @@ msgstr ""
 msgid "Requisição inválida, captcha inválido."
 msgstr ""
 
-#: opac/webapp/main/views.py:928 opac/webapp/main/views.py:949
+#: opac/webapp/main/views.py:930 opac/webapp/main/views.py:951
 msgid "Artigos ahead of print não encontrados"
 msgstr ""
 
-#: opac/webapp/main/views.py:1130 opac/webapp/main/views.py:1406
+#: opac/webapp/main/views.py:1132 opac/webapp/main/views.py:1408
 msgid "Issue não encontrado"
 msgstr ""
 
-#: opac/webapp/main/views.py:1163
+#: opac/webapp/main/views.py:1165
 msgid "Não existe '{}'. No seu lugar use '{}'"
 msgstr ""
 
-#: opac/webapp/main/views.py:1184
+#: opac/webapp/main/views.py:1186
 msgid "Resumo inexistente"
 msgstr ""
 
-#: opac/webapp/main/views.py:1185
+#: opac/webapp/main/views.py:1187
 msgid "Artigo inexistente"
 msgstr ""
 
-#: opac/webapp/main/views.py:1200 opac/webapp/main/views.py:1364
+#: opac/webapp/main/views.py:1202 opac/webapp/main/views.py:1366
 msgid "Recurso não encontrado"
 msgstr ""
 
-#: opac/webapp/main/views.py:1236
+#: opac/webapp/main/views.py:1238
 msgid "HTML do Artigo não encontrado ou indisponível"
 msgstr ""
 
-#: opac/webapp/main/views.py:1238 opac/webapp/main/views.py:1348
-#: opac/webapp/main/views.py:1366
+#: opac/webapp/main/views.py:1240 opac/webapp/main/views.py:1350
+#: opac/webapp/main/views.py:1368
 msgid "Erro inesperado"
 msgstr ""
 
-#: opac/webapp/main/views.py:1284 opac/webapp/main/views.py:1288
-#: opac/webapp/main/views.py:1293
+#: opac/webapp/main/views.py:1286 opac/webapp/main/views.py:1290
+#: opac/webapp/main/views.py:1295
 msgid "PDF do Artigo não encontrado"
 msgstr ""
 
-#: opac/webapp/main/views.py:1297 opac/webapp/main/views.py:1385
+#: opac/webapp/main/views.py:1299 opac/webapp/main/views.py:1387
 msgid "Recurso do Artigo não encontrado. Caminho inválido!"
 msgstr ""
 
-#: opac/webapp/main/views.py:1315
+#: opac/webapp/main/views.py:1317
 msgid "Formato não suportado"
 msgstr ""
 
-#: opac/webapp/main/views.py:1328
+#: opac/webapp/main/views.py:1330
 msgid "Parâmetros insuficientes para obter o EPDF do artigo"
 msgstr ""
 
-#: opac/webapp/main/views.py:1346
+#: opac/webapp/main/views.py:1348
 msgid "PDF não encontrado"
 msgstr ""
 
-#: opac/webapp/main/views.py:1431
+#: opac/webapp/main/views.py:1433
 msgid ""
 "Este PDF não existe em http://www.scielo.br. Consulte "
 "http://search.scielo.org"
 msgstr ""
 
-#: opac/webapp/main/views.py:1437
+#: opac/webapp/main/views.py:1439
 msgid "PDF do artigo não foi encontrado"
 msgstr ""
 
-#: opac/webapp/main/views.py:1480 opac/webapp/main/views.py:1511
+#: opac/webapp/main/views.py:1482 opac/webapp/main/views.py:1513
 msgid "Requisição inválida."
 msgstr ""
 
@@ -1501,6 +1501,10 @@ msgstr ""
 
 #: opac/webapp/templates/article/includes/modal/download.html:8
 msgid "Versão para download de PDF"
+msgstr ""
+
+#: opac/webapp/templates/article/includes/modal/download.html:39
+msgid "O periódico não forneceu este documento em formato PDF."
 msgstr ""
 
 #: opac/webapp/templates/article/includes/modal/translate_version.html:6

--- a/opac/webapp/translations/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/opac/webapp/translations/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2021-11-17 16:48+0000\n"
+"POT-Creation-Date: 2021-11-25 12:08+0000\n"
 "PO-Revision-Date: 2021-10-18 09:36-0300\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: pt_BR\n"
@@ -196,7 +196,7 @@ msgstr ""
 #: opac/webapp/templates/article/includes/levelMenu_abstracts.html:45
 #: opac/webapp/templates/article/includes/levelMenu_texts.html:33
 #: opac/webapp/templates/article/includes/levelMenu_texts.html:46
-#: opac/webapp/templates/article/includes/modal/download.html:26
+#: opac/webapp/templates/article/includes/modal/download.html:28
 msgid "Português"
 msgstr ""
 
@@ -205,7 +205,7 @@ msgstr ""
 #: opac/webapp/templates/article/includes/levelMenu_abstracts.html:43
 #: opac/webapp/templates/article/includes/levelMenu_texts.html:31
 #: opac/webapp/templates/article/includes/levelMenu_texts.html:44
-#: opac/webapp/templates/article/includes/modal/download.html:24
+#: opac/webapp/templates/article/includes/modal/download.html:26
 msgid "Inglês"
 msgstr ""
 
@@ -214,7 +214,7 @@ msgstr ""
 #: opac/webapp/templates/article/includes/levelMenu_abstracts.html:41
 #: opac/webapp/templates/article/includes/levelMenu_texts.html:29
 #: opac/webapp/templates/article/includes/levelMenu_texts.html:42
-#: opac/webapp/templates/article/includes/modal/download.html:22
+#: opac/webapp/templates/article/includes/modal/download.html:24
 msgid "Espanhol"
 msgstr ""
 
@@ -1034,12 +1034,12 @@ msgstr ""
 msgid "10 últimos periódicos inseridos na coleção %s"
 msgstr ""
 
-#: opac/webapp/main/views.py:347 opac/webapp/main/views.py:1658
+#: opac/webapp/main/views.py:347 opac/webapp/main/views.py:1660
 msgid "Página não encontrada"
 msgstr ""
 
 #: opac/webapp/main/views.py:372 opac/webapp/main/views.py:461
-#: opac/webapp/main/views.py:1457
+#: opac/webapp/main/views.py:1459
 #, python-format
 msgid "Requsição inválida ao tentar acessar o artigo com pid: %s"
 msgstr ""
@@ -1051,15 +1051,15 @@ msgstr ""
 msgid "Periódico não encontrado"
 msgstr ""
 
-#: opac/webapp/main/views.py:393 opac/webapp/main/views.py:819
-#: opac/webapp/main/views.py:987
+#: opac/webapp/main/views.py:393 opac/webapp/main/views.py:821
+#: opac/webapp/main/views.py:989
 msgid "Número não encontrado"
 msgstr ""
 
 #: opac/webapp/main/views.py:416 opac/webapp/main/views.py:448
-#: opac/webapp/main/views.py:1038 opac/webapp/main/views.py:1138
-#: opac/webapp/main/views.py:1188 opac/webapp/main/views.py:1410
-#: opac/webapp/main/views.py:1461
+#: opac/webapp/main/views.py:1040 opac/webapp/main/views.py:1140
+#: opac/webapp/main/views.py:1190 opac/webapp/main/views.py:1412
+#: opac/webapp/main/views.py:1463
 msgid "Artigo não encontrado"
 msgstr ""
 
@@ -1099,71 +1099,71 @@ msgstr ""
 msgid "Requisição inválida, captcha inválido."
 msgstr ""
 
-#: opac/webapp/main/views.py:928 opac/webapp/main/views.py:949
+#: opac/webapp/main/views.py:930 opac/webapp/main/views.py:951
 msgid "Artigos ahead of print não encontrados"
 msgstr ""
 
-#: opac/webapp/main/views.py:1130 opac/webapp/main/views.py:1406
+#: opac/webapp/main/views.py:1132 opac/webapp/main/views.py:1408
 msgid "Issue não encontrado"
 msgstr ""
 
-#: opac/webapp/main/views.py:1163
+#: opac/webapp/main/views.py:1165
 msgid "Não existe '{}'. No seu lugar use '{}'"
 msgstr ""
 
-#: opac/webapp/main/views.py:1184
+#: opac/webapp/main/views.py:1186
 msgid "Resumo inexistente"
 msgstr ""
 
-#: opac/webapp/main/views.py:1185
+#: opac/webapp/main/views.py:1187
 msgid "Artigo inexistente"
 msgstr ""
 
-#: opac/webapp/main/views.py:1200 opac/webapp/main/views.py:1364
+#: opac/webapp/main/views.py:1202 opac/webapp/main/views.py:1366
 msgid "Recurso não encontrado"
 msgstr ""
 
-#: opac/webapp/main/views.py:1236
+#: opac/webapp/main/views.py:1238
 msgid "HTML do Artigo não encontrado ou indisponível"
 msgstr ""
 
-#: opac/webapp/main/views.py:1238 opac/webapp/main/views.py:1348
-#: opac/webapp/main/views.py:1366
+#: opac/webapp/main/views.py:1240 opac/webapp/main/views.py:1350
+#: opac/webapp/main/views.py:1368
 msgid "Erro inesperado"
 msgstr ""
 
-#: opac/webapp/main/views.py:1284 opac/webapp/main/views.py:1288
-#: opac/webapp/main/views.py:1293
+#: opac/webapp/main/views.py:1286 opac/webapp/main/views.py:1290
+#: opac/webapp/main/views.py:1295
 msgid "PDF do Artigo não encontrado"
 msgstr ""
 
-#: opac/webapp/main/views.py:1297 opac/webapp/main/views.py:1385
+#: opac/webapp/main/views.py:1299 opac/webapp/main/views.py:1387
 msgid "Recurso do Artigo não encontrado. Caminho inválido!"
 msgstr ""
 
-#: opac/webapp/main/views.py:1315
+#: opac/webapp/main/views.py:1317
 msgid "Formato não suportado"
 msgstr ""
 
-#: opac/webapp/main/views.py:1328
+#: opac/webapp/main/views.py:1330
 msgid "Parâmetros insuficientes para obter o EPDF do artigo"
 msgstr ""
 
-#: opac/webapp/main/views.py:1346
+#: opac/webapp/main/views.py:1348
 msgid "PDF não encontrado"
 msgstr ""
 
-#: opac/webapp/main/views.py:1431
+#: opac/webapp/main/views.py:1433
 msgid ""
 "Este PDF não existe em http://www.scielo.br. Consulte "
 "http://search.scielo.org"
 msgstr ""
 
-#: opac/webapp/main/views.py:1437
+#: opac/webapp/main/views.py:1439
 msgid "PDF do artigo não foi encontrado"
 msgstr ""
 
-#: opac/webapp/main/views.py:1480 opac/webapp/main/views.py:1511
+#: opac/webapp/main/views.py:1482 opac/webapp/main/views.py:1513
 msgid "Requisição inválida."
 msgstr ""
 
@@ -1503,6 +1503,10 @@ msgstr ""
 #: opac/webapp/templates/article/includes/modal/download.html:8
 msgid "Versão para download de PDF"
 msgstr ""
+
+#: opac/webapp/templates/article/includes/modal/download.html:39
+msgid "O periódico não forneceu este documento em formato PDF."
+msgstr "La revista no proporcionó este documento en formato PDF."
 
 #: opac/webapp/templates/article/includes/modal/translate_version.html:6
 msgid "Versões e tradução automática"


### PR DESCRIPTION
#### O que esse PR faz?
Adiciona uma verificação de ausência do campo PDF e apresenta uma msg informando para o usuário que o PDF está indisponível por conta de o SciELO não ter recebido o ativo.

#### Onde a revisão poderia começar?

No template: opac/webapp/templates/article/includes/modal/download.html

#### Como este poderia ser testado manualmente?

Acessando um artigo sem **PDF**.

Esse é um exemplo: https://www.scielo.br/j/pusp/a/s63y4NmBfsHYpwm3gtw4wFD/?lang=pt#

Irei disponibilizar um exemplo em homologação para validação 

#### Algum cenário de contexto que queira dar?

Esse PR mostra uma msg para o usuário, mas é importante saber que existe a possibilidade dele também esconde casos onde recebemos o PDF e não está disponível no site.

### Screenshots

![Captura de Tela 2021-11-25 às 09 01 22](https://user-images.githubusercontent.com/86991526/143444569-530ae15c-2b5a-4015-a70b-85d59b9dc2d6.png)


#### Quais são tickets relevantes?

Tíquete referente: #2093 

### Referências

N/A

