### PR TITLE
Adiciona a capacidade de resolver URL legadas para material suplementar.

### DIFF
--- a/opac/tests/test_legacy_urls.py
+++ b/opac/tests/test_legacy_urls.py
@@ -371,6 +371,48 @@ class LegacyURLTestCase(BaseTestCase):
 
                 self.assertStatus(response, 301)
 
+    @patch('requests.get')
+    def test_router_legacy_pdf_suppl_material(self, mocked_requests_get):
+        """
+        Testa o acesso à URL antiga do PDF de material suplementar quando existe
+        a chave filename no campo pdf.
+        URL testada: /pdf/<JOURNAL_ACRON>/<ISSUE_LABEL>/<PDF_FILENAME>
+            Exemplo: /pdf/cta/v39s2/0101-2061-cta-suppl01.pdf
+        """
+
+        mocked_response = Mock()
+        mocked_response.status_code = 200
+        mocked_response.content = b'<pdf>'
+        mocked_requests_get.return_value = mocked_response
+
+        with current_app.app_context():
+
+            journal = utils.makeOneJournal({'print_issn': '0000-0000', 'acronym': 'cta'},)
+
+            issue = utils.makeOneIssue({
+                'journal': journal.id,
+                'label': 'v92n2',
+            })
+
+            article = utils.makeOneArticle({
+                'journal': journal.id,
+                'issue': issue.id,
+                'mat_suppl': [
+                    {
+                        'url': 'http://minio:9000/documentstore/1678-457X/JDH74Jr4SyDVpnkMyrqkDhF/e5e09c7d5e4e5052868372df837de4e1ee9d651a.pdf',
+                        'filename': '0101-2061-cta-suppl01.pdf',
+                    }
+                ]
+            })
+
+            with self.client as c:
+
+                url = '/pdf/cta/v92n2/0101-2061-cta-suppl01.pdf'
+
+                response = c.get(url, follow_redirects=False)
+
+                self.assertStatus(response, 301)
+
     def test_article_text_with_lng(self):
         """
         Testa o acesso ao artigo pela URL antiga.

--- a/opac/webapp/controllers.py
+++ b/opac/webapp/controllers.py
@@ -1293,6 +1293,37 @@ def get_article_by_pdf_filename(journal_acron, issue_label, pdf_filename):
                 article._pdf_url = pdf["url"]
                 return article
 
+def get_article_by_suppl_material_filename(journal_acron, issue_label, pdf_filename):
+    """
+    Retorna artigo pelo nome de arquivo pdf legado
+    `issue_label`: nome da pasta que contém volume, número, suplemento
+    """
+
+    if not journal_acron:
+        raise ValueError(__('Obrigatório o acrônimo do periódico.'))
+    if not issue_label:
+        raise ValueError(__('Obrigatório o campo issue_label.'))
+    if not pdf_filename:
+        raise ValueError(__('Obrigatório o nome do arquivo PDF.'))
+
+    journal = get_journal_by_acron(journal_acron)
+
+    issue = get_issue_by_label(journal, issue_label)
+
+    # add filter publication_date__lte_today_date
+    kwargs = add_filter_without_embargo()
+
+    article = Article.objects.filter(
+                mat_suppl__filename=pdf_filename,
+                journal=journal,
+                issue=issue,
+                is_public=True,
+                **kwargs,
+                ).first()
+
+    if article:
+        return article
+
 
 def get_articles_by_date_range(begin_date, end_date, page=1, per_page=100):
     """

--- a/opac/webapp/main/views.py
+++ b/opac/webapp/main/views.py
@@ -1437,6 +1437,12 @@ def router_legacy_pdf(journal_acron, issue_info, pdf_filename):
     article = controllers.get_article_by_pdf_filename(
         journal_acron, issue_info, pdf_filename)
 
+    # Se não tem pdf do artigo
+    # Verifica se tem material suplementar
+    if not article:
+        article = controllers.get_article_by_suppl_material_filename(
+            journal_acron, issue_info, pdf_filename)
+
     if not article:
         abort(404, _('PDF do artigo não foi encontrado'))
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -38,7 +38,7 @@ MarkupSafe==2.0.1
 mongoengine==0.16.3
 natsort==7.0.1
 oauthlib==3.1.0
--e git+https://git@github.com/scieloorg/opac_schema@v2.63#egg=Opac_Schema
+-e git+https://git@github.com/scieloorg/opac_schema@v2.65#egg=Opac_Schema
 -e git+https://github.com/scieloorg/packtools/@2.8.1#egg=packtools
 passlib==1.7.2
 pbr==5.4.5


### PR DESCRIPTION
#### O que esse PR faz?

Atualiza a versão do opac_schema para v2.65, adiciona teste para obter pdfs da (URL) legada para suplemento e adiciona uma nova função no **controller** para entrar a URL legadas para suplemento.

#### Onde a revisão poderia começar?

Por commit.

#### Como este poderia ser testado manualmente?

É possível acessando uma rota como essa: http://<HOST>/pdf/aabc/v92.n2/0001-3765-aabc-92-suppl01-e20181357.pdf

**IMPORTANTE**: É necessário que existe uma **mat_suppl** em algum registro do tipo Article no na base de dados do site.


#### Algum cenário de contexto que queira dar?

Essa implementação reutilizou a rota já existente para os /pdf(s) dos artigos, reparem esse reuso na views.py alterado.

Para rotar somente os do legacy_route: `export OPAC_CONFIG="config/templates/testing.template" && python opac/manager.py test -p "test_legacy_urls"`

### Screenshots
N/A

#### Quais são tickets relevantes?

#2220 

https://github.com/scieloorg/opac-airflow/issues/315

### Referências
N/A

