### PR TITLE
Correção do css do botão floatingBtnError

### DIFF
--- a/opac/webapp/static/less/scielo-portal.less
+++ b/opac/webapp/static/less/scielo-portal.less
@@ -1852,9 +1852,12 @@ button.btn:active {
 
 .floatingBtnError{
 	position: fixed;
-	right: -80px;
-	top: 45%;
-	transform: rotate(-90deg);
+	padding: 12px;
+	writing-mode: vertical-rl;		
+	right: 10px;
+	top: 40%;
+	transform: rotate(-180deg);
+	line-height: 1rem;
 
 	&:focus{
 		color: white;


### PR DESCRIPTION
#### O que esse PR faz?
Atualiza a classe .floatingBtnError do arquivo scielo-portal.less,
Corrige o posicionamento do botão independentemente da quantidade de caracteres do botão.

#### Onde a revisão poderia começar?
1 - gere os arquivos css a partir dos arquivos .less
2 - limpe o cache
3 - rode o sistema e verifique que o botão deve ser visualizado fixado no lado direito da tela.

#### Como este poderia ser testado manualmente?
Siga os passos anteriores.

#### Algum cenário de contexto que queira dar?
Está funcionando para os labels no idioma en, es e pt

### Screenshots
![Screen Shot 2022-10-27 at 15 38 36](https://user-images.githubusercontent.com/22373640/198372611-73c194db-0d1f-4ee2-85eb-7f7914779078.png)
![Screen Shot 2022-10-27 at 15 38 53](https://user-images.githubusercontent.com/22373640/198372650-8d5799e6-460c-42cb-83c7-c72f9a3665bd.png)


#### Quais são tickets relevantes?
Sem ticket - urgente.

### Referências
-

