### PR TITLE
Atualiza a versão de packtools que corrige apresentação de xref[@ref-type='bibr'] para o padrão autor, ano

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -40,7 +40,7 @@ mongoengine==0.16.3
 natsort==7.0.1
 oauthlib==3.1.0
 -e git+https://git@github.com/scieloorg/opac_schema@v2.69#egg=Opac_Schema
--e git+https://github.com/scieloorg/packtools@ace2e602dfc0c39fd0d023be9701da5dd4d733d7#egg=packtools
+-e git+https://github.com/scieloorg/packtools@7377e61441330b9d5e49dc86ede14179fd5ec38a#egg=packtools
 passlib==1.7.2
 pbr==5.4.5
 picles.plumber==0.11


### PR DESCRIPTION
#### O que esse PR faz?
Atualiza a versão de packtools que corrige apresentação de xref[@ref-type='bibr'] para o padrão autor, ano

#### Onde a revisão poderia começar?
n/a

#### Como este poderia ser testado manualmente?
n/a

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
n/a

#### Quais são tickets relevantes?
https://github.com/scieloorg/packtools/pull/519

### Referências
n/a
