### PR TITLE
correção de dimensões do logo do periodico

### DIFF
--- a/opac/webapp/static/less/journal.less
+++ b/opac/webapp/static/less/journal.less
@@ -34,6 +34,11 @@
 		img {
 			margin-top: 15px;
 			width: 100%;
+
+			@media (min-width: 992px) {
+				width: auto;
+				max-height: 200px;
+			}
 		}
 		.theme {
 			color: #7b7469;


### PR DESCRIPTION

#### O que esse PR faz?
Corrige as dimensões do logo do periódico na tela do artigo.

#### Onde a revisão poderia começar?
acesse a tela do artigo e verifique as dimensões do logo do periódico.
Ela deve estar setada como width: 100% apenas no mobile.
Nos demais dispositivos a largura é automática e a altura máxima é de 200px.

#### Como este poderia ser testado manualmente?
Siga o passo anterior.

#### Algum cenário de contexto que queira dar?
sem contexto específico.

### Screenshots
![Screen Shot 2022-07-06 at 11 03 34](https://user-images.githubusercontent.com/22373640/178012399-3538fd51-392d-4893-a153-c67ff62231d8.png)
![Screen Shot 2022-07-06 at 11 03 42](https://user-images.githubusercontent.com/22373640/178012415-296e83b5-ddde-4b05-94c2-1b566a97358b.png)
![Screen Shot 2022-07-06 at 11 03 51](https://user-images.githubusercontent.com/22373640/178012422-bba7b630-a6a7-464c-b523-3a9d31aa6d26.png)
![Screen Shot 2022-07-06 at 11 04 09](https://user-images.githubusercontent.com/22373640/178012429-47eaf522-bf34-4146-9ac9-bf16751567f3.png)
![Screen Shot 2022-07-06 at 11 07 17](https://user-images.githubusercontent.com/22373640/178012435-33b3d245-7e32-4b4f-b31f-29888d6dc4bf.png)
![Screen Shot 2022-07-06 at 11 08 05](https://user-images.githubusercontent.com/22373640/178012437-d204dae8-30c8-4cab-804f-42551ac17c19.png)
![Screen Shot 2022-07-06 at 11 08 13](https://user-images.githubusercontent.com/22373640/178012442-80ec5548-d0ee-489f-865c-0ac45bcca647.png)


#### Quais são tickets relevantes?
Não foi criado um ticket. Apenas relatado o bug.

### Referências
--

