### PR TITLE
Corrige a atribuição de valor para o parâmetro begin_date

### DIFF
--- a/opac/webapp/main/views.py
+++ b/opac/webapp/main/views.py
@@ -1900,7 +1900,12 @@ def router_counter_dicts():
         end_date = datetime.strptime(end_date, "%Y-%m-%d")
     except ValueError:
         end_date = datetime.now()
-    begin_date = end_date - timedelta(days=30)
+
+    begin_date = request.args.get("begin_date", "", type=str)
+    try:
+        begin_date = datetime.strptime(begin_date, "%Y-%m-%d")
+    except ValueError:
+        begin_date = end_date - timedelta(days=30)
 
     page = request.args.get("page", type=int)
     if not page:


### PR DESCRIPTION
#### O que esse PR faz?
Corrige a atribuição de valor para o parâmetro begin_date

#### Onde a revisão poderia começar?
Por commits

#### Como este poderia ser testado manualmente?
Executando o acesso a:
https://www.scielo.br/api/v1/counter_dict?end_date=2023-08-08&begin_date=2017-01-01&limit=100&page=4
que deve retornar dados mais antigos e não 30 dias antes de 2023-08-08

#### Algum cenário de contexto que queira dar?
Este endpoint foi criado para uso no procedimento de contagem de acessos.
E está sendo reaproveitado no core para carga dos XML de scielo.br no pid provider, para garantir a atribuição / checagem de pid v3 consistente.

### Screenshots
n/a

#### Quais são tickets relevantes?
n/a

### Referências
n/a
