### PR TITLE
Atualiza dependência opac_schema para versão v2.8.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -39,7 +39,7 @@ MarkupSafe==2.0.1
 mongoengine==0.16.3
 natsort==7.0.1
 oauthlib==3.1.0
--e git+https://git@github.com/scieloorg/opac_schema@v2.69#egg=Opac_Schema
+-e git+https://git@github.com/scieloorg/opac_schema@v2.8.0#egg=Opac_Schema
 -e git+https://github.com/scieloorg/packtools@20155160b491dd98deec91adf0c2536f6e476762#egg=packtools
 passlib==1.7.2
 pbr==5.4.5


### PR DESCRIPTION
#### O que esse PR faz?
Atualiza dependência opac_schema para versão v2.8.0

#### Onde a revisão poderia começar?
pelos commits

#### Como este poderia ser testado manualmente?
1. docker-compose -f docker-compose-dev.yml build --no-cache
2. make up 

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
n/a

#### Quais são tickets relevantes?
n/A

### Referências
n/a

