### PR TITLE
Alterar a forma de identificar quando é uma requisição via ajax.

### DIFF
--- a/opac/webapp/main/views.py
+++ b/opac/webapp/main/views.py
@@ -639,7 +639,7 @@ def about_journal(url_seg):
 @cache.cached(key_prefix=cache_key_with_lang_with_qs)
 def journals_search_alpha_ajax():
 
-    if not request.is_json:
+    if not request.headers.get('X-Requested-With'):
         abort(400, _('Requisição inválida. Deve ser por ajax'))
 
     query = request.args.get('query', '', type=str)
@@ -660,7 +660,7 @@ def journals_search_alpha_ajax():
 @cache.cached(key_prefix=cache_key_with_lang_with_qs)
 def journals_search_by_theme_ajax():
 
-    if not request.is_json:
+    if not request.headers.get('X-Requested-With'):
         abort(400, _('Requisição inválida. Deve ser por ajax'))
 
     query = request.args.get('query', '', type=str)
@@ -712,7 +712,7 @@ def download_journal_list(list_type, extension):
 @main.route("/<string:url_seg>/contact", methods=['POST'])
 def contact(url_seg):
 
-    if not request.is_json:
+    if not request.headers.get('X-Requested-With'):
         abort(403, _('Requisição inválida, deve ser ajax.'))
 
     if utils.is_recaptcha_valid(request):
@@ -1513,7 +1513,7 @@ def router_legacy_article(text_or_abstract):
 @main.route("/email_share_ajax/", methods=['POST'])
 def email_share_ajax():
 
-    if not request.is_json:
+    if not request.headers.get('X-Requested-With'):
         abort(400, _('Requisição inválida.'))
 
     form = forms.EmailShareForm(request.form)
@@ -1545,7 +1545,7 @@ def email_form():
 @main.route("/email_error_ajax/", methods=['POST'])
 def email_error_ajax():
 
-    if not request.is_json:
+    if not request.headers.get('X-Requested-With'):
         abort(400, _('Requisição inválida.'))
 
     form = forms.ErrorForm(request.form)


### PR DESCRIPTION
#### O que esse PR faz?
Alterar a forma de identificar quando é uma requisição via ajax.

#### Onde a revisão poderia começar?

Por commit 

#### Como este poderia ser testado manualmente?

Utilizando as partes do site que tenha uso de ajax e realizando envio de formulário de erro.

#### Algum cenário de contexto que queira dar?

Essa alteração é necessário por conta da versão do werkzeug que não dá mais suporte para **is_json**

### Screenshots
N/A

#### Quais são tickets relevantes?
N/A

### Referências
N/A

