### PR TITLE
Corrige apresentação de alguns casos fórmulas em LaTeX que não estavam renderizando corretamente

### DIFF
--- a/opac/webapp/config/default.py
+++ b/opac/webapp/config/default.py
@@ -533,7 +533,7 @@ MAILING_CRON_STRING = os.environ.get(
 DEFAULT_SCHEDULER_TIMEOUT = int(
     os.environ.get('OPAC_DEFAULT_SCHEDULER_TIMEOUT', 1000))
 
-DEFAULT_MATHJAX_CDN_URL = "https://cdn.jsdelivr.net/npm/mathjax@3.0.0/es5/tex-chtml.js"
+DEFAULT_MATHJAX_CDN_URL = "https://cdn.jsdelivr.net/npm/mathjax@3.0.0/es5/tex-mml-svg.js"
 MATHJAX_CDN_URL = os.environ.get('OPAC_MATHJAX_CDN_URL', DEFAULT_MATHJAX_CDN_URL)
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -39,7 +39,7 @@ mongoengine==0.16.3
 natsort==7.0.1
 oauthlib==3.1.0
 -e git+https://git@github.com/scieloorg/opac_schema@v2.66#egg=Opac_Schema
--e git+https://github.com/scieloorg/packtools/@2.9.2#egg=packtools
+-e git+https://github.com/scieloorg/packtools/@2.9.3#egg=packtools
 passlib==1.7.2
 pbr==5.4.5
 picles.plumber==0.11


### PR DESCRIPTION

#### O que esse PR faz?
Atualiza a versão do packtools para 2.9.3 e o valor padrão da variável `DEFAULT_MATHJAX_CDN_URL` que indica o renderizador de fórmulas

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
Ver https://www.scielo.br/scielo.php?script=sci_arttext&pid=S0103-63512018000200385&lng=en&nrm=iso&tlng=pt

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots


<img width="593" alt="Captura de Tela 2022-04-18 às 10 54 01" src="https://user-images.githubusercontent.com/505143/163818482-7f99adc5-b519-454e-b939-b6ffd02411f3.png">

<img width="398" alt="Captura de Tela 2022-04-18 às 10 53 47" src="https://user-images.githubusercontent.com/505143/163818498-0cd7155f-5fff-40b0-80d4-08b73aae9b46.png">

#### Quais são tickets relevantes?
#1160 

### Referências
n/a
