### PR TITLE
Atualiza a versão do packtools para trocar http para https para orcid, lattes, researcherid

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -40,7 +40,7 @@ mongoengine==0.16.3
 natsort==7.0.1
 oauthlib==3.1.0
 -e git+https://git@github.com/scieloorg/opac_schema@v2.69#egg=Opac_Schema
--e git+https://github.com/scieloorg/packtools@e5e0fbabfa85672e557994178983044549e0e961#egg=packtools
+-e git+https://github.com/scieloorg/packtools@ce98be3ddc645a3681f353490734db1fc8fb6286#egg=packtools
 passlib==1.7.2
 pbr==5.4.5
 picles.plumber==0.11


### PR DESCRIPTION
#### O que esse PR faz?
Atualiza a versão do packtools para trocar http para https para orcid, lattes, researcherid

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
Acessando a página do artigo, abrindo o modal de autores e verificando a apresentação dos ORCID que devem estar com `https://`

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
n/a

#### Quais são tickets relevantes?
https://github.com/scieloorg/packtools/pull/583

### Referências
n/a
