### PR TITLE
Remoção da definição de margem refList Artigo - issue 2731

### DIFF
--- a/opac/webapp/static/less/article.less
+++ b/opac/webapp/static/less/article.less
@@ -345,11 +345,9 @@
 	}
 
 	.refList {
-		margin: 0;
 		padding: 0;
 		font-size: .8em;
 		color: @Gray;
-		margin-top: -10px;
 		width: 100%;
 
 		* {


### PR DESCRIPTION
#### O que esse PR faz?
Corrige o problema de margem negativa relatado no ticket 2731.
Remove a definição de margem negativa deixando assim o layout correto.

#### Onde a revisão poderia começar?
Carregue os arquivos desse commit, gere via gulp os arquivos css estaticos e abra um dos artigos citados no issue 2731 ou similar. Veja que o erro foi corrigido. 

#### Como este poderia ser testado manualmente?
Siga os passos anteriores. Muito importante gerar os arquivos estáticos e limpar o cache antes de testar.

#### Algum cenário de contexto que queira dar?
O arquivo modificado foi um .less, portanto é necessário gerar os css estáticos. Depois disso limpe o cache e teste na tela do artigo.

### Screenshots
![Screen Shot 2023-06-27 at 14 14 06](https://github.com/scieloorg/opac/assets/5552212/6d758e73-76f2-456e-8868-512132faef4d)
![Screen Shot 2023-06-27 at 14 13 55](https://github.com/scieloorg/opac/assets/5552212/a34f3844-ff0b-44ef-91eb-1ec528fc4134)


#### Quais são tickets relevantes?
#2731 

### Referências
--

