### PR TITLE
ajuste logo scielo 25 anos no header 

### DIFF
--- a/opac/webapp/templates/article/includes/alternative_header.html
+++ b/opac/webapp/templates/article/includes/alternative_header.html
@@ -5,14 +5,27 @@
   <div class="container">
     <div class="col-md-2 col-sm-3 mainNav">
       <a href="" class="menu" data-rel="#alternativeMainMenu" title="{% trans %}Abrir menu{% endtrans %}">{% trans %}Abrir menu{% endtrans %}</a>
+      {% if coll_macro.get_image() != "None" %}
+      <h2 class="logo-svg-mini">
+        <a href="/" title="{% trans %}Ir para a homepage da coleção: {% endtrans %}{{ coll_macro.get_collection_name() }}" style="background:url({{ coll_macro.get_image() }}); background-position: 0px; background-repeat: no-repeat;">
+          <span class="logo-collection logo-collection-svg-mini"><strong>{{ coll_macro.get_collection_name() }}</strong></span>
+        </a>
+      </h2>    
+      {% else %}
       <h2 class="logo-svg-mini">
         <a href="/" title="{% trans %}Ir para a homepage da coleção: {% endtrans %}{{ coll_macro.get_collection_name() }}">
           <span class="logo-collection logo-collection-svg-mini"><strong>{{ coll_macro.get_collection_name() }}</strong></span>
         </a>
-      </h2>
+      </h2>    
+      {% endif %}
+      
       <div class="mainMenu" id="alternativeMainMenu">
           <div class="row">
-              <div class="col-md-7 col-md-offset-2 col-sm-7 col-sm-offset-2 logo logo-svg"></div>
+            {% if coll_macro.get_image() != "None" %}
+              <div class="col-md-7 col-md-offset-2 col-sm-7 col-sm-offset-2 logo logo-svg" style="background:url({{ coll_macro.get_image() }}); background-position: 0px; background-repeat: no-repeat;"></div>
+            {% else %}
+              <div class="col-md-7 col-md-offset-2 col-sm-7 col-sm-offset-2 logo logo-svg"></div>     
+            {% endif %}
           </div>
           <nav>
             <ul>
@@ -88,7 +101,11 @@
         </a>
         <div class="mainMenu" id="alternativeMainMenu">
           <div class="row">
-            <div class="col-md-7 col-md-offset-2 col-sm-7 col-sm-offset-2 logo logo-svg"></div>
+            {% if coll_macro.get_image() != "None" %}
+              <div class="col-md-7 col-md-offset-2 col-sm-7 col-sm-offset-2 logo logo-svg" style="background:url({{ coll_macro.get_image() }});background-repeat: no-repeat;"></div>
+            {% else %}
+              <div class="col-md-7 col-md-offset-2 col-sm-7 col-sm-offset-2 logo logo-svg"></div>     
+            {% endif %}
           </div>
           <nav>
             <ul>
@@ -97,12 +114,20 @@
         </div>
       </div>
       <div class="col-xs-6 text-center">
-        
+        {% if coll_macro.get_image() != "None" %}
+        <h2 class="logo-svg-mini">
+          <a href="/" title="{% trans %}Ir para a homepage da coleção: {% endtrans %}{{ coll_macro.get_collection_name() }}" style="background:url({{ coll_macro.get_image() }}); background-repeat:no-repeat;background-position:0px;">
+            <span class="logo-collection logo-collection-svg-mini"><strong>{{ coll_macro.get_collection_name() }}</strong></span>
+          </a>
+        </h2>         
+        {% else %}
         <h2 class="logo-svg-mini">
           <a href="/" title="{% trans %}Ir para a homepage da coleção: {% endtrans %}{{ coll_macro.get_collection_name() }}">
             <span class="logo-collection logo-collection-svg-mini"><strong>{{ coll_macro.get_collection_name() }}</strong></span>
           </a>
-        </h2>
+        </h2>       
+        {% endif %}
+        
 
       </div>
       <div class="col-xs-4 language">

--- a/opac/webapp/templates/collection/includes/header.html
+++ b/opac/webapp/templates/collection/includes/header.html
@@ -11,19 +11,23 @@
       </div>
 
       <div class="col-md-6 col-sm-4 brandLogo">
-        <h1 class="logo-svg-legenda">
-          {% if coll_macro.get_image() != "None" %}
-            <a href="/" style="background:url({{ coll_macro.get_image() }}); background-position: 20px; background-repeat: no-repeat;">
-              <small>{{ coll_macro.get_collection_name() }}</small>
+      
+        {% if coll_macro.get_image() != "None" %}
+          <h1 class="logo-svg-legenda">
+            <a href="/" style="background:url({{ coll_macro.get_image() }}); background-repeat:no-repeat;background-position:6px;background-size:75%;">
+              <small style="margin-top:-31px;margin-left:17px;">{{ coll_macro.get_collection_name() }}</small>
               <span style="margin-top:10px;">Scientific Electronic Library Online</span>
             </a>
-          {% else %}
+          </h1>
+        {% else %}
+          <h1 class="logo-svg-legenda">
             <a href="/">
               <small>{{ coll_macro.get_collection_name() }}</small>
               <span>Scientific Electronic Library Online</span>
             </a>
-          {% endif %}
-        </h1>
+          </h1>
+        {% endif %}
+      
       </div>
 
       <div class="col-md-3 col-sm-4 language">

--- a/opac/webapp/templates/issue/includes/alternative_header.html
+++ b/opac/webapp/templates/issue/includes/alternative_header.html
@@ -5,14 +5,29 @@
   <div class="container">
     <div class="col-md-2 col-sm-3 mainNav">
       <a href="#" class="menu" data-rel="#alternativeMainMenu" title="{% trans %}Abrir menu{% endtrans %}">{% trans %}Abrir menu{% endtrans %}</a>
+      
+      {% if coll_macro.get_image() != "None" %}
+      <h2 class="logo-svg-mini">
+        <a href="/" title="{% trans %}Ir para a homepage da coleção: {% endtrans %}{{ coll_macro.get_collection_name() }}"  style="background:url({{ coll_macro.get_image() }}); background-position: 0px; background-repeat: no-repeat;">
+          <span class="logo-collection logo-collection-svg-mini"><strong>{{ coll_macro.get_collection_name() }}</strong></span>
+        </a>
+      </h2>    
+      {% else %}
       <h2 class="logo-svg-mini">
         <a href="/" title="{% trans %}Ir para a homepage da coleção: {% endtrans %}{{ coll_macro.get_collection_name() }}">
           <span class="logo-collection logo-collection-svg-mini"><strong>{{ coll_macro.get_collection_name() }}</strong></span>
         </a>
-      </h2>
+      </h2>    
+      {% endif %}
+      
       <div class="mainMenu" id="alternativeMainMenu">
         <div class="row">
-          <div class="col-md-7 col-md-offset-2 col-sm-7 col-sm-offset-2 logo logo-svg"></div>
+          
+          {% if coll_macro.get_image() != "None" %}
+            <div class="col-md-7 col-md-offset-2 col-sm-7 col-sm-offset-2 logo logo-svg" style="background:url({{ coll_macro.get_image() }}); background-position: 0px; background-repeat: no-repeat;"></div>
+          {% else %}
+            <div class="col-md-7 col-md-offset-2 col-sm-7 col-sm-offset-2 logo logo-svg"></div>     
+          {% endif %}
         </div>
         <nav>
           <ul>

--- a/opac/webapp/templates/journal/includes/alternative_header.html
+++ b/opac/webapp/templates/journal/includes/alternative_header.html
@@ -5,14 +5,27 @@
   <div class="container">
     <div class="col-md-2 col-sm-3 mainNav">
       <a href="#" class="menu" data-rel="#alternativeMainMenu" title="{% trans %}Abrir menu{% endtrans %}">{% trans %}Abrir menu{% endtrans %}</a>
+      {% if coll_macro.get_image() != "None" %}
+      <h2 class="logo-svg-mini">
+        <a href="/" title="{% trans %}Ir para a homepage da coleção: {% endtrans %}{{ coll_macro.get_collection_name() }}" style="background:url({{ coll_macro.get_image() }}); background-position: 0px; background-repeat: no-repeat;">
+          <span class="logo-collection logo-collection-svg-mini"><strong>{{ coll_macro.get_collection_name() }}</strong></span>
+        </a>
+      </h2>  
+      {% else %}
       <h2 class="logo-svg-mini">
         <a href="/" title="{% trans %}Ir para a homepage da coleção: {% endtrans %}{{ coll_macro.get_collection_name() }}">
           <span class="logo-collection logo-collection-svg-mini"><strong>{{ coll_macro.get_collection_name() }}</strong></span>
         </a>
-      </h2>
+      </h2> 
+      {% endif %}
       <div class="mainMenu" id="alternativeMainMenu">
         <div class="row">
-          <div class="col-md-7 col-md-offset-2 col-sm-7 col-sm-offset-2 logo logo-svg"></div>
+          {% if coll_macro.get_image() != "None" %}
+          <div class="col-md-7 col-md-offset-2 col-sm-7 col-sm-offset-2 logo logo-svg" style="background:url({{ coll_macro.get_image() }}); background-position: 0px; background-repeat: no-repeat;"></div>   
+          {% else %}
+          <div class="col-md-7 col-md-offset-2 col-sm-7 col-sm-offset-2 logo logo-svg"></div>     
+          {% endif %}
+          
         </div>
         <nav>
           <ul>

--- a/opac/webapp/templates/journal/includes/header.html
+++ b/opac/webapp/templates/journal/includes/header.html
@@ -20,7 +20,11 @@
           {% endif %}
         <div class="mainMenu" id="mainMenu">
           <div class="row">
-            <div class="col-md-7 col-md-offset-2 col-sm-7 col-sm-offset-2 logo logo-svg"></div>
+            {% if coll_macro.get_image() != "None" %}
+            <div class="col-md-7 col-md-offset-2 col-sm-7 col-sm-offset-2 logo logo-svg" style="background:url({{ coll_macro.get_image() }}); background-position: 0px; background-repeat: no-repeat;"></div>       
+            {% else %}
+            <div class="col-md-7 col-md-offset-2 col-sm-7 col-sm-offset-2 logo logo-svg"></div>       
+            {% endif %}
           </div>
           {% include "collection/includes/nav.html" %}
         </div>


### PR DESCRIPTION

#### O que esse PR faz?
Ajusta o novo logo scielo-25 anos nos headers das telas em que ele aparece. As telas corrigidas foram: home, periódico e artigo mobile e desktop. As telas que exibem o alternative header após a rolagem do scroll foram ajustadas também.

#### Onde a revisão poderia começar?
rode o sistema e navegue. No header, parte superior do sistema onde aparece o logo do SciELO deve exibir somente o logo scielo 25 anos.

#### Como este poderia ser testado manualmente?
1 - cadastrar o logo scielo 25 anos no admin do sistema. É importante que a url do logo seja no mesmo servidor em que o sistema esteja rodando. Caso contrário, o chrome ou outro navegador pode bloquear o carregamento da imagem externa.
2 - navegar por todas as telas do sistema em modo desktop. Deve ser possível visualizar somente o logo scielo 25 anos no header do sistema. Navegar também na resolução mobile quando estiver na tela do artigo.

#### Algum cenário de contexto que queira dar?
Não foram alterados os logos do footer. Estes permanecem exibindo o logo original do SciELO.

### Screenshots
![Screen Shot 2022-10-17 at 20 07 32](https://user-images.githubusercontent.com/22373640/196300107-61b1a7ae-88c3-411c-b6e8-55e501e03a06.png)
![Screen Shot 2022-10-17 at 20 07 26](https://user-images.githubusercontent.com/22373640/196300108-c2610a21-1577-426c-9e5d-f97169a3570a.png)
![Screen Shot 2022-10-17 at 20 07 12](https://user-images.githubusercontent.com/22373640/196300110-dbd2f6b9-3710-4773-948b-65b17eb30bfd.png)
![Screen Shot 2022-10-17 at 20 07 05](https://user-images.githubusercontent.com/22373640/196300112-5eecc256-86fc-4275-ac7c-a094613a93b4.png)
![Screen Shot 2022-10-17 at 20 06 59](https://user-images.githubusercontent.com/22373640/196300113-e3352f7a-a467-442a-aae5-1119be092b10.png)
![Screen Shot 2022-10-17 at 20 06 52](https://user-images.githubusercontent.com/22373640/196300114-1c618090-cd20-4d61-970e-2b1a337ea893.png)
![Screen Shot 2022-10-17 at 20 06 42](https://user-images.githubusercontent.com/22373640/196300115-42bf2245-edbc-4eb2-abcd-a8caa8897cb5.png)
![Screen Shot 2022-10-17 at 20 06 27](https://user-images.githubusercontent.com/22373640/196300116-588d0e5b-e668-4d1b-ac1f-c41dc7f76b76.png)
![Screen Shot 2022-10-17 at 20 07 44](https://user-images.githubusercontent.com/22373640/196300105-f1545734-873f-4048-8158-c5811d1d3d4e.png)
![Screen Shot 2022-10-17 at 20 07 50](https://user-images.githubusercontent.com/22373640/196300104-d2a973e0-250e-46e5-a6d0-38efd8358c76.png)
![Screen Shot 2022-10-17 at 20 08 30](https://user-images.githubusercontent.com/22373640/196300091-ee4a09a7-cabe-4a18-bd68-34fbcc49ebaa.png)
![Screen Shot 2022-10-17 at 20 08 23](https://user-images.githubusercontent.com/22373640/196300097-cbb5a8a8-a18c-4998-b3e6-c36bf131f31b.png)
![Screen Shot 2022-10-17 at 20 08 07](https://user-images.githubusercontent.com/22373640/196300098-935d870d-aefc-4f29-afdd-f2b1d6608634.png)
![Screen Shot 2022-10-17 at 20 08 01](https://user-images.githubusercontent.com/22373640/196300101-cbb25fb3-220e-4f14-a1c8-2599346bec92.png)

#### Quais são tickets relevantes?
Sem ticket. Urgente.

### Referências
-

