### PR TITLE
Remove rota desnecessária para a contrução da URL para os diversos formatos de apresentação do artigo e para acesso ao text e pdf.

### DIFF
--- a/opac/webapp/main/views.py
+++ b/opac/webapp/main/views.py
@@ -1161,7 +1161,6 @@ def article_detail(url_seg, url_seg_issue, url_seg_article, lang_code=''):
 
 @main.route('/j/<string:url_seg>/a/<string:article_pid_v3>/')
 @main.route('/j/<string:url_seg>/a/<string:article_pid_v3>/<string:part>/')
-@main.route('/j/<string:url_seg>/a/<string:article_pid_v3>/citation/')
 @cache.cached(key_prefix=cache_key_with_lang)
 def article_detail_v3(url_seg, article_pid_v3, part=None):
     qs_lang = request.args.get('lang', type=str) or None


### PR DESCRIPTION
#### O que esse PR faz?
Remove rota desnecessária para a contrução da URL para os diversos formatos de apresentação do artigo e para acesso ao text e pdf.

#### Onde a revisão poderia começar?

Por commit 

#### Como este poderia ser testado manualmente?

Acessando o link para o PDF na página do artigo.

#### Algum cenário de contexto que queira dar?

Isso corrige um bug introduzido no release https://github.com/scieloorg/opac/releases/tag/v4.1.2

### Screenshots
N/A

#### Quais são tickets relevantes?

https://github.com/scieloorg/opac/issues/2578

### Referências
N/A

