### PR TITLE
Atualiza a versão do packtools 2.9.7 que resolve apresentação de cartas, afiliações e orcid

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -39,7 +39,7 @@ mongoengine==0.16.3
 natsort==7.0.1
 oauthlib==3.1.0
 -e git+https://git@github.com/scieloorg/opac_schema@v2.66#egg=Opac_Schema
--e git+https://github.com/scieloorg/packtools/@2.9.6#egg=packtools
+-e git+https://github.com/scieloorg/packtools/@2.9.7#egg=packtools
 passlib==1.7.2
 pbr==5.4.5
 picles.plumber==0.11


### PR DESCRIPTION

#### O que esse PR faz?
Atualiza a versão do packtools 2.9.7 que resolve apresentação de cartas, afiliações e orcid

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
veja https://github.com/scieloorg/packtools/pull/305

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
n/a

#### Quais são tickets relevantes?
Fix #2308
Fix #2306
Fix #2146
Fix #2277

### Referências
n/a
