### PR TITLE
Fixa a versão 0.4.17 da biblioteca greenlet.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -27,6 +27,7 @@ Flask-SQLAlchemy==2.3.2
 Flask-WTF==1.0.0
 gunicorn==20.1.0
 gevent==1.4.0
+greenlet==0.4.17
 htmlmin==0.1.12
 idna==2.10
 itsdangerous==2.0.1


### PR DESCRIPTION
#### O que esse PR faz?

Fixa a versão 0.4.17 da biblioteca greenlet que não tem mais suporte, ver issue: https://github.com/gevent/gevent/issues/1685


#### Onde a revisão poderia começar?

Rodando a aplicação.

Esse PR resolve o seguinte erro: 

![Captura de Tela 2022-11-18 às 08 20 04](https://user-images.githubusercontent.com/86991526/202693908-102f7902-f2e5-43b8-80e0-0c42656f58da.png)

**Importante**: O correto é atualizarmos a versão do python para a versão >=3.9 e atualizarmos a versão do gevent para não utilizamos uma versão antiga da greenlet que como consta no link não tem mais suporte. 