### PR TITLE
Atualiza a versão de packtools 2.17.8

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -40,7 +40,7 @@ mongoengine==0.16.3
 natsort==7.0.1
 oauthlib==3.1.0
 -e git+https://git@github.com/scieloorg/opac_schema@v2.66#egg=Opac_Schema
--e git+https://github.com/scieloorg/packtools@2.17.6#egg=packtools
+-e git+https://github.com/scieloorg/packtools@2.17.8#egg=packtools
 passlib==1.7.2
 pbr==5.4.5
 picles.plumber==0.11


### PR DESCRIPTION
#### O que esse PR faz?
- Acrescenta na seção de Histórico, o link de preprint, que não tem data preprint associada
- Apresenta a lista de materiais suplementares que foram indicados em `article-meta` de acordo com o issue #2506

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
Consultar os issues #2506, #2423, #2424

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
Ver os PR
https://github.com/scieloorg/packtools/pull/358
https://github.com/scieloorg/packtools/pull/359

#### Quais são tickets relevantes?
#2506, #2423, #2424

### Referências
n/a
