### PR TITLE
Inibe a disponibilização de artigos que estão em "embargo"

### DIFF
--- a/opac/tests/test_controller.py
+++ b/opac/tests/test_controller.py
@@ -1330,7 +1330,8 @@ class ArticleControllerTestCase(BaseTestCase):
         self.assertEqual(article._id, '012ijs9y24')
         self.assertEqual(article.scielo_pids["v1"], 'S0101-0202(99)12345')
 
-    def test_get_recent_articles_of_issue(self):
+    @patch('webapp.controllers.now', return_value="2020-01-01")
+    def test_get_recent_articles_of_issue(self, mk):
         self._make_one(attrib={
             '_id': '012ijs9y24',
             'issue': '90210j83',
@@ -1360,6 +1361,7 @@ class ArticleControllerTestCase(BaseTestCase):
 
         self._make_one(attrib={
             '_id': '2183ikos9B',
+            'publication_date': '2022',
             'issue': '90210j83',
             'type': 'rapid-communication',
             'journal': 'oak,ajimn1'
@@ -1367,6 +1369,7 @@ class ArticleControllerTestCase(BaseTestCase):
 
         self._make_one(attrib={
             '_id': '012ijs9y1B',
+            'publication_date': '2022',
             'issue': '90210j83',
             'type': 'research-article',
             'journal': 'oak,ajimn1'
@@ -1391,9 +1394,9 @@ class ArticleControllerTestCase(BaseTestCase):
         })
         result = controllers.get_recent_articles_of_issue(
             issue_iid='90210j83', is_public=True)
-        self.assertEqual(len(result), 6)
+        self.assertEqual(len(result), 4)
         result = [article._id for article in result]
-        expected = ['2183ikos90', '2183ikoD90', '2183ikos9B', '012ijs9y1B',
+        expected = ['2183ikos90', '2183ikoD90',
                     '2183ikoD9F', '012ijs9y14']
         self.assertEqual(set(result), set(expected))
 

--- a/opac/tests/test_controller.py
+++ b/opac/tests/test_controller.py
@@ -1397,11 +1397,14 @@ class ArticleControllerTestCase(BaseTestCase):
                     '2183ikoD9F', '012ijs9y14']
         self.assertEqual(set(result), set(expected))
 
+    @patch('webapp.controllers.now', return_value="2020-01-01")
     @patch('webapp.controllers.Article.objects')
     @patch('webapp.controllers.get_journal_by_acron')
     @patch('webapp.controllers.get_issue_by_label')
     def test_get_article_by_pdf_filename_retrieves_articles_by_pdf_filename(
-        self, mk_get_issue_by_label, mk_get_journal_by_acron, mk_article_objects
+        self, mk_get_issue_by_label, mk_get_journal_by_acron,
+        mk_article_objects,
+        mk_now,
     ):
 
         article = self._make_one(attrib={
@@ -1417,17 +1420,22 @@ class ArticleControllerTestCase(BaseTestCase):
             article.journal.acronym, article.issue.label, "article.pdf"
         )
 
-        mk_article_objects.filter.assert_called_once_with(is_public=True,
-                                                          issue=article.issue,
-                                                          journal=article.journal,
-                                                          pdfs__filename='article.pdf'
-                                                          )
+        mk_article_objects.filter.assert_called_once_with(
+            is_public=True,
+            issue=article.issue,
+            journal=article.journal,
+            pdfs__filename='article.pdf',
+            publication_date__lte='2020-01-01',
+        )
 
+    @patch('webapp.controllers.now', return_value="2021-01-01")
     @patch('webapp.controllers.Article.objects')
     @patch('webapp.controllers.get_journal_by_acron')
     @patch('webapp.controllers.get_issue_by_label')
     def test_get_article_by_pdf_filename_retrieves_aop_article_by_pdf_filename(
-        self, mk_get_issue_by_label, mk_get_journal_by_acron, mk_article_objects
+        self, mk_get_issue_by_label, mk_get_journal_by_acron,
+        mk_article_objects,
+        mk_now,
     ):
 
         article = self._make_one(attrib={
@@ -1446,7 +1454,8 @@ class ArticleControllerTestCase(BaseTestCase):
             journal=article.journal,
             is_public=True,
             issue='oak,ajimn1-aop',
-            pdfs__filename='article.pdf'
+            pdfs__filename='article.pdf',
+            publication_date__lte='2021-01-01',
         )
 
     def test_get_article_by_pdf_filename_raises_error_if_no_journal_acronym(self):

--- a/opac/tests/test_controller.py
+++ b/opac/tests/test_controller.py
@@ -1,5 +1,6 @@
 # coding: utf-8
 from unittest.mock import patch
+from unittest import TestCase
 
 from werkzeug.security import check_password_hash
 
@@ -1845,4 +1846,25 @@ class PageControllerTestCase(BaseTestCase):
             {item.name for item in _page},
             {'Critérios', 'Criterios'}
             )
+
+
+@patch("webapp.controllers.now", return_value="2021-01-01")
+class AddFilterWithoutEmbargoTestCase(TestCase):
+
+    def test_add_filter_without_embargo_returns_filter_if_input_is_None(self, mock_now):
+        expected = {"publication_date__lte": "2021-01-01"}
+        result = controllers.add_filter_without_embargo()
+        self.assertDictEqual(expected, result)
+
+    def test_add_filter_without_embargo_returns_filter_if_input_is_empty_dict(self, mock_now):
+        expected = {"publication_date__lte": "2021-01-01"}
+        result = controllers.add_filter_without_embargo({})
+        self.assertDictEqual(expected, result)
+    
+    def test_add_filter_without_embargo_returns_filter_if_input_is_public_false(self, mock_now):
+        kwargs = {"is_public": False}
+        expected = {"is_public": False, "publication_date__lte": "2021-01-01"}
+        result = controllers.add_filter_without_embargo(kwargs)
+        self.assertDictEqual(expected, result)
+
 

--- a/opac/tests/utils.py
+++ b/opac/tests/utils.py
@@ -317,6 +317,7 @@ def makeOneArticle(attrib=None):  # noqa
         'lpage': attrib.get('lpage', '16'),
         'translated_titles': attrib.get('translated_titles', []),
         'languages': attrib.get('languages', ['pt', ]),
+        'publication_date': "2000",
     }
     article.update(attrib)
 

--- a/opac/webapp/controllers.py
+++ b/opac/webapp/controllers.py
@@ -6,7 +6,7 @@
     ou outras camadas superiores, evitando assim que as camadas superiores
     acessem diretamente a camada inferior de modelos.
 """
-
+from datetime import datetime
 import re
 import unicodecsv
 import io
@@ -73,6 +73,21 @@ class ArticleNotFoundError(Exception):
 
 class PreviousOrNextArticleNotFoundError(Exception):
     ...
+
+
+def now():
+    return datetime.utcnow().isoformat()[:10]
+
+
+def add_filter_without_embargo(kwargs={}):
+    """
+    Add filter to publish only articles which is allowed to be published
+    (not embargoed)
+    (only articles which are publication date is before or equal today date)
+    """
+    kwargs = kwargs or {}
+    kwargs["publication_date__lte"] = now()
+    return kwargs
 
 
 # -------- COLLECTION --------

--- a/opac/webapp/controllers.py
+++ b/opac/webapp/controllers.py
@@ -1093,6 +1093,9 @@ def get_articles_by_iid(iid, **kwargs):
     if not iid:
         raise ValueError(__('Obrigatório um iid.'))
 
+    # add filter publication_date__lte_today_date
+    kwargs = add_filter_without_embargo(kwargs)
+
     # FIXME - Melhorar esta consulta
     # Em um fascículo em que não é aop nem publicação contínua
     # todas as datas são iguais, então, `order_by`,

--- a/opac/webapp/controllers.py
+++ b/opac/webapp/controllers.py
@@ -1412,10 +1412,12 @@ def count_elements_by_type_and_visibility(type, public_only=False):
         else:
             return Issue.objects.count()
     elif type == 'article':
+        # add filter publication_date__lte_today_date
+        kwargs = add_filter_without_embargo()
         if public_only:
-            return Article.objects(is_public=True).count()
+            return Article.objects(is_public=True, **kwargs).count()
         else:
-            return Article.objects.count()
+            return Article.objects(**kwargs).count()
     elif type == 'news':
         return News.objects.count()
     elif type == 'sponsor':

--- a/opac/webapp/controllers.py
+++ b/opac/webapp/controllers.py
@@ -1023,6 +1023,9 @@ def get_article_by_aop_url_segs(jid, url_seg_issue, url_seg_article, **kwargs):
         "url_seg_issue": url_seg_issue
     }
 
+    # add filter publication_date__lte_today_date
+    kwargs = add_filter_without_embargo(kwargs)
+
     return Article.objects(journal=jid, aop_url_segs=aop_url_segs, **kwargs).first()
 
 

--- a/opac/webapp/controllers.py
+++ b/opac/webapp/controllers.py
@@ -822,6 +822,9 @@ def get_article_by_aid(aid, journal_url_seg, lang=None, gs_abstract=False, **kwa
     if not aid:
         raise ValueError(__('Obrigatório um aid.'))
 
+    # add filter publication_date__lte_today_date
+    kwargs = add_filter_without_embargo(kwargs)
+
     articles = Article.objects(pk=aid, is_public=True, **kwargs)
     if not articles:
         articles = Article.objects(

--- a/opac/webapp/controllers.py
+++ b/opac/webapp/controllers.py
@@ -1139,6 +1139,9 @@ def get_article_by_pid_v1(v1, **kwargs):
     if not v1:
         raise ValueError(__('Obrigatório um pid.'))
 
+    # add filter publication_date__lte_today_date
+    kwargs = add_filter_without_embargo(kwargs)
+
     return Article.objects(
         scielo_pids__v1=v1,
         is_public=True,
@@ -1156,6 +1159,9 @@ def get_article_by_pid(pid, **kwargs):
     if not pid:
         raise ValueError(__('Obrigatório um pid.'))
 
+    # add filter publication_date__lte_today_date
+    kwargs = add_filter_without_embargo(kwargs)
+
     return Article.objects(pid=pid, **kwargs).first()
 
 
@@ -1169,6 +1175,9 @@ def get_article_by_oap_pid(aop_pid, **kwargs):
     if not aop_pid:
         raise ValueError(__('Obrigatório um aop_pid.'))
 
+    # add filter publication_date__lte_today_date
+    kwargs = add_filter_without_embargo(kwargs)
+
     return Article.objects(aop_pid=aop_pid, **kwargs).first()
 
 
@@ -1181,6 +1190,9 @@ def get_article_by_scielo_pid(scielo_pid, **kwargs):
 
     if not scielo_pid:
         raise ValueError(__('Obrigatório um pid.'))
+
+    # add filter publication_date__lte_today_date
+    kwargs = add_filter_without_embargo(kwargs)
 
     return Article.objects(
         (Q(pid=scielo_pid) | Q(scielo_pids__v1=scielo_pid) | Q(scielo_pids__v2=scielo_pid) | Q(scielo_pids__v3=scielo_pid)),
@@ -1199,6 +1211,9 @@ def get_article_by_pid_v2(v2, **kwargs):
         raise ValueError(__('Obrigatório um pid.'))
 
     v2 = v2.upper()
+
+    # add filter publication_date__lte_today_date
+    kwargs = add_filter_without_embargo(kwargs)
 
     articles = Article.objects(pid=v2, is_public=True, **kwargs)
     if articles:

--- a/opac/webapp/controllers.py
+++ b/opac/webapp/controllers.py
@@ -999,6 +999,9 @@ def get_article_by_issue_article_seg(iid, url_seg_article, **kwargs):
     if not iid and url_seg_article:
         raise ValueError(__('Obrigatório um iid and url_seg_article.'))
 
+    # add filter publication_date__lte_today_date
+    kwargs = add_filter_without_embargo(kwargs)
+
     return Article.objects(issue=iid, url_segment=url_seg_article, **kwargs).first()
 
 

--- a/opac/webapp/controllers.py
+++ b/opac/webapp/controllers.py
@@ -981,6 +981,9 @@ def get_article_by_url_seg(url_seg_article, **kwargs):
     if not url_seg_article:
         raise ValueError(__('Obrigatório um url_seg_article.'))
 
+    # add filter publication_date__lte_today_date
+    kwargs = add_filter_without_embargo(kwargs)
+
     return Article.objects(url_segment=url_seg_article, **kwargs).first()
 
 

--- a/opac/webapp/controllers.py
+++ b/opac/webapp/controllers.py
@@ -1238,9 +1238,14 @@ def get_recent_articles_of_issue(issue_iid, is_public=True):
     if not issue_iid:
         raise ValueError(__('Parámetro obrigatório: issue_iid.'))
 
+    # add filter publication_date__lte_today_date
+    kwargs = add_filter_without_embargo()
+
     return Article.objects.filter(
         issue=issue_iid, is_public=is_public,
-        type__in=HIGHLIGHTED_TYPES).order_by('-order')
+        type__in=HIGHLIGHTED_TYPES,
+        **kwargs
+        ).order_by('-order')
 
 
 def get_article_by_pdf_filename(journal_acron, issue_label, pdf_filename):
@@ -1271,10 +1276,15 @@ def get_article_by_pdf_filename(journal_acron, issue_label, pdf_filename):
         prefix = splitted[0]
         pdf_filename = pdf_filename[3:]
 
+    # add filter publication_date__lte_today_date
+    kwargs = add_filter_without_embargo()
+
     article = Article.objects.filter(
                 journal=journal,
                 issue=issue, pdfs__filename=pdf_filename,
-                is_public=True).first()
+                is_public=True,
+                **kwargs,
+                ).first()
     if article:
         for pdf in article.pdfs:
             if ((pdf["filename"] == pdf_filename and prefix == '') or


### PR DESCRIPTION
#### O que esse PR faz?
Inibe a disponibilização de artigos que estão em "embargo", usando como filtro o campo `publication_date`.

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
Edite o campo `publication_date` de um artigo, colocando uma data futura. Este artigo não deve ficar acessível, nem apresentar em nenhuma listagem como sumário, nem ser contabilizado. Ou seja, deve ter o mesmo comportamento de um artigo não publicado.

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
n/a

#### Quais são tickets relevantes?
n/a

### Referências
n/a
