### PR TITLE
Adiciona na consulta a artigos, o PID de artigo "corrigido"

### DIFF
--- a/opac/webapp/controllers.py
+++ b/opac/webapp/controllers.py
@@ -912,9 +912,9 @@ def get_article_by_aid(
     # add filter publication_date__lte_today_date
     kwargs = add_filter_without_embargo(kwargs)
 
-    articles = Article.objects(pk=aid, is_public=True, **kwargs)
-    if not articles:
-        articles = Article.objects(scielo_pids__other=aid, is_public=True, **kwargs)
+    articles = Article.objects(
+        Q(pk=aid) | Q(scielo_pids__other=aid),
+        is_public=True, **kwargs)
 
     if articles:
         article = articles[0]

--- a/opac/webapp/controllers.py
+++ b/opac/webapp/controllers.py
@@ -1298,18 +1298,11 @@ def get_article_by_pid_v2(v2, **kwargs):
     # add filter publication_date__lte_today_date
     kwargs = add_filter_without_embargo(kwargs)
 
-    articles = Article.objects(pid=v2, is_public=True, **kwargs)
+    articles = Article.objects(
+        Q(pid=v2) | Q(aop_pid=v2) | Q(scielo_pids__other=v2),
+        is_public=True, **kwargs)
     if articles:
         return articles[0]
-
-    articles = Article.objects(aop_pid=v2, is_public=True, **kwargs)
-    if articles:
-        return articles[0]
-
-    articles = Article.objects(scielo_pids__other=v2, is_public=True, **kwargs)
-    if articles:
-        return articles[0]
-
     return None
 
 

--- a/opac/webapp/controllers.py
+++ b/opac/webapp/controllers.py
@@ -1298,7 +1298,10 @@ def get_article_by_pid_v2(v2, **kwargs):
     # add filter publication_date__lte_today_date
     kwargs = add_filter_without_embargo(kwargs)
 
+    fixed = _fix_pid(v2)
     q = Q(pid=v2) | Q(aop_pid=v2) | Q(scielo_pids__other=v2)
+    if fixed != v2:
+        q = Q(pid=fixed) | Q(aop_pid=fixed) | Q(scielo_pids__other=fixed) | q
     articles = Article.objects(q, is_public=True, **kwargs)
     if articles:
         return articles[0]

--- a/opac/webapp/controllers.py
+++ b/opac/webapp/controllers.py
@@ -59,6 +59,13 @@ _PIDS_FIXES = (
 )
 
 
+def _fix_pid(pid):
+    for found, replace in _PIDS_FIXES:
+        if found in pid:
+            return pid.replace(found, replace)
+    return pid
+
+
 class ArticleAbstractNotFoundError(Exception):
     ...
 

--- a/opac/webapp/controllers.py
+++ b/opac/webapp/controllers.py
@@ -1298,9 +1298,8 @@ def get_article_by_pid_v2(v2, **kwargs):
     # add filter publication_date__lte_today_date
     kwargs = add_filter_without_embargo(kwargs)
 
-    articles = Article.objects(
-        Q(pid=v2) | Q(aop_pid=v2) | Q(scielo_pids__other=v2),
-        is_public=True, **kwargs)
+    q = Q(pid=v2) | Q(aop_pid=v2) | Q(scielo_pids__other=v2)
+    articles = Article.objects(q, is_public=True, **kwargs)
     if articles:
         return articles[0]
     return None

--- a/opac/webapp/controllers.py
+++ b/opac/webapp/controllers.py
@@ -40,6 +40,7 @@ from .choices import INDEX_NAME, JOURNAL_STATUS, STUDY_AREAS
 from .models import User
 from .utils import utils
 
+
 HIGHLIGHTED_TYPES = (
     "article-commentary",
     "brief-report",
@@ -47,6 +48,14 @@ HIGHLIGHTED_TYPES = (
     "rapid-communication",
     "research-article",
     "review-article",
+)
+
+
+_PIDS_FIXES = (
+    ('0102-7638', '1678-9741'),
+    ('1807-0302', '0101-8205'),
+    ('1806-1117', '0102-4744'),
+    ('1678-4510', '0100-879X'),
 )
 
 

--- a/opac/webapp/controllers.py
+++ b/opac/webapp/controllers.py
@@ -1240,7 +1240,7 @@ def get_article_by_pid(pid, **kwargs):
     # add filter publication_date__lte_today_date
     kwargs = add_filter_without_embargo(kwargs)
 
-    return Article.objects(pid=pid, **kwargs).first()
+    return Article.objects(Q(pid=pid) | Q(pid=_fix_pid(pid)), **kwargs).first()
 
 
 def get_article_by_oap_pid(aop_pid, **kwargs):

--- a/opac/webapp/controllers.py
+++ b/opac/webapp/controllers.py
@@ -1256,7 +1256,9 @@ def get_article_by_oap_pid(aop_pid, **kwargs):
     # add filter publication_date__lte_today_date
     kwargs = add_filter_without_embargo(kwargs)
 
-    return Article.objects(aop_pid=aop_pid, **kwargs).first()
+    return Article.objects(
+        Q(aop_pid=aop_pid) | Q(aop_pid=_fix_pid(aop_pid)),
+        **kwargs).first()
 
 
 def get_article_by_scielo_pid(scielo_pid, **kwargs):


### PR DESCRIPTION
#### O que esse PR faz?
Adiciona na consulta a artigos, o PID de artigo "corrigido", a fim de retornar artigos que foram criados usando um ISSN anteriormente registrado. Também elimina consulta excedentes, adotando o uso de `Q()`.

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
Ver #2673

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
n/a

#### Quais são tickets relevantes?
#2673

### Referências
n/a
