### PR TITLE
Garante que a contagem de quantidade de 'volume_issue'(publicação continua) seja a mesma do issue toc.

### DIFF
--- a/opac/webapp/controllers.py
+++ b/opac/webapp/controllers.py
@@ -634,7 +634,7 @@ def get_issues_for_grid_by_jid(jid, **kwargs):
         if issue.type == 'volume_issue':
             volume_issue.setdefault(issue.volume, {})
             volume_issue[issue.volume]['issue'] = issue
-            volume_issue[issue.volume]['art_count'] = len(get_articles_by_iid(issue.iid))
+            volume_issue[issue.volume]['art_count'] = len(get_articles_by_iid(issue.iid, is_public=True))
 
         key_volume = issue.volume
 


### PR DESCRIPTION
#### O que esse PR faz?
Garante que a contagem de quantidade de '**volume_issue**'(publicação continua) seja a mesma do **issue toc**.

#### Onde a revisão poderia começar?

Por commit 

#### Como este poderia ser testado manualmente?

Para teste manual acesso a página **/j/cta/grid** do site e veja a quantidade de artigos para o Volume 42 do ano 2022. 

Compare com a quantidade de itens no **/j/cta/i/2022.v42/** veja que a quantidade é a mesma.

#### Algum cenário de contexto que queira dar?

Esse bug acontece por que não estava na contagem dos artigo considerando que deve se contabilizado somente artigos públicos.

### Screenshots

![Screenshot 2023-01-26 at 15 34 12](https://user-images.githubusercontent.com/86991526/214920551-3d023a91-be83-4c25-8659-3be13d3b23cd.png)



#### Quais são tickets relevantes?
https://github.com/scieloorg/opac/issues/2455

### Referências
N/A

