### PR TITLE
Adiciona a funcionalidade de persistir os dados das páginas de 30 em 30 segundos.

### DIFF
--- a/opac/webapp/admin/views.py
+++ b/opac/webapp/admin/views.py
@@ -1,4 +1,5 @@
 # coding: utf-8
+import json
 import logging
 import socket
 from uuid import uuid4
@@ -6,6 +7,7 @@ from jinja2 import Markup
 from flask_babelex import gettext as _
 from flask_babelex import lazy_gettext as __
 import flask_admin as admin
+from flask import jsonify
 from flask_admin.actions import action
 from flask_admin.form import Select2Field
 from wtforms.fields import SelectField
@@ -733,7 +735,7 @@ class PagesAdminView(OpacBaseAdminView):
         'name', 'description', 'content',
     ]
 
-    create_template = 'admin/pages/edit.html'
+    create_template = 'admin/pages/add.html'
     edit_template = 'admin/pages/edit.html'
 
     form_overrides = dict(
@@ -749,6 +751,20 @@ class PagesAdminView(OpacBaseAdminView):
     )
 
     form_excluded_columns = ('created_at', 'updated_at')
+
+    @admin.expose('/ajx/', methods=('GET', 'POST'))
+    def save_ajax_view(self):
+        """
+            View to save page (time to time).
+        """
+        try:
+            p = Pages(id=request.args.get('id'), **request.form)
+            p.save()
+        except Exception as ex:
+            return jsonify({'saved': False, 'error': ex})
+        else:
+            return jsonify({'saved': True})
+
 
     def _content_formatter(self, context, model, name):
         return Markup(model.content)

--- a/opac/webapp/templates/admin/pages/add.html
+++ b/opac/webapp/templates/admin/pages/add.html
@@ -1,0 +1,37 @@
+{% extends 'admin/model/edit.html' %}
+
+{% block messages %}
+{{ super() }}
+<div class="alert alert-info alert-dismissable">
+    <button type="button" class="close" data-dismiss="alert" aria-hidden="true">×</button>
+    {% trans %}<strong>Atenção:</strong> ao selecionar um <strong>periódico</strong> esta página será a página
+    "secundária" do periódico selecionado, caso contrário será uma página da coleção, verificar páginas da coleção em
+    <em>Sobre o SciELO</em>. {% endtrans %}
+</div>
+{% endblock %}
+
+{% block tail %}
+{{ super() }}
+<script src="/static/js/ckeditor/ckeditor.js"></script>
+<script>
+    var editor_content = CKEDITOR.replace('content', {});
+    editor_content.on('instanceReady', function () {
+        // Use line breaks for block elements, tables, and lists.
+        var dtd = CKEDITOR.dtd;
+        var extended_tools = CKEDITOR.tools.extend(
+            {},
+            dtd.$nonBodyContent, dtd.$block, dtd.$listItem, dtd.$tableContent
+        );
+
+        for (var e in extended_tools) {
+            this.dataProcessor.writer.setRules(e, {
+                indent: true,
+                breakBeforeOpen: true,
+                breakAfterOpen: true,
+                breakBeforeClose: true,
+                breakAfterClose: true
+            });
+        }
+    });
+</script>
+{% endblock %}

--- a/opac/webapp/templates/admin/pages/edit.html
+++ b/opac/webapp/templates/admin/pages/edit.html
@@ -1,5 +1,11 @@
 {% extends 'admin/model/edit.html' %}
 
+{% block head %}
+{{ super() }}
+<link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/toastr.js/latest/toastr.min.css">
+{% endblock %}
+
+
 {% block messages %}
     {{ super() }}
     <div class="alert alert-info alert-dismissable">
@@ -8,9 +14,57 @@
     </div>
 {% endblock %}
 
+{% block edit_form %}
+        {% call lib.form_tag(form) %}
+        <div class="row">
+            <div class="col-md-12 col-xs-12">
+                {{ lib.render_form_fields([form.name])}}
+            </div>
+        </div>
+        <div class="row">
+            <div class="col-md-12 col-xs-12">
+                {{ lib.render_form_fields([form.language])}}
+            </div>
+        </div>
+        <div class="row">
+            <div class="col-md-12 col-xs-12">
+                {{ lib.render_form_fields([form.content])}}
+            </div>
+        </div>
+        <div class="row">
+            <div class="col-md-12 col-xs-12">
+                {{ lib.render_form_fields([form.journal])}}
+            </div>
+        </div>
+        <div class="row">
+            <div class="col-md-12 col-xs-12">
+                {{ lib.render_form_fields([form.description])}}
+            </div>
+        </div>
+        <div class="row">
+            <div class="col-md-12 col-xs-12">
+                {{ lib.render_form_fields([form.slug_name])}}
+            </div>
+        </div>
+        <div class="row">
+            <div class="col-md-3 offset-md-3">
+                <div class="custom-control custom-checkbox">
+                    <input type="checkbox" class="custom-control-input" id="autoSave" checked="checked">
+                    <label class="custom-control-label" for="autoSave">Salvar a cada 10 segundos</label>
+                </div>
+            </div>
+        </div>
+        <div class="form-buttons">
+            {{ lib.render_form_buttons(return_url) }}
+        </div>
+        {% endcall %}
+
+{% endblock %}
+
 {% block tail %}
     {{ super() }}
     <script src="/static/js/ckeditor/ckeditor.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/toastr.js/latest/toastr.min.js"></script>
     <script>
         var editor_content = CKEDITOR.replace( 'content', {} );
         editor_content.on('instanceReady', function() {
@@ -30,6 +84,45 @@
                     breakAfterClose: true
                 });
             }
+        });
+
+        var autoSave = $('#autoSave');
+        var interval;
+        // Time is set in millisecond (1 second = 1000 milliseconds).
+        var timer = function () {
+            interval = setInterval(function () {
+                //start slide...
+                if (autoSave.prop('checked'))
+                    save();
+                clearInterval(interval);
+            }, 10000);
+        };
+
+        //save
+        var save = function () {
+            $.ajax({
+                url: "/admin/pages/ajx/?id={{ request.args.get('id') }}",
+                type: "POST",
+                // Get the first form of the page.
+                data: $("form:first").serialize(),
+                success: function (data) {
+                    if(data.saved == false){
+                        toastr.error(data.error);
+                    }else{
+                        toastr.success("Dados do conteúdo salvo com sucesso!");
+                    }
+                },
+                error: function (data) {
+                    toastr.error("Erro ao tentar salvar os dados do conteúdo.\
+                                 Tente novamente, mais tarde.");
+                },
+
+            });
+        };
+
+        editor_content.on('change', function () {
+            clearInterval(interval);
+            timer();
         });
     </script>
 {% endblock %}


### PR DESCRIPTION
#### O que esse PR faz?
Adiciona a funcionalidade de persistir os dados das páginas de 30 em 30 segundos.

#### Onde a revisão poderia começar?

Sugiro revisar pelos modulos: 

- opac/webapp/admin/views.py 
- opac/webapp/templates/admin/pages/add.html
- opac/webapp/templates/admin/pages/edit.html

#### Como este poderia ser testado manualmente?

Subindo uma instância do opac localmente e acessando o ambiente de administração e realizando alguma alteração nas páginas secundárias. 

#### Algum cenário de contexto que queira dar?

Essa funcionalidade tenta garantir que seja salvo os dados das páginas secundárias em tempo de edição. Está configurado para ser salvo de 30 em 30 minutos os dados da página secundária, **caso haja alguma mudança nos dado**s. 

### Screenshots

Segue algumas imagens da nova funcionalidade: 
![Captura de Tela 2022-01-24 às 12 49 34](https://user-images.githubusercontent.com/86991526/150827188-378d7628-05ef-4949-8e96-b22731e9a108.png)
![Captura de Tela 2022-01-24 às 12 49 43](https://user-images.githubusercontent.com/86991526/150827198-5d8658ee-cb69-4416-a909-0b0184935b08.png)


#### Quais são tickets relevantes?

Não temos um tíquete para essa atividade mas temos ela como demanda na nossa planilha de atividade. 

Esse tíquete tem como objetivo também diminuir a incidência esse erro: https://github.com/scieloorg/opac/issues/2114


### Referências
#2114 

