### PR TITLE
Garante que não quebre a posição do link do scimago instituição para a lista de autores

### DIFF
--- a/opac/webapp/templates/article/base.html
+++ b/opac/webapp/templates/article/base.html
@@ -111,7 +111,7 @@
 
   affiliations = {};
 
-  function add_scimago_image(selector, remove_br=true, add_br_after=true){
+  function add_scimago_image(selector, remove_br=true, add_br_after=true, find_div=false){
     
     $(selector).each(
 
@@ -121,7 +121,9 @@
         $(this).find("br").remove()
       }
       
-      $(this).not(".clearfix").each(function () { 
+      internal_items = find_div ? $(this).find('div').not(".clearfix") : $(this).not(".clearfix")
+
+      internal_items.each(function () { 
         self = $(this);
 
         affiliation_name = $('span:first', self).text();
@@ -140,7 +142,7 @@
   }
 
   add_scimago_image('#ModalScimago .info div')
-  add_scimago_image('.tutors', remove_br=false, add_br_after=false)
+  add_scimago_image('.tutors', remove_br=false, add_br_after=false, find_div=true) 
 
   $(".scimago_link").click(function(e){
     e.preventDefault();

--- a/requirements.txt
+++ b/requirements.txt
@@ -40,7 +40,7 @@ mongoengine==0.16.3
 natsort==7.0.1
 oauthlib==3.1.0
 -e git+https://git@github.com/scieloorg/opac_schema@v2.69#egg=Opac_Schema
--e git+https://github.com/scieloorg/packtools@9b65872a262430dd90b3c9b9dc7f303032a7901c#egg=packtools
+-e git+https://github.com/scieloorg/packtools@ce8211f4f6829972db6f15215616eaddc9c31f58#egg=packtools
 passlib==1.7.2
 pbr==5.4.5
 picles.plumber==0.11


### PR DESCRIPTION
#### O que esse PR faz?
Garante que não quebre a posição do link do **SCIMAGO** instituição para a lista de autores

#### Onde a revisão poderia começar?

Sugiro avaliar o código em javascript do arquivo: ``opac/webapp/templates/article/base.html``

#### Como este poderia ser testado manualmente?

Subindo uma instância local do opac e acessando a página do artigo, clicando no link, veja: 

![Screenshot 2023-06-28 at 07 39 10](https://github.com/scieloorg/opac/assets/86991526/60aa3950-d51c-4118-94db-ed70a685cf1e)

#### Algum cenário de contexto que queira dar?

Anteriormente o link estava sendo apresentado após o **ORCID**, veja: 

![Screenshot 2023-06-28 at 07 42 02](https://github.com/scieloorg/opac/assets/86991526/59f7aa7a-6861-4670-bb9c-8fbcd161c2b1)

Agora esta correto na linha onde temos uma instituição, veja: 


![Screenshot 2023-06-28 at 07 43 10](https://github.com/scieloorg/opac/assets/86991526/0a502019-13c3-42d0-8823-efbf5ac10c7f)


### Screenshots

![Screenshot 2023-06-28 at 07 31 35](https://github.com/scieloorg/opac/assets/86991526/30e6d513-4d09-49ae-948b-d12b3d78052f)

#### Quais são tickets relevantes?

Não tem tíquete para essa atividade.

### Referências
N/A

