### PR TITLE
Correção tamanho do logo do periodico na tela do periodico 

### DIFF
--- a/opac/webapp/static/less/journal.less
+++ b/opac/webapp/static/less/journal.less
@@ -34,11 +34,6 @@
 		img {
 			margin-top: 15px;
 			width: 100%;
-
-			@media (min-width: 992px) {
-				width: auto;
-				max-height: 200px;
-			}
 		}
 		.theme {
 			color: #7b7469;
@@ -88,6 +83,22 @@
 			max-width: 1000px;
 		}
 		
+	}
+
+	.dropdown-menu{
+
+		.brandLogo{
+
+			img {
+				margin-top: 15px;
+				width: 100%;
+	
+				@media (min-width: 992px) {
+					width: auto;
+					max-height: 200px;
+				}
+			}
+		}
 	}
 
 	.journalContent {


### PR DESCRIPTION

#### O que esse PR faz?
Corrige o tamanho do logo do periódico na tela do periódico sem interferir no tamanho do logo do periódico na tela do artigo

#### Onde a revisão poderia começar?
acesse a home do periódico e verifiquei se o logo do cliente fica sobre outros elementos da interface. Não deve ficar. O logo do periódico na tela do periódico está setado para ocupar 100% da largura do espaço onde ele está inserido. Dessa maneira não deve sobrepor nenhum outro item.

#### Como este poderia ser testado manualmente?
Siga o passo anterior

#### Algum cenário de contexto que queira dar?
Atualize o sistema, rode o gulp para gerar os css. Acesse a pagina do periódico. Veja o comportamento do logo. Execute esse teste com vários periódicos diferentes para ver se com a variação de tamanho de logo o problema persiste. Não deve persistir.
Acesse a tela do artigo e verifique o tamanho do logo.

### Screenshots
-

#### Quais são tickets relevantes?
-

### Referências
-

