### PR TITLE
Adiciona a caixa amarela contendo lista de documentos relacionados quando não foi gerada pelo packtools

### DIFF
--- a/opac/webapp/templates/article/base.html
+++ b/opac/webapp/templates/article/base.html
@@ -80,7 +80,11 @@
 <!-- xxx Verifica se o artigo contém artigos relacionados -->
 {% if article.related_articles %}
 <script>
-  $('.articleBadge-editionMeta-doi-copyLink').append($('.related-panel').html())
+    if (document.querySelectorAll(".related-panel").length == 1) {
+        // somente há o related-panel do site
+        // não há o related-panel inserido pelo packtools
+        $('.articleBadge-editionMeta-doi-copyLink').append($('.related-panel').html())
+    }
 </script>
 {% endif %}
 

--- a/opac/webapp/templates/article/base.html
+++ b/opac/webapp/templates/article/base.html
@@ -80,7 +80,7 @@
 <!-- xxx Verifica se o artigo contém artigos relacionados -->
 {% if article.related_articles %}
 <script>
-    if (document.querySelectorAll(".related-panel").length == 1) {
+    if (document.querySelectorAll(".article-correction-title").length == 0) {
         // somente há o related-panel do site
         // não há o related-panel inserido pelo packtools
         $('.articleBadge-editionMeta-doi-copyLink').append($('.related-panel').html())

--- a/opac/webapp/templates/article/base.html
+++ b/opac/webapp/templates/article/base.html
@@ -73,26 +73,26 @@
     </script>
     -->
 
-  {% endif %}
+{% endif %}
 
-  <script type="text/javascript" src="//badge.dimensions.ai/badge.js" charset="utf-8" async></script>
+<script type="text/javascript" src="//badge.dimensions.ai/badge.js" charset="utf-8" async></script>
 
-  <!-- xxx Verifica se o artigo contém artigos relacionados -->
-  {% if article.related_articles %}
-    <script>
-      $('.articleBadge-editionMeta-doi-copyLink').append($('.related-panel').html())
-    </script>
-  {% endif %}
+<!-- xxx Verifica se o artigo contém artigos relacionados -->
+{% if article.related_articles %}
+<script>
+  $('.articleBadge-editionMeta-doi-copyLink').append($('.related-panel').html())
+</script>
+{% endif %}
 
-  <!-- Verifica se o artigo contém suplemento -->
-  {% if article.mat_suppl %}
-    <script type="text/javascript">
-        {% for suppl in article.mat_suppl %}
-            elem = document.querySelector("a[href='{{ suppl.url }}']").getElementsByClassName("REPLACE_BY_SUPPLEMENTARY_MATERIAL_TEXT");
-            if (elem) elem[0].parentElement.innerHTML = "{{ suppl.filename }}";
-        {% endfor %}
-    </script>
-  {% endif %}
+<!-- Verifica se o artigo contém suplemento -->
+{% if article.mat_suppl %}
+<script type="text/javascript">
+    {% for suppl in article.mat_suppl %}
+        elem = document.querySelector("a[href='{{ suppl.url }}']").getElementsByClassName("REPLACE_BY_SUPPLEMENTARY_MATERIAL_TEXT");
+        if (elem) elem[0].parentElement.innerHTML = "{{ suppl.filename }}";
+    {% endfor %}
+</script>
+{% endif %}
 
 <script type="text/javascript" src="//badge.dimensions.ai/badge.js" charset="utf-8" async></script>
 

--- a/opac/webapp/templates/article/base.html
+++ b/opac/webapp/templates/article/base.html
@@ -77,6 +77,12 @@
 
   <script type="text/javascript" src="//badge.dimensions.ai/badge.js" charset="utf-8" async></script>
 
+  <!-- xxx Verifica se o artigo contém artigos relacionados -->
+  {% if article.related_articles %}
+    <script>
+      $('.articleBadge-editionMeta-doi-copyLink').append($('.related-panel').html())
+    </script>
+  {% endif %}
 
   <!-- Verifica se o artigo contém suplemento -->
   {% if article.mat_suppl %}
@@ -90,6 +96,12 @@
 
 <script type="text/javascript" src="//badge.dimensions.ai/badge.js" charset="utf-8" async></script>
 
+<!-- xxx Verifica se o artigo contém artigos relacionados -->
+{% if article.related_articles %}
+<script>
+  $('.articleBadge-editionMeta-doi-copyLink').append($('.related-panel').html())
+</script>
+{% endif %}
 
 <script>
   var scimago_verify = false;

--- a/opac/webapp/templates/article/base.html
+++ b/opac/webapp/templates/article/base.html
@@ -94,15 +94,6 @@
 </script>
 {% endif %}
 
-<script type="text/javascript" src="//badge.dimensions.ai/badge.js" charset="utf-8" async></script>
-
-<!-- xxx Verifica se o artigo contém artigos relacionados -->
-{% if article.related_articles %}
-<script>
-  $('.articleBadge-editionMeta-doi-copyLink').append($('.related-panel').html())
-</script>
-{% endif %}
-
 <script>
   var scimago_verify = false;
 

--- a/opac/webapp/templates/article/detail.html
+++ b/opac/webapp/templates/article/detail.html
@@ -25,5 +25,8 @@
 
       {% include "journal/includes/contact_footer.html" %}
 
+      {% if article.related_articles %}
+        {% include "article/includes/related-article.html" %}
+      {% endif %}
 
 {% endblock %}

--- a/opac/webapp/templates/article/includes/related-article.html
+++ b/opac/webapp/templates/article/includes/related-article.html
@@ -1,0 +1,31 @@
+<div class="related-panel" style="display: none;">
+    <div class="panel article-correction-title">
+
+        {% for related in article.related_articles %}
+            <div class="panel-heading">
+                {% if related.related_type == "corrected-article" %}
+                    {% trans %}Esta errata corrige o documento{% endtrans %}:
+                {% elif related.related_type == "retracted-article" %}
+                    {% trans %}Esta retratação retrata o documento{% endtrans %}:
+                {% elif related.related_type == "commentary-article" %}
+                    {% trans %}Este adendo adiciona informação ao documento{% endtrans %}:
+                {% elif related.related_type == "addendum" %}
+                    {% trans %}Este documento possui um adendo{% endtrans %}:
+                {% elif related.related_type == "retraction" %}
+                    {% trans %}Este documento possui uma retratação{% endtrans %}:
+                {% elif related.related_type == "correction" %}
+                    {% trans %}Este documento possui uma errata{% endtrans %}:
+                {% endif %}
+            </div>
+
+            <div class="panel-body">
+                <ul>
+                    <li>
+                        <a href="https://doi.org/{{ related.doi }}" target="_blank">{{ related.doi }}</a>
+                    </li>
+                </ul>
+            </div>
+        {% endfor %}
+
+    </div>
+</div>

--- a/requirements.txt
+++ b/requirements.txt
@@ -40,7 +40,7 @@ mongoengine==0.16.3
 natsort==7.0.1
 oauthlib==3.1.0
 -e git+https://git@github.com/scieloorg/opac_schema@v2.66#egg=Opac_Schema
--e git+https://github.com/scieloorg/packtools@2.17.2#egg=packtools
+-e git+https://github.com/scieloorg/packtools@2.17.3#egg=packtools
 passlib==1.7.2
 pbr==5.4.5
 picles.plumber==0.11

--- a/requirements.txt
+++ b/requirements.txt
@@ -40,7 +40,7 @@ mongoengine==0.16.3
 natsort==7.0.1
 oauthlib==3.1.0
 -e git+https://git@github.com/scieloorg/opac_schema@v2.66#egg=Opac_Schema
--e git+https://github.com/scieloorg/packtools@2.17.4#egg=packtools
+-e git+https://github.com/scieloorg/packtools@2.17.5#egg=packtools
 passlib==1.7.2
 pbr==5.4.5
 picles.plumber==0.11

--- a/requirements.txt
+++ b/requirements.txt
@@ -40,7 +40,7 @@ mongoengine==0.16.3
 natsort==7.0.1
 oauthlib==3.1.0
 -e git+https://git@github.com/scieloorg/opac_schema@v2.66#egg=Opac_Schema
--e git+https://github.com/scieloorg/packtools@2.17.3#egg=packtools
+-e git+https://github.com/scieloorg/packtools@2.17.4#egg=packtools
 passlib==1.7.2
 pbr==5.4.5
 picles.plumber==0.11


### PR DESCRIPTION
#### O que esse PR faz?
Adiciona a caixa amarela contendo lista de documentos relacionados quando não foi gerada pelo packtools

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
Acessando a página do artigo que tem errata, ou que tem comentários, que tem comentários, pois geralmente não foi inserida a tag related-article neste tipo de documento.
https://www.scielo.br/j/rbso/a/Km3dDZSWmGgpgYbjgc57RCn/?lang=pt
Sua errata
https://www.scielo.br/j/rbso/a/rj76QtnmbLz5w5YpfV7gTTL/?lang=pt

#### Algum cenário de contexto que queira dar?
Foi sugerido que passassem a inserir a tag. Este código deve funcionar para ambas as situações.

### Screenshots
Está sem a caixa
<img width="1153" alt="Captura de Tela 2022-12-04 às 11 26 07" src="https://user-images.githubusercontent.com/505143/205496351-bcb9fbfb-f7d4-4613-b5d0-cfbf1a5f744e.png">

Sua errata tem a caixa gerada pelo packtools
<img width="749" alt="Captura de Tela 2022-12-04 às 11 27 28" src="https://user-images.githubusercontent.com/505143/205496409-6c276fb6-a2db-4c34-82b4-6f6f196b9d66.png">


#### Quais são tickets relevantes?
#2389 
#2424
#2352

### Referências
n/a
