### PR TITLE
Modifica a orientação para o usuário quando recurso não foi encontrado

### DIFF
--- a/opac/webapp/controllers.py
+++ b/opac/webapp/controllers.py
@@ -69,6 +69,10 @@ def _fix_pid(pid):
     return pid
 
 
+class ArticleWillBePublishedError(Exception):
+    ...
+
+
 class ArticleAbstractNotFoundError(Exception):
     ...
 

--- a/opac/webapp/controllers.py
+++ b/opac/webapp/controllers.py
@@ -923,10 +923,10 @@ def get_article_by_aid(
         Q(pk=aid) | Q(scielo_pids__other=aid), is_public=True, **kwargs
     )
 
-    if articles:
-        article = articles[0]
-    else:
+    if not articles:
         raise ArticleNotFoundError(aid)
+
+    article = articles[0]
 
     if not article.issue.is_public:
         raise IssueIsNotPublishedError(article.issue.unpublish_reason)

--- a/opac/webapp/main/views.py
+++ b/opac/webapp/main/views.py
@@ -1301,7 +1301,7 @@ def article_detail_v3(url_seg, article_pid_v3, part=None):
         # ABSTRACTNOTFOUND
         abort(404, _("Recurso não encontrado"))
     except controllers.ArticleWillBePublishedError as e:
-        abort(404, _("Artigo estará disponível a partir de {}").format(e))
+        abort(404, _("Artigo estará disponível em {} (ano-mes-dia)").format(e))
     except controllers.ArticleIsNotPublishedError as e:
         # exceção não está sendo levantada
         abort(404, "{}{}".format(ARTICLE_UNPUBLISH, e))

--- a/opac/webapp/main/views.py
+++ b/opac/webapp/main/views.py
@@ -1288,10 +1288,9 @@ def article_detail_v3(url_seg, article_pid_v3, part=None):
                 code=301,
             )
     except controllers.PreviousOrNextArticleNotFoundError as e:
+        # No contexto de navegação, não existe o próximo ou anterior 
         if gs_abstract:
-            # ABSTRACTNOTFOUND
             abort(404, _("Resumo inexistente"))
-        # ARTICLENOTFOUND
         abort(404, _("Artigo inexistente"))
     except (controllers.ArticleNotFoundError, controllers.ArticleJournalNotFoundError):
         # ARTICLENOTFOUND

--- a/opac/webapp/main/views.py
+++ b/opac/webapp/main/views.py
@@ -422,7 +422,11 @@ def router_legacy():
             )
 
         elif script_php == "sci_arttext" or script_php == "sci_abstract":
-            article = controllers.get_article_by_pid_v2(pid)
+            try:
+                article = controllers.get_article_by_pid_v2(pid)
+            except controllers.ArticleWillBePublishedError as exc:
+                abort(404, _("Artigo estará disponível em {} (ano-mes-dia)").format(exc))
+
             if not article:
                 # ARTICLENOTFOUND
                 abort(404, _("Artigo não encontrado"))
@@ -459,7 +463,11 @@ def router_legacy():
 
         elif script_php == "sci_pdf":
             # accesso ao pdf do artigo:
-            article = controllers.get_article_by_pid_v2(pid)
+            try:
+                article = controllers.get_article_by_pid_v2(pid)
+            except controllers.ArticleWillBePublishedError as exc:
+                abort(404, _("Artigo estará disponível em {} (ano-mes-dia)").format(exc))
+
             if not article:
                 # ARTICLENOTFOUND
                 abort(404, _("Artigo não encontrado"))

--- a/opac/webapp/main/views.py
+++ b/opac/webapp/main/views.py
@@ -1125,7 +1125,11 @@ def issue_feed(url_seg, url_seg_issue):
 @main.route('/article/<regex("S\d{4}-\d{3}[0-9xX][0-2][0-9]{3}\d{4}\d{5}"):pid>/')
 @cache.cached(key_prefix=cache_key_with_lang)
 def article_detail_pid(pid):
-    article = controllers.get_article_by_pid_v2(pid)
+
+    try:
+        article = controllers.get_article_by_pid_v2(pid)
+    except controllers.ArticleWillBePublishedError as exc:
+        abort(404, _("Artigo estará disponível em {} (ano-mes-dia)").format(exc))
 
     if not article:
         # ARTICLENOTFOUND

--- a/opac/webapp/main/views.py
+++ b/opac/webapp/main/views.py
@@ -1300,6 +1300,8 @@ def article_detail_v3(url_seg, article_pid_v3, part=None):
     except controllers.ArticleAbstractNotFoundError:
         # ABSTRACTNOTFOUND
         abort(404, _("Recurso não encontrado"))
+    except controllers.ArticleWillBePublishedError as e:
+        abort(404, _("Artigo estará disponível a partir de {}").format(e))
     except controllers.ArticleIsNotPublishedError as e:
         # exceção não está sendo levantada
         abort(404, "{}{}".format(ARTICLE_UNPUBLISH, e))

--- a/opac/webapp/main/views.py
+++ b/opac/webapp/main/views.py
@@ -1125,10 +1125,7 @@ def issue_feed(url_seg, url_seg_issue):
 @main.route('/article/<regex("S\d{4}-\d{3}[0-9xX][0-2][0-9]{3}\d{4}\d{5}"):pid>/')
 @cache.cached(key_prefix=cache_key_with_lang)
 def article_detail_pid(pid):
-    article = controllers.get_article_by_pid(pid)
-
-    if not article:
-        article = controllers.get_article_by_oap_pid(pid)
+    article = controllers.get_article_by_pid_v2(pid)
 
     if not article:
         # ARTICLENOTFOUND

--- a/opac/webapp/main/views.py
+++ b/opac/webapp/main/views.py
@@ -424,6 +424,7 @@ def router_legacy():
         elif script_php == "sci_arttext" or script_php == "sci_abstract":
             article = controllers.get_article_by_pid_v2(pid)
             if not article:
+                # ARTICLENOTFOUND
                 abort(404, _("Artigo não encontrado"))
 
             # 'abstract' or None (not False, porque False converterá a string 'False')
@@ -460,6 +461,7 @@ def router_legacy():
             # accesso ao pdf do artigo:
             article = controllers.get_article_by_pid_v2(pid)
             if not article:
+                # ARTICLENOTFOUND
                 abort(404, _("Artigo não encontrado"))
 
             return redirect(
@@ -1121,6 +1123,7 @@ def article_detail_pid(pid):
         article = controllers.get_article_by_oap_pid(pid)
 
     if not article:
+        # ARTICLENOTFOUND
         abort(404, _("Artigo não encontrado"))
 
     return redirect(
@@ -1232,6 +1235,7 @@ def article_detail(url_seg, url_seg_issue, url_seg_article, lang_code=""):
             issue.journal, url_seg_issue, url_seg_article
         )
     if article is None:
+        # ARTICLENOTFOUND
         abort(404, _("Artigo não encontrado"))
 
     req_params = {
@@ -1276,9 +1280,12 @@ def article_detail_v3(url_seg, article_pid_v3, part=None):
             )
     except controllers.PreviousOrNextArticleNotFoundError as e:
         if gs_abstract:
+            # ABSTRACTNOTFOUND
             abort(404, _("Resumo inexistente"))
+        # ARTICLENOTFOUND
         abort(404, _("Artigo inexistente"))
     except (controllers.ArticleNotFoundError, controllers.ArticleJournalNotFoundError):
+        # ARTICLENOTFOUND
         abort(404, _("Artigo não encontrado"))
     except controllers.ArticleLangNotFoundError:
         return redirect(
@@ -1291,8 +1298,10 @@ def article_detail_v3(url_seg, article_pid_v3, part=None):
             code=301,
         )
     except controllers.ArticleAbstractNotFoundError:
+        # ABSTRACTNOTFOUND
         abort(404, _("Recurso não encontrado"))
     except controllers.ArticleIsNotPublishedError as e:
+        # exceção não está sendo levantada
         abort(404, "{}{}".format(ARTICLE_UNPUBLISH, e))
     except controllers.IssueIsNotPublishedError as e:
         abort(404, "{}{}".format(ISSUE_UNPUBLISH, e))
@@ -1374,15 +1383,18 @@ def article_detail_v3(url_seg, article_pid_v3, part=None):
 
     def _handle_pdf():
         if not article.pdfs:
+            # PDFNOTFOUND
             abort(404, _("PDF do Artigo não encontrado"))
 
         pdf_info = [pdf for pdf in article.pdfs if pdf["lang"] == qs_lang]
         if len(pdf_info) != 1:
+            # PDFNOTFOUND
             abort(404, _("PDF do Artigo não encontrado"))
 
         try:
             pdf_url = pdf_info[0]["url"]
         except (IndexError, KeyError, ValueError, TypeError):
+            # PDFNOTFOUND
             abort(404, _("PDF do Artigo não encontrado"))
 
         if pdf_url:
@@ -1444,6 +1456,7 @@ def get_pdf_content(url):
     try:
         response = fetch_data(url)
     except NonRetryableError:
+        # PDFNOTFOUND
         abort(404, _("PDF não encontrado"))
     except RetryableError:
         abort(500, _("Erro inesperado"))
@@ -1515,6 +1528,7 @@ def article_detail_pdf(url_seg, url_seg_issue, url_seg_article, lang_code=""):
 
     article = controllers.get_article_by_issue_article_seg(issue.iid, url_seg_article)
     if not article:
+        # ARTICLENOTFOUND
         abort(404, _("Artigo não encontrado"))
 
     req_params = {
@@ -1559,6 +1573,7 @@ def router_legacy_pdf(journal_acron, issue_info, pdf_filename):
         )
 
     if not article:
+        # PDFNOTFOUND
         abort(404, _("PDF do artigo não foi encontrado"))
 
     return redirect(
@@ -1584,6 +1599,7 @@ def router_legacy_article(text_or_abstract):
 
     article = controllers.get_article_by_pid_v1(pid)
     if not article:
+        # ARTICLENOTFOUND
         abort(404, _("Artigo não encontrado"))
 
     return redirect(
@@ -1612,6 +1628,7 @@ def article_cite_csl(article_id):
     ) or controllers.get_article_by_pid(article_id)
 
     if article is None:
+        # ARTICLENOTFOUND
         abort(404, _("Artigo não encontrado"))
 
     if csl:
@@ -1714,6 +1731,7 @@ def article_cite_export_format(article_id):
     ) or controllers.get_article_by_pid(article_id)
 
     if article is None:
+        # ARTICLENOTFOUND
         abort(404, _("Artigo não encontrado."))
 
     csl_json = article.csl_json(site_domain=current_app.config.get("OPAC_BASE_URI"))

--- a/opac/webapp/templates/errors/base.html
+++ b/opac/webapp/templates/errors/base.html
@@ -24,7 +24,23 @@
                 {% trans %}Erro{% endtrans %}
               {% endblock %}
             </h2>
-            <p>{% trans %}Qualquer dúvida, por favor entre em contato com o administrador{% endtrans %}. <a href="mailto:{{config.WEBMASTER_EMAIL}}">{{config.WEBMASTER_EMAIL}}</a>.</p>
+            <p>
+                <ul>
+                    <li>{% trans %}Certifique-se de ter o endereço correto{% endtrans %}.</li>
+                    <li>{% trans %}Certifique-se de ter obtido o endereço de fontes especializadas em publicações científicas{% endtrans %}.</li>
+                    <li>{% trans %}Para localizar um artigo científico, consulte <a href="//search.scielo.org">search.scielo.org</a>{% endtrans %}.</li>
+                </ul>
+            </p>
+            <p>{% trans %}Se o problema persistir, entre em contato com o administrador{% endtrans %} <a href="mailto:{{config.WEBMASTER_EMAIL}}">{{config.WEBMASTER_EMAIL}}</a>, {% trans %}informando{% endtrans %}:</p>
+            <p>
+                <ul>
+                    <li>{% trans %}imagem da tela de onde o endereço foi obtido{% endtrans %}</li>
+                    <li>{% trans %}título do periódico{% endtrans %}</li>
+                    <li>{% trans %}título do artigo{% endtrans %}</li>
+                    <li>{% trans %}nomes dos autores{% endtrans %}</li>
+                    <li>{% trans %}outros dados que julgar relevantes{% endtrans %}</li>
+                </ul>
+            </p>
           </div>
         </div>
       </div>


### PR DESCRIPTION
#### O que esse PR faz?
Modifica a orientação para o usuário quando recurso não foi encontrado ou quando está agendado para publicação no futuro.

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
Acessando links errados para padrão de artigos, fascículos, periódicos etc.
Acessando links de artigos com data de publicação no futuro.

#### Algum cenário de contexto que queira dar?
Foi necessário remover o filtro referente à data de publicação para distinguir artigo não existente de artigo de publicação agendada.

### Screenshots
n/a

#### Quais são tickets relevantes?
#2680

### Referências
n/a
