### PR TITLE
Melhora a implementação do SCImagoIR na página do artigo

### DIFF
--- a/opac/webapp/config/default.py
+++ b/opac/webapp/config/default.py
@@ -542,7 +542,13 @@ SCIMAGO_URL = os.environ.get(
 SCIMAGO_ENABLED = os.environ.get('SCIMAGO_ENABLED', 'True') == 'True'
 
 # SCImago Institutions Ranking(IR)
-SCIMAGO_URL_IR = os.environ.get('SCIMAGO_URL_IR', 'https://www.scimagoir.com/')
+SCIMAGO_URL_IR = os.environ.get('OPAC_SCIMAGO_URL_IR', 'https://www.scimagoir.com/')
+# Turn On or Off the load of SCImago link 
+SCIMAGO_IR_LOAD_ON_MODAL = os.environ.get('OPAC_SCIMAGO_IR_LOAD_ON_MODAL', 'True') == 'True'
+SCIMAGO_IR_LOAD_ON_MODAL = True
+# Check the length of authors on article page to Turn On or Off the load of SCImago on page load or modal load (avoid page break)
+SCIMAGO_IR_AUTHOR_LENGTH = int(os.environ.get('OPAC_SCIMAGO_IR_AUTHOR_LENGTH', '30'))
+
 
 # Audit Log Email notifications:
 AUDIT_LOG_NOTIFICATION_ENABLED = os.environ.get(

--- a/opac/webapp/config/default.py
+++ b/opac/webapp/config/default.py
@@ -543,11 +543,6 @@ SCIMAGO_ENABLED = os.environ.get('SCIMAGO_ENABLED', 'True') == 'True'
 
 # SCImago Institutions Ranking(IR)
 SCIMAGO_URL_IR = os.environ.get('OPAC_SCIMAGO_URL_IR', 'https://www.scimagoir.com/')
-# Turn On or Off the load of SCImago link 
-SCIMAGO_IR_LOAD_ON_MODAL = os.environ.get('OPAC_SCIMAGO_IR_LOAD_ON_MODAL', 'True') == 'True'
-# Check the length of authors on article page to Turn On or Off the load of SCImago on page load or modal load (avoid page break)
-SCIMAGO_IR_AUTHOR_LENGTH = int(os.environ.get('OPAC_SCIMAGO_IR_AUTHOR_LENGTH', '30'))
-
 
 # Audit Log Email notifications:
 AUDIT_LOG_NOTIFICATION_ENABLED = os.environ.get(

--- a/opac/webapp/config/default.py
+++ b/opac/webapp/config/default.py
@@ -545,7 +545,6 @@ SCIMAGO_ENABLED = os.environ.get('SCIMAGO_ENABLED', 'True') == 'True'
 SCIMAGO_URL_IR = os.environ.get('OPAC_SCIMAGO_URL_IR', 'https://www.scimagoir.com/')
 # Turn On or Off the load of SCImago link 
 SCIMAGO_IR_LOAD_ON_MODAL = os.environ.get('OPAC_SCIMAGO_IR_LOAD_ON_MODAL', 'True') == 'True'
-SCIMAGO_IR_LOAD_ON_MODAL = True
 # Check the length of authors on article page to Turn On or Off the load of SCImago on page load or modal load (avoid page break)
 SCIMAGO_IR_AUTHOR_LENGTH = int(os.environ.get('OPAC_SCIMAGO_IR_AUTHOR_LENGTH', '30'))
 

--- a/opac/webapp/templates/article/base.html
+++ b/opac/webapp/templates/article/base.html
@@ -109,7 +109,7 @@
 
   var scimago_verify = false;
 
-  $('#ModalTutors').on('shown.bs.modal', function () {
+  function add_scimago_link(){
 
     if (!scimago_verify) {
 
@@ -150,7 +150,30 @@
         });
       scimago_verify = true;
     }
-  });
+  
+  }
+  
+  {% if config.SCIMAGO_IR_LOAD_ON_MODAL %}
+
+    $('#ModalTutors').on('shown.bs.modal', function () {
+      add_scimago_link()
+    });
+
+  {% else %}
+    
+    if ($('.tutors').length > {{config.SCIMAGO_IR_AUTHOR_LENGTH}}){
+
+      $('#ModalTutors').on('shown.bs.modal', function () {
+        add_scimago_link();
+      });
+
+    }else{
+
+      add_scimago_link()
+
+    }
+    
+  {% endif %}
 
   var howcite_initialized = false;
 

--- a/opac/webapp/templates/article/base.html
+++ b/opac/webapp/templates/article/base.html
@@ -107,73 +107,57 @@
   //Change the bootstrap gobally behavior to select2 work with modal, more about see: https://select2.org/troubleshooting/common-problems
   $.fn.modal.Constructor.prototype.enforceFocus = function () { };
 
-  var scimago_verify = false;
+  affiliations = {};
 
-  function add_scimago_link(){
+  function add_scimago_image(){
+    $('.tutors').each(
 
-    if (!scimago_verify) {
+    function () {
 
-      // Like a cache dict
-      var affiliations = {};
+      $(this).find('div').not(".clearfix").each(function () {
+        self = $(this);
 
-      $('.tutors').each(
+        affiliation_name = $('span:first', self).text();
+        if (affiliation_name){
+            scimago_link = ' <a href="#" target="_blank" class="scimago_link" data-affiliation="' + affiliation_name + '" ><img src="/static/img/scimago.svg" alt="{% trans %} SCImago image{% endtrans %}" height="20" width="100" data-toggle="tooltip" data-placement="top" title="{% trans %}Link to SCIMAGO{% endtrans %}"></a>';
+            self.append(scimago_link);
 
-        function () {
-
-          $(this).find('div').not(".clearfix").each(function () {
-            self = $(this);
-
-            affiliation_name = $('span:first', self).text();
-
-            if (affiliation_name){
-              // if affiliations is in dict
-              if (affiliations[affiliation_name]) {
-                self.append(affiliations[affiliation_name]);
-                // if affiliations is not in dict  
-              } else {
-                $.ajax({
-                  type: "GET",
-                  async: false,
-                  url: "{{ url_for('main.scimago_ir') }}",
-                  data: 'q=' + encodeURI(affiliation_name),
-                  success: function (data) {
-                    if (data) {
-                      scimago_link = ' <a href="{{ config.SCIMAGO_URL_IR }}' + data + '" target="_blank"><img src="/static/img/scimago.svg" alt="{% trans %} SCImago image{% endtrans %}" height="12" data-toggle="tooltip" data-placement="top" title="{% trans %}Link to SCIMAGO{% endtrans %}"></a>'
-                      self.append(scimago_link);
-                      affiliations[affiliation_name] = scimago_link;
-                    }
-                  }
-                });
-              }
-            }
-          });
-        });
-      scimago_verify = true;
-    }
-  
-  }
-  
-  {% if config.SCIMAGO_IR_LOAD_ON_MODAL %}
-
-    $('#ModalTutors').on('shown.bs.modal', function () {
-      add_scimago_link()
-    });
-
-  {% else %}
-    
-    if ($('.tutors').length > {{config.SCIMAGO_IR_AUTHOR_LENGTH}}){
-
-      $('#ModalTutors').on('shown.bs.modal', function () {
-        add_scimago_link();
+        }
       });
 
-    }else{
+    });
 
-      add_scimago_link()
+  }
 
-    }
-    
-  {% endif %}
+  add_scimago_image()
+
+  $(".scimago_link").click(function(e){
+    e.preventDefault();
+
+    affiliation_name = $(this).data("affiliation");
+
+    if (affiliation_name){
+      if (affiliations[affiliation_name]) {
+        window.open(affiliations[affiliation_name], '_blank');
+      } else {
+        $.ajax({
+          type: "GET",
+          async: false,
+          url: "{{ url_for('main.scimago_ir') }}",
+          data: 'q=' + encodeURI(affiliation_name),
+          success: function (data) {
+            if (data) {
+              affiliations[affiliation_name] = '{{ config.SCIMAGO_URL_IR }}' + data
+              window.open(affiliations[affiliation_name], '_blank');
+            }else{
+              alert("{% trans %}Afiliação: {% endtrans%}<b>" + affiliation_name + "</b>{% trans %} não encontrado no SCImago Institutions Rankings{% endtrans%}");
+            }
+          }
+        });
+      }
+    }    
+  });
+
 
   var howcite_initialized = false;
 


### PR DESCRIPTION
#### O que esse PR faz?

Esse PR melhora a implementação do SCImagoIR na página do artigo. 

Garante que já esteja o ícone no modal antes mesmo do link ser montado.

#### Onde a revisão poderia começar?

Por commit 

#### Como este poderia ser testado manualmente?

Para testar manualmente é necessário ter uma instância do SciELO rodando localmente e com acesso a artigo é possível verificar as imagens do SCImagoIR no modal.

#### Algum cenário de contexto que queira dar?

Essa é uma melhoria de uma implementação anterior.

Essa implementação não afeta o tempo de carga da página do artigo.

### Screenshots

Algumas imagens dessa implementação funcionando: 
![Screenshot 2023-02-20 at 14 46 15](https://user-images.githubusercontent.com/86991526/220175102-b2094444-874f-4f33-81d8-beb26a512252.png)
![Screenshot 2023-02-20 at 14 46 37](https://user-images.githubusercontent.com/86991526/220175108-cbbad7b2-106b-4a96-8636-65d03092fe66.png)
![Screenshot 2023-02-20 at 14 47 25](https://user-images.githubusercontent.com/86991526/220175110-f7da5f54-9b17-4b4a-a516-90ea4e3269da.png)
![Screenshot 2023-02-20 at 14 47 49](https://user-images.githubusercontent.com/86991526/220175112-51c775c7-db93-4ad8-8754-dc5b7cd40858.png)
![Screenshot 2023-02-20 at 14 48 08](https://user-images.githubusercontent.com/86991526/220175114-d3ad9324-0771-47a2-be50-77237675aed2.png)
![Screenshot 2023-02-20 at 14 53 43](https://user-images.githubusercontent.com/86991526/220175116-85aa87ce-c380-4766-ae6c-faa751d5c761.png)

#### Quais são tickets relevantes?

Essa demanda não tem um tíquete.

### Referências

N/A

