### PR TITLE
Adiciona a funcionalidade de deixar as páginas secundárias como rascunho.

### DIFF
--- a/opac/tests/test_admin_views.py
+++ b/opac/tests/test_admin_views.py
@@ -4765,16 +4765,16 @@ class PagesAdminViewTests(BaseTestCase):
                 response_data = response.data.decode('utf-8')
                 self.assertIn(page.id, response_data)
                 self.assertIn(
-                    "/media/files/criterios_pt-br_faq-avaliacao-en.htm",
+                    "/avaliacao/faq_avaliacao_en.htm",
                     response_data)
                 self.assertIn(
-                    "/media/images/criterios_pt-br_glogo.gif",
+                    "/img/revistas/abcd/glogo.gif",
                     response_data)
                 self.assertEqual(
                     response_data.count(
-                        "/media/files/criterios_pt-br_faq-avaliacao-en.htm"),
+                        "/avaliacao/faq_avaliacao_en.htm"),
                     2)
                 self.assertEqual(
                     response_data.count(
-                        "/media/images/criterios_pt-br_glogo.gif"),
+                        "/img/revistas/abcd/glogo.gif"),
                     2)

--- a/opac/tests/test_main_views.py
+++ b/opac/tests/test_main_views.py
@@ -1741,6 +1741,43 @@ class PageTestCase(BaseTestCase):
             self.assertStatus(response, 404)
 
 
+    def test_page_when_is_draft_collection(self):
+        """
+        Teste da ``view function`` ``page``, deve retornar uma página
+        que usa o template ``collection/about.html`` quando está em rascunho.
+
+        """
+        with current_app.app_context():
+            utils.makeOneCollection()
+
+            page = utils.makeOnePage({'name': 'Critérios SciELO',
+                                      'language': 'pt_BR',
+                                      'is_draft': True})
+            response = self.client.get(url_for('main.about_collection',
+                                               slug_name=page.slug_name))
+
+            self.assertEqual(404, response.status_code)
+            self.assertIn('Página não encontrada', response.data.decode('utf-8'))
+
+
+    def test_page_when_is_draft_journal(self):
+        """
+        Teste da ``view function`` ``page``, deve retornar uma página
+        que usa o template ``journal/about.html``, retorna que o
+        ``Conteúdo não cadastrado.``
+        """
+        with current_app.app_context():
+            utils.makeOneCollection()
+
+            page = utils.makeOnePage({'name': 'Critérios SciELO',
+                                      'language': 'pt_BR',
+                                      'is_draft': True})
+            response = self.client.get(url_for('main.about_journal',
+                                               url_seg=page.slug_name))
+
+            self.assertEqual(404, response.status_code)
+
+
 class TestJournaDetail(BaseTestCase):
 
         # JOURNAL

--- a/opac/tests/utils.py
+++ b/opac/tests/utils.py
@@ -155,6 +155,7 @@ def makeOnePage(attrib=None):  # noqa
         'name': attrib.get('name', default_name),
         'slug_name': slugify(attrib.get('name', default_name)),
         'journal': attrib.get('journal', ''),
+        'is_draft': attrib.get('is_draft', False),
         'content': ' '.join([random.choice(texts) for n in range(0, times)]),
         'description': 'Description {}'.format(default_name),
         'language': attrib.get('language', 'pt_BR'),

--- a/opac/webapp/admin/views.py
+++ b/opac/webapp/admin/views.py
@@ -728,7 +728,7 @@ class PagesAdminView(OpacBaseAdminView):
     )
 
     column_filters = [
-        'name', 'language', 'journal', 'created_at', 'updated_at',
+        'name', 'language', 'journal', 'is_draft', 'created_at', 'updated_at',
     ]
 
     column_searchable_list = [

--- a/opac/webapp/controllers.py
+++ b/opac/webapp/controllers.py
@@ -1512,28 +1512,28 @@ def send_email_contact(recipents, name, your_mail, message):
 # -------- PAGES --------
 
 
-def get_page_by_journal_acron_lang(acron, language):
-    return Pages.objects(language=language, journal=acron).first()
+def get_page_by_journal_acron_lang(acron, language, is_draft=False):
+    return Pages.objects(language=language, journal=acron, is_draft=is_draft).first()
 
 
-def get_page_by_id(id):
-    return Pages.objects.get(_id=id)
+def get_page_by_id(id, is_draft=False):
+    return Pages.objects.get(_id=id, is_draft=is_draft)
 
 
-def get_pages_by_lang(lang, journal=''):
-    return Pages.objects(language=lang, journal=journal)
+def get_pages_by_lang(lang, journal='', is_draft=False):
+    return Pages.objects(language=lang, journal=journal, is_draft=is_draft)
 
 
-def get_pages():
-    return Pages.objects()
+def get_pages(is_draft=False):
+    return Pages.objects(is_draft=is_draft)
 
 
-def get_page_by_slug_name(slug_name, lang=None):
+def get_page_by_slug_name(slug_name, lang=None, is_draft=False):
     if not slug_name:
         raise ValueError(__('Obrigatório um slug_name.'))
     if not lang:
-        return Pages.objects(slug_name=slug_name)
-    return Pages.objects(language=lang, slug_name=slug_name).first()
+        return Pages.objects(slug_name=slug_name, is_draft=is_draft)
+    return Pages.objects(language=lang, slug_name=slug_name, is_draft=is_draft).first()
 
 
 def related_links(article):

--- a/opac/webapp/templates/admin/pages/edit.html
+++ b/opac/webapp/templates/admin/pages/edit.html
@@ -47,6 +47,11 @@
             </div>
         </div>
         <div class="row">
+            <div class="col-md-12 col-xs-12">
+                {{ lib.render_form_fields([form.is_draft])}}
+            </div>
+        </div>
+        <div class="row">
             <div class="col-md-3 offset-md-3">
                 <div class="custom-control custom-checkbox">
                     <input type="checkbox" class="custom-control-input" id="autoSave" checked="checked">

--- a/requirements.txt
+++ b/requirements.txt
@@ -42,7 +42,7 @@ mock==2.0.0
 mongoengine==0.16.3
 natsort==7.0.1
 oauthlib==3.1.0
--e git+https://git@github.com/scieloorg/opac_schema@v2.60#egg=Opac_Schema
+-e git+https://git@github.com/scieloorg/opac_schema@v2.63#egg=Opac_Schema
 -e git+https://github.com/scieloorg/packtools/@2.8.3#egg=packtools
 passlib==1.7.2
 pbr==5.4.5


### PR DESCRIPTION
#### O que esse PR faz?
Adiciona a funcionalidade de deixar as páginas secundárias como rascunho. Atualizado a versão do opac_schema para v2.63

#### Onde a revisão poderia começar?

Por commit.

#### Como este poderia ser testado manualmente?

Acessando a área administrativa das páginas secundárias e observando que existe uma opção de marcar como rascunho.

#### Algum cenário de contexto que queira dar?

**Importante:** As páginas em rascunho não são apresentadas no site.

### Screenshots

![Captura de Tela 2022-01-25 às 08 36 14](https://user-images.githubusercontent.com/86991526/151041039-382485f9-6d70-4482-8535-c0bbf0c447c3.png)

![Captura de Tela 2022-01-25 às 15 58 18](https://user-images.githubusercontent.com/86991526/151041279-85c42d76-1eb6-46cd-9956-85fa7c123b48.png)

#### Quais são tickets relevantes?

#2113 

### Referências
N/A

