### PR TITLE
Atualiza versão de packtools para 2.9.4 para corrigir apresentação de…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -39,7 +39,7 @@ mongoengine==0.16.3
 natsort==7.0.1
 oauthlib==3.1.0
 -e git+https://git@github.com/scieloorg/opac_schema@v2.66#egg=Opac_Schema
--e git+https://github.com/scieloorg/packtools/@2.9.3#egg=packtools
+-e git+https://github.com/scieloorg/packtools/@2.9.4#egg=packtools
 passlib==1.7.2
 pbr==5.4.5
 picles.plumber==0.11


### PR DESCRIPTION
… fórmulas provenientes de mathml e que tem atributos em elementos

#### O que esse PR faz?
Atualiza versão de packtools para 2.9.4 para corrigir apresentação de fórmulas provenientes de mathml e que tem atributos em elementos

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
Verificar a apresentação de artigos cujas fórmulas estão mathml e que têm atributos
Ex.: 7f8rqRq4vSnJ7B738VKMKqF

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
n/a

#### Quais são tickets relevantes?
n/a

### Referências
https://github.com/scieloorg/packtools/pull/296

