### PR TITLE
Scimago ON OFF modal load

### DIFF
--- a/opac/webapp/config/default.py
+++ b/opac/webapp/config/default.py
@@ -542,7 +542,13 @@ SCIMAGO_URL = os.environ.get(
 SCIMAGO_ENABLED = os.environ.get('SCIMAGO_ENABLED', 'True') == 'True'
 
 # SCImago Institutions Ranking(IR)
-SCIMAGO_URL_IR = os.environ.get('SCIMAGO_URL_IR', 'https://www.scimagoir.com/')
+SCIMAGO_URL_IR = os.environ.get('OPAC_SCIMAGO_URL_IR', 'https://www.scimagoir.com/')
+# Turn On or Off the load of SCImago link 
+SCIMAGO_IR_LOAD_ON_MODAL = os.environ.get('OPAC_SCIMAGO_IR_LOAD_ON_MODAL', 'True') == 'True'
+SCIMAGO_IR_LOAD_ON_MODAL = True
+# Check the length of authors on article page to Turn On or Off the load of SCImago on page load or modal load (avoid page break)
+SCIMAGO_IR_AUTHOR_LENGTH = int(os.environ.get('OPAC_SCIMAGO_IR_AUTHOR_LENGTH', '30'))
+
 
 # Audit Log Email notifications:
 AUDIT_LOG_NOTIFICATION_ENABLED = os.environ.get(

--- a/opac/webapp/config/default.py
+++ b/opac/webapp/config/default.py
@@ -545,7 +545,6 @@ SCIMAGO_ENABLED = os.environ.get('SCIMAGO_ENABLED', 'True') == 'True'
 SCIMAGO_URL_IR = os.environ.get('OPAC_SCIMAGO_URL_IR', 'https://www.scimagoir.com/')
 # Turn On or Off the load of SCImago link 
 SCIMAGO_IR_LOAD_ON_MODAL = os.environ.get('OPAC_SCIMAGO_IR_LOAD_ON_MODAL', 'True') == 'True'
-SCIMAGO_IR_LOAD_ON_MODAL = True
 # Check the length of authors on article page to Turn On or Off the load of SCImago on page load or modal load (avoid page break)
 SCIMAGO_IR_AUTHOR_LENGTH = int(os.environ.get('OPAC_SCIMAGO_IR_AUTHOR_LENGTH', '30'))
 

--- a/opac/webapp/templates/article/base.html
+++ b/opac/webapp/templates/article/base.html
@@ -109,7 +109,7 @@
 
   var scimago_verify = false;
 
-  $('#ModalTutors').on('shown.bs.modal', function () {
+  function add_scimago_link(){
 
     if (!scimago_verify) {
 
@@ -150,7 +150,30 @@
         });
       scimago_verify = true;
     }
-  });
+  
+  }
+  
+  {% if config.SCIMAGO_IR_LOAD_ON_MODAL %}
+
+    $('#ModalTutors').on('shown.bs.modal', function () {
+      add_scimago_link()
+    });
+
+  {% else %}
+    
+    if ($('.tutors').length > {{config.SCIMAGO_IR_AUTHOR_LENGTH}}){
+
+      $('#ModalTutors').on('shown.bs.modal', function () {
+        add_scimago_link();
+      });
+
+    }else{
+
+      add_scimago_link()
+
+    }
+    
+  {% endif %}
 
   var howcite_initialized = false;
 


### PR DESCRIPTION
#### O que esse PR faz?

Esse PR liga e desliga a carga dos links do SCImago na página do artigo

#### Onde a revisão poderia começar?

Por commit.

#### Como este poderia ser testado manualmente?

Para testar manualmente é necessário ter uma instância do SciELO rodando localmente e com acesso a artigo é possível ligar e desligar a carga dos links no modal ou na carga da página.

#### Algum cenário de contexto que queira dar?

**IMPORTANTE**: Essa alteração é perigosa, pois, ao ligarmos a carga dos links do SCImago na página do artigo duplicamos o tempo de finalização da carga da própria página. 

Os params que ligam essa funcionalidade estão todos alinhados a deixar a carregamento desses links no modal, o param **SCIMAGO_IR_LOAD_ON_MODAL** tem valor padrão **True**

### Screenshots

Aumento no tempo de carga da página: 

De 1.8s

![Screenshot 2023-02-16 at 09 00 50](https://user-images.githubusercontent.com/86991526/219361462-eb438da9-49b1-4670-88a2-6b12303697b3.png)


para 3.8s

![Screenshot 2023-02-16 at 09 00 20](https://user-images.githubusercontent.com/86991526/219361481-fe5b6a0a-311d-45c0-990c-634cd765b242.png)


Possíveis problemas que podem ser recorrentes ao ligarmos a carga dos links do SCImago na página do artigo: 

![Screenshot 2023-02-16 at 07 47 33](https://user-images.githubusercontent.com/86991526/219361782-40ae0eda-6d4b-461f-ab7d-3e03176e9284.png)


#### Quais são tickets relevantes?

Essa demanda não tem um tíquete. 

### Referências
N/A

