### PR TITLE
Correção do Script MathJax e exibição das fórmulas no corpo do artigo

### DIFF
--- a/opac/webapp/config/default.py
+++ b/opac/webapp/config/default.py
@@ -533,7 +533,9 @@ MAILING_CRON_STRING = os.environ.get(
 DEFAULT_SCHEDULER_TIMEOUT = int(
     os.environ.get('OPAC_DEFAULT_SCHEDULER_TIMEOUT', 1000))
 
-DEFAULT_MATHJAX_CDN_URL = "https://cdn.jsdelivr.net/npm/mathjax@3.0.0/es5/tex-mml-svg.js"
+# MATH JAX
+DEFAULT_MATHJAX_CDN_URL = "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/latest.js?config=TeX-MML-AM_SVG"
+
 MATHJAX_CDN_URL = os.environ.get('OPAC_MATHJAX_CDN_URL', DEFAULT_MATHJAX_CDN_URL)
 
 

--- a/opac/webapp/static/less/article.less
+++ b/opac/webapp/static/less/article.less
@@ -1679,10 +1679,12 @@
 
 		span {
 			font-family: Arial;
-			font-weight: bold;
+			//font-weight: bold;
 			font-size: 16px;
+			/*
 			display: block;
 			width: 100%;
+			*/
 		}
 
 		.formula-container {
@@ -1691,6 +1693,7 @@
 			align-content: center;
 			align-items: center;
 			position: relative;
+			flex-direction: column;
 
 			.formula-body,
 			.MathJax_SVG_Display,


### PR DESCRIPTION

#### O que esse PR faz?
Faz a troca do link do script que carrega o mathjax. Estava a versão 3.0.0 e foi carregada a versão 2.7.5 com a configuração para renderizar fórmulas em formato SVG. Além disso, no arquivo article.less foram removidos alguns atributos que impediam a correta renderização da fórmula no corpo do artigo.

#### Onde a revisão poderia começar?
Visualizando os dois arquivos em questão:
- default.py
- article.less

#### Como este poderia ser testado manualmente?
- Baixe a atualização
- Gere os novos css a partir dos arquivos .less, principalmente o article.less
- Rode o sistema e visualize o seguinte artigo:
https://www.scielo.br/j/ocr/a/6RRnV59vSsPJLxCzVsBKJ6Q/?lang=en
Aponte para a sua instancia local.

As fórmulas devem ser renderizadas corretamente. Teste também no mobile. Nesse caso, quando a fórmula tiver a largura maior do que a tela do dispositivo, por estar em formato svg, ela se adaptará a largura.

#### Algum cenário de contexto que queira dar?
É necessário gerar os css. Nesse PR estou enviando apenas o arquivo que carrega o novo script do mathjax com a configuração correta para renderizar fórmulas em formato SVG e também o article.less, que deve ser processado para gerar o article.css

### Screenshots
![Screen Shot 2022-06-07 at 10 45 10](https://user-images.githubusercontent.com/22373640/172615220-bcb92cfe-9c3b-4d5c-80ca-9c6275a65123.png)
![Screen Shot 2022-06-07 at 10 45 19](https://user-images.githubusercontent.com/22373640/172615254-89d1dafe-b990-41a6-9677-207b89c32918.png)
![Screen Shot 2022-06-08 at 09 22 58](https://user-images.githubusercontent.com/22373640/172615290-3075aebc-eeaa-42a6-b218-c02b37099b4a.png)
![Screen Shot 2022-06-08 at 09 23 09](https://user-images.githubusercontent.com/22373640/172615327-dd592545-b860-4aee-b48e-623b597e90b0.png)


#### Quais são tickets relevantes?
Não havia um ticket criado para a resolução desse bug.

### Referências
https://docs.mathjax.org/en/v2.7-latest/options/output-processors/SVG.html
https://stackoverflow.com/questions/45774826/svg-output-of-mathjax

