### PR TITLE
Melhorias na implementação do SCIMAGO na página do artigo.

### DIFF
--- a/opac/webapp/templates/article/base.html
+++ b/opac/webapp/templates/article/base.html
@@ -15,7 +15,7 @@
 
 {% block extra_css %}
 <link rel="stylesheet" href="{{ url_for('static', filename='css/scielo-article.css') }}" type="text/css" async />
-<link href="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/css/select2.min.css" rel="stylesheet" async/>
+<link href="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/css/select2.min.css" rel="stylesheet" async />
 {% endblock %}
 
 {% block content %}
@@ -84,102 +84,97 @@
 <!-- xxx Verifica se o artigo contém artigos relacionados -->
 {% if article.related_articles %}
 <script>
-    if (document.querySelectorAll(".article-correction-title").length == 1) {
-        // length == 1: related-panel do site
-        // length == 2: related-panel do site + do packtools
-        $('.articleBadge-editionMeta-doi-copyLink').append($('.related-panel').html())
-    }
+  if (document.querySelectorAll(".article-correction-title").length == 1) {
+    // length == 1: related-panel do site
+    // length == 2: related-panel do site + do packtools
+    $('.articleBadge-editionMeta-doi-copyLink').append($('.related-panel').html())
+  }
 </script>
 {% endif %}
 
 <!-- Verifica se o artigo contém suplemento -->
 {% if article.mat_suppl %}
 <script type="text/javascript">
-    {% for suppl in article.mat_suppl %}
-        elem = document.querySelector("a[href='{{ suppl.url }}']").getElementsByClassName("REPLACE_BY_SUPPLEMENTARY_MATERIAL_TEXT");
-        if (elem) elem[0].parentElement.innerHTML = "{{ suppl.filename }}";
-    {% endfor %}
+  {% for suppl in article.mat_suppl %}
+  elem = document.querySelector("a[href='{{ suppl.url }}']").getElementsByClassName("REPLACE_BY_SUPPLEMENTARY_MATERIAL_TEXT");
+  if (elem) elem[0].parentElement.innerHTML = "{{ suppl.filename }}";
+  {% endfor %}
 </script>
 {% endif %}
 
 <script>
 
   //Change the bootstrap gobally behavior to select2 work with modal, more about see: https://select2.org/troubleshooting/common-problems
-  $.fn.modal.Constructor.prototype.enforceFocus = function() {};
-
-  function splitMulti(str, tokens){
-    var tempChar = tokens[0];
-    for(var i = 1; i < tokens.length; i++){
-        str = str.split(tokens[i]).join(tempChar);
-    }
-    str = str.split(tempChar);
-    return str;
-  }
+  $.fn.modal.Constructor.prototype.enforceFocus = function () { };
 
   var scimago_verify = false;
 
   $('#ModalTutors').on('shown.bs.modal', function () {
 
     if (!scimago_verify) {
+
+      // Like a cache dict
+      var affiliations = {};
+
       $('.tutors').each(
 
         function () {
-          // ensure just one item is append on html.
-          appended = false;
 
           $(this).find('div').not(".clearfix").each(function () {
             self = $(this);
 
-            items = splitMulti(self.text(), ['–', ',', '.', ':'])
+            affiliation_name = $('span:first', self).text();
 
-            // just the first and the second item.
-            items.forEach(function (item) {
-
-              if (!appended) {
+            if (affiliation_name){
+              // if affiliations is in dict
+              if (affiliations[affiliation_name]) {
+                self.append(affiliations[affiliation_name]);
+                // if affiliations is not in dict  
+              } else {
                 $.ajax({
                   type: "GET",
                   async: false,
                   url: "{{ url_for('main.scimago_ir') }}",
-                  data: 'q=' + encodeURI(item),
+                  data: 'q=' + encodeURI(affiliation_name),
                   success: function (data) {
                     if (data) {
-                      self.append(' <a href="{{ config.SCIMAGO_URL_IR }}' + data + '" target="_blank"><img src="/static/img/scimago.svg" alt="{% trans %} SCImago image{% endtrans %}" height="12"></a>')
-                      appended = true;
+                      scimago_link = ' <a href="{{ config.SCIMAGO_URL_IR }}' + data + '" target="_blank"><img src="/static/img/scimago.svg" alt="{% trans %} SCImago image{% endtrans %}" height="12" data-toggle="tooltip" data-placement="top" title="{% trans %}Link to SCIMAGO{% endtrans %}"></a>'
+                      self.append(scimago_link);
+                      affiliations[affiliation_name] = scimago_link;
                     }
                   }
                 });
               }
-
-            });
+            }
           });
         });
       scimago_verify = true;
     }
   });
-  
+
   var howcite_initialized = false;
 
   $('#ModalHowcite').on('shown.bs.modal', function () {
-    
-    if (!howcite_initialized){
+
+    if (!howcite_initialized) {
       initial = {
-        "American Psychological Association": "apa",  "Vancouver": "vancouver"
-      } 
-    
-      $.each(initial, function( key, value ) {
-          $.ajax({
-            url: "{{ url_for('main.article_cite_csl', article_id=article.id) }}?style=" + value, 
-            dataType: 'html',
-            delay: 250,
-            async: true
-          })
-          .done(function(html) {
+        "American Psychological Association": "apa", "Vancouver": "vancouver"
+      }
+
+      $.each(initial, function (key, value) {
+        $.ajax({
+          url: "{{ url_for('main.article_cite_csl', article_id=article.id) }}?style=" + value,
+          dataType: 'html',
+          delay: 250,
+          async: true
+        })
+          .done(function (html) {
             $("<span><b>" + key + "</b></span>" + "<pre>" + html + "</pre>").insertBefore($("#select_label"));
           })
       });
       howcite_initialized = true;
     }
-    
+
     $(".js-data-example-ajax").select2({
       ajax: {
         url: "{{ url_for('main.article_cite_csl_list') }}",
@@ -200,32 +195,32 @@
       escapeMarkup: function (markup) { return markup; },
       minimumInputLength: 1,
     });
-  
+
     $(document).on('select2:open', () => {
       document.querySelector('.select2-search__field').focus();
     });
-  
+
     $(".js-data-example-ajax").on('select2:select', function (e) {
-        var data = e.params.data;
-  
-        $.ajax({
-          url: "{{ url_for('main.article_cite_csl', article_id=article.id) }}?style=" + data.id,
-          dataType: 'html',
-          delay: 250
-        })
-        .done(function(html) {
-  
-          if($('#citation_text').css('display') == 'none'){
-              $('#citation_text').show()
+      var data = e.params.data;
+
+      $.ajax({
+        url: "{{ url_for('main.article_cite_csl', article_id=article.id) }}?style=" + data.id,
+        dataType: 'html',
+        delay: 250
+      })
+        .done(function (html) {
+
+          if ($('#citation_text').css('display') == 'none') {
+            $('#citation_text').show()
           }
-  
+
           $("#citation_text").html(html);
-          
+
         })
-        .fail(function() {
+        .fail(function () {
           alert("Erro ao tentar obter esse estilo de citação");
         })
-  
+
     });
   });
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -40,7 +40,7 @@ mongoengine==0.16.3
 natsort==7.0.1
 oauthlib==3.1.0
 -e git+https://git@github.com/scieloorg/opac_schema@v2.67#egg=Opac_Schema
--e git+https://github.com/scieloorg/packtools@2.17.8#egg=packtools
+-e git+https://github.com/scieloorg/packtools@3.0.1#egg=packtools
 passlib==1.7.2
 pbr==5.4.5
 picles.plumber==0.11


### PR DESCRIPTION
#### O que esse PR faz?

Adiciona melhorias na busca pelo ID do **SCIMAGO** para montar o link, para a instituição na página do artigo.

#### Onde a revisão poderia começar?

Por commit. 

#### Como este poderia ser testado manualmente?

Rodando a aplicação, acessando o modal de autores e realizando verificações das afiliações(instituições) em: https://www.scimagoir.com/

#### Algum cenário de contexto que queira dar?

Essa é uma melhoria, já que a implementação anterior tentava obter a afiliação a partir de um string sem qualquer semântica.

Foi possível após a versão **3.0.1** do **packtools**.


### Screenshots
N/A

#### Quais são tickets relevantes?

PR do packtools com a implementação das instituições: 
https://github.com/scieloorg/packtools/pull/367

### Referências
N/A

