### PR TITLE
Correção acessibilidade. Troca da posição do botão acessibilidade

### DIFF
--- a/opac/webapp/templates/base.html
+++ b/opac/webapp/templates/base.html
@@ -43,6 +43,8 @@
   <body class="{% block body_class %}{% endblock %}">
     <a name="top"></a>
 
+    <a class="btn floatingBtnError" href="#" id="#floatingBtnError">{% trans %}Acessibilidade / Reportar erro{% endtrans %}</a>
+
     {% block content %}{% endblock %}
 
     <!-- share modal -->
@@ -83,9 +85,6 @@
           </div>
       </div>
     </div>
-    
-    <a class="btn floatingBtnError" href="#" id="#floatingBtnError">{% trans %}Acessibilidade / Reportar erro{% endtrans %}</a>
-    <!-- error modal -->
 
     <script src="{{ url_for('static', filename='js/scielo-bundle-min.js') }}"></script>
 


### PR DESCRIPTION
#### O que esse PR faz?
Visando facilitar a encontrabilidade do botão Acessibilidade / Reportar erro por leitores de tela, o botão foi colocado mais próximo possível da abertura da tag body. Dessa maneira, ao se acessar o sistema e teclar tab o botão passa a ser um dos primeiro itens a serem selecionados.

#### Onde a revisão poderia começar?
Este foi um ajuste simples de posicionamento de HTML. Portanto não haverá mudanças visuais na tela.
Uma forma simples de testar é ao acessar a aplicação, pressionar a tecla tab do teclado e verificar que o botão Acessibilidade / Reportar Erro passa a ser um dos primeiros itens a serem selecionados.

#### Como este poderia ser testado manualmente?
Siga os passos descritos anteriormente.

#### Algum cenário de contexto que queira dar?
É importante limpar o cache antes de efetuar os testes.

### Screenshots
![Screen Shot 2022-12-20 at 11 05 21](https://user-images.githubusercontent.com/22373640/208685527-fc0af13a-dadc-4708-a432-b8e9701581fb.png)


#### Quais são tickets relevantes?
#2534 

### Referências
--

