### PR TITLE
Adiciona a licença no rodapé do site e atualiza o opac_schema

### DIFF
--- a/opac/webapp/config/default.py
+++ b/opac/webapp/config/default.py
@@ -186,7 +186,13 @@ import os
         - OPAC_FILTER_SECTION_ENABLE: ativa/desativa o filtro por seção na página do issue.
 
       - Common Style List
-        - OAPC_COMMON_STYLE_LIST: Caminho para um arquivo .json com as CSL.
+        - OPAC_COMMON_STYLE_LIST: Caminho para um arquivo .json com as CSL.
+
+      - Site License
+        - OPAC_SITE_LICENSE_ENABLE: ativa/desativa a exibição do logo do creative commons no rodapé do site
+        - OPAC_SITE_LICENSE_NAME: Nome da licença (default: "Creative Common - by 4.0")
+        - OPAC_SITE_LICENSE_URL: URL da licença (default: https://creativecommons.org/licenses/by-nc/4.0/)
+        - OPAC_SITE_LICENSE_IMG_URL: Imagem da licença (default: https://licensebuttons.net/l/by/4.0/88x31.png)
 """
 
 PROJECT_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
@@ -662,3 +668,8 @@ COMMON_STYLE_LIST = os.environ.get(
 
 # Citation Export Format
 CITATION_EXPORT_FORMATS = {"bib": "BibTex", "ris": "Reference Manager"}
+
+SITE_LICENSE_ENABLE = os.environ.get("OPAC_SITE_LICENSE_ENABLE", "True") == "True"
+SITE_LICENSE_NAME = os.environ.get("OPAC_SITE_LICENSE_NAME", "Creative Common - by 4.0")
+SITE_LICENSE_URL = os.environ.get("OPAC_SITE_LICENSE_URL", "https://creativecommons.org/licenses/by-nc/4.0/")
+SITE_LICENSE_IMG_URL = os.environ.get("OPAC_SITE_LICENSE_IMG_URL", "https://licensebuttons.net/l/by/4.0/88x31.png")

--- a/opac/webapp/templates/includes/footer.html
+++ b/opac/webapp/templates/includes/footer.html
@@ -5,35 +5,47 @@
         <span class="logo-svg-footer"></span>
       </div>
       <div class="col-md-8 col-sm-9">
-        <strong>SciELO - Scientific Electronic Library Online</strong><br/>
-        {{ g.collection.address1 or '' }}<br/>
+        <strong>SciELO - Scientific Electronic Library Online</strong><br />
+        {{ g.collection.address1 or '' }}<br />
         {{ g.collection.address2 or '' }}
       </div>
+      {% if config.SITE_LICENSE_ENABLE %}
+        <div class="container-license">
+          <div class="row">
+            <div class="col-sm-3 col-md-2">
+              <a href="{{config.SITE_LICENSE_URL}}" target="_blank" title="" rel="license"><img
+                  src="{{config.SITE_LICENSE_IMG_URL}}" alt="{{config.SITE_LICENSE_NAME}}">
+              </a>
+            </div>
+          </div>
+        </div>
+      {% endif %}
     </div>
   </div>
   {% if g.collection and g.collection.sponsors %}
-    <div class="partners">
-      {% for sponsor in g.collection.sponsors|sort(attribute='order') %}
-        {% if sponsor.url and sponsor.logo_url %}
-          <a href="{{ sponsor.url }}" target="_blank">
-            {% if sponsor.logo_url %}
-                <img src="{{ sponsor.logo_url }}" alt="{{ sponsor.name }}">
-            {% else %}
-                {{ sponsor.name }}
-            {% endif %}
-          </a>
-        {% elif sponsor.logo_url %}
-          <img src="{{ sponsor.logo_url }}" alt="{{ sponsor.name }}">
-        {% else %}
-          {{ sponsor.name }}
-        {% endif %}
-      {% endfor %}
-    </div>
+  <div class="partners">
+    {% for sponsor in g.collection.sponsors|sort(attribute='order') %}
+    {% if sponsor.url and sponsor.logo_url %}
+    <a href="{{ sponsor.url }}" target="_blank">
+      {% if sponsor.logo_url %}
+      <img src="{{ sponsor.logo_url }}" alt="{{ sponsor.name }}">
+      {% else %}
+      {{ sponsor.name }}
+      {% endif %}
+    </a>
+    {% elif sponsor.logo_url %}
+    <img src="{{ sponsor.logo_url }}" alt="{{ sponsor.name }}">
+    {% else %}
+    {{ sponsor.name }}
+    {% endif %}
+    {% endfor %}
+  </div>
   {% endif %}
 
   <div class="container collectionLicense">
     <a href="{{ url_for('main.about_collection') }}">
-      <img alt="{% trans %}Open Access{% endtrans %}" style="border-width:0" class="image" src="{{ url_for('static', filename='img/oa_logo_32.png') }}">
+      <img alt="{% trans %}Open Access{% endtrans %}" style="border-width:0" class="image"
+        src="{{ url_for('static', filename='img/oa_logo_32.png') }}">
       <span>
         <strong>{% trans %}Leia{% endtrans %}</strong> {% trans %}a Declaração de Acesso Aberto{% endtrans %}
       </span>

--- a/requirements.txt
+++ b/requirements.txt
@@ -39,7 +39,7 @@ MarkupSafe==2.0.1
 mongoengine==0.16.3
 natsort==7.0.1
 oauthlib==3.1.0
--e git+https://git@github.com/scieloorg/opac_schema@v2.8.0#egg=Opac_Schema
+-e git+https://git@github.com/scieloorg/opac_schema@v2.8.1#egg=Opac_Schema
 -e git+https://github.com/scieloorg/packtools@dd8bb00c08ce5285a4dc00aa7fdb1f3af6b708cb#egg=packtools
 passlib==1.7.2
 pbr==5.4.5


### PR DESCRIPTION
#### O que esse PR faz?
Adiciona a licença no rodapé do site e atualiza o opac_schema.

#### Onde a revisão poderia começar?
Pelos commits

#### Como este poderia ser testado manualmente?
Sugiro que seja executado a aplicação e verificado a licença no rodapé

#### Algum cenário de contexto que queira dar?

Com essa alteração é possível ligar/desligar a licença no rodapé 

Repare que temos novas variáveis de ambiente: 

* SITE_LICENSE_ENABLE
* SITE_LICENSE_NAME
* SITE_LICENSE_URL
* SITE_LICENSE_IMG_URL


### Screenshots

Algumas telas com a licença: 
![Screenshot 2024-11-04 at 22 37 03](https://github.com/user-attachments/assets/d4d63ea5-73cd-4efc-82be-3b2361009d8b)
![Screenshot 2024-11-04 at 22 37 21](https://github.com/user-attachments/assets/87fc0299-e65b-4745-a86c-05ee4b22a26e)
![Screenshot 2024-11-04 at 22 37 33](https://github.com/user-attachments/assets/32f6c06c-0d51-45eb-ac9c-3aa65b2deaad)
![Screenshot 2024-11-04 at 22 38 06](https://github.com/user-attachments/assets/22efbd6b-4cb9-4616-b97a-3f51da8fe731)
![Screenshot 2024-11-04 at 22 39 59](https://github.com/user-attachments/assets/8c7fcd8f-878c-43a2-88c4-1d9c3cae873c)


#### Quais são tickets relevantes?

https://github.com/scieloorg/opac/issues/3127

### Referências
Indique as referências utilizadas para a elaboração do pull request.

