### PR TITLE
Ajusta a obtenção dos parâmetros para compor o POST do ajax de atualização dos dados do formulário.

### DIFF
--- a/opac/webapp/templates/admin/pages/edit.html
+++ b/opac/webapp/templates/admin/pages/edit.html
@@ -109,7 +109,14 @@
                 url: "/admin/pages/ajx/?id={{ request.args.get('id') }}",
                 type: "POST",
                 // Get the first form of the page.
-                data: $("form:first").serialize(),
+                data: {
+                        'content': editor_content.getData(),
+                        'description': $('#description').val(),
+                        'journal': $('#journal').val(),
+                        'language': $('#language').val(),
+                        'name': $('#name').val(),
+                        'slug_name': $('slug_name').val()
+                    },
                 success: function (data) {
                     if(data.saved == false){
                         toastr.error(data.error);


### PR DESCRIPTION
#### O que esse PR faz?
Corrigi erro enviado no PR: https://github.com/scieloorg/opac/pull/2183

#### Onde a revisão poderia começar?

Sugiro revisar pelos modulos:

opac/webapp/templates/admin/pages/edit.html


#### Como este poderia ser testado manualmente?

Subindo uma instância do opac localmente e acessando o ambiente de administração e realizando alguma alteração nas páginas secundárias.

#### Algum cenário de contexto que queira dar?

Essa funcionalidade tenta garantir que seja salvo os dados das páginas secundárias em tempo de edição. Está configurado para ser salvo de 10 em 10 minutos os dados da página secundária, porém não estava persistindo os dados do conteúdo, já que a forma de obter os dados é com **CKEDITOR**. 

### Screenshots
N/A

#### Quais são tickets relevantes?

https://github.com/scieloorg/opac/issues/2114

### Referências
N/A

