### PR TITLE
Atualiza o Flask Admin para a versão 1.5.8

### DIFF
--- a/opac/webapp/admin/views.py
+++ b/opac/webapp/admin/views.py
@@ -235,6 +235,13 @@ class FileAdminView(AssetsMixin, sqla.ModelView):
         language=__('Idioma'),
     )
 
+    def search_placeholder(self):
+        if self.column_searchable_list:
+            return ", ".join(
+                str(self.column_labels.get(col, col))
+                for col in self.column_searchable_list
+            )
+
 
 class ImageAdminView(AssetsMixin, sqla.ModelView):
 
@@ -269,6 +276,13 @@ class ImageAdminView(AssetsMixin, sqla.ModelView):
         path=__('Link'),
         language=__('Idioma'),
     )
+
+    def search_placeholder(self):
+        if self.column_searchable_list:
+            return ", ".join(
+                str(self.column_labels.get(col, col))
+                for col in self.column_searchable_list
+            )
 
 
 class OpacBaseAdminView(mongoengine.ModelView):

--- a/opac/webapp/config/templates/testing.template
+++ b/opac/webapp/config/templates/testing.template
@@ -130,6 +130,6 @@ FORCE_USE_HTTPS_GOOGLE_TAGS = False
 
 # ativa/desativa a apresentação dos dados de métricas da coleção (default: False),
 # o padrão é não apresentar
-USE_HOME_METRICS = True
+USE_HOME_METRICS = False
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ elastic-apm==5.5.2
 email-validator==1.0.5
 feedparser==5.2.1
 Flask==0.12.4
-Flask-Admin==1.5.2
+Flask-Admin==1.5.8
 Flask-BabelEx==0.9.3
 Flask-Caching==1.4.0
 Flask-DebugToolbar==0.10.1


### PR DESCRIPTION
#### O que esse PR faz?
Atualiza o Flask Admin para a versão 1.5.8

#### Onde a revisão poderia começar?

Por commit. 

#### Como este poderia ser testado manualmente?

Sugiro realizar os teste automáticos e rodar a aplicação utilizando a área administrativa. 

```
make test
```
#### Algum cenário de contexto que queira dar?

Para não obtermos o erro:

```
TypeError: sequence item 0: expected str instance, _LazyString found
```

Tivemos que realizar alteração no ModelView do admin, assim como explicado no link: https://github.com/flask-admin/flask-admin/issues/1790

### Screenshots
N/A.

#### Quais são tickets relevantes?

Essa atividade está com riso de segurança, veja: https://github.com/scieloorg/opac/security/dependabot

### Referências
N/A.

